### PR TITLE
feat: toast component and hooks

### DIFF
--- a/__tests__/Toast.js
+++ b/__tests__/Toast.js
@@ -2,11 +2,11 @@ import React from "react"
 import { render, fireEvent, act } from "react-testing-library"
 
 import {
-  ToastType,
   ToastProvider,
   ToastConsumer,
   useShowSuccessToast,
   useShowErrorToast,
+  useShowErrorAlert,
 } from "../src"
 import Toast from "../src/components/Toast/Toast"
 
@@ -14,7 +14,7 @@ describe(`Toast`, () => {
   const baseProps = {
     id: 0,
     message: `Lorem ipsum`,
-    type: ToastType.SUCCESS,
+    tone: `SUCCESS`,
     onRemove: () => {},
     closeButtonLabel: `close`,
   }
@@ -23,7 +23,7 @@ describe(`Toast`, () => {
     const { container } = render(
       <React.Fragment>
         <Toast {...baseProps} />
-        <Toast {...baseProps} id={1} type={ToastType.ERROR} />
+        <Toast {...baseProps} id={1} tone="DANGER" />
       </React.Fragment>
     )
 
@@ -186,5 +186,78 @@ describe(`useShowErrorToast hook`, () => {
 
     expect(queryByTestId(`toast`)).toBeTruthy()
     setTimeout(() => expect(queryByTestId(`toast`)).toBeTruthy(), 600)
+  })
+})
+
+describe(`useShowErrorAlert hook`, () => {
+  it(`returns a method to show error alert`, () => {
+    function TestComponent() {
+      const showErrorAlert = useShowErrorAlert()
+
+      return (
+        <button
+          onClick={() =>
+            showErrorAlert(`Lorem ipsum`, {
+              linkLabel: `See details`,
+              href: `https://google.com`,
+              target: `_blank`,
+            })
+          }
+        >
+          Show toast
+        </button>
+      )
+    }
+
+    const { getByText, queryByTestId } = render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    )
+
+    act(() => {
+      fireEvent.click(getByText(`Show toast`))
+    })
+
+    expect(queryByTestId(`toast`)).toBeTruthy()
+    setTimeout(() => expect(queryByTestId(`toast`)).toBeTruthy(), 600)
+
+    const link = getByText(`See details`)
+    expect(link).toHaveAttribute(`href`, `https://google.com`)
+    expect(link).toHaveAttribute(`target`, `_blank`)
+  })
+
+  it(`allows to show error alert with an internal link`, () => {
+    function TestComponent() {
+      const showErrorAlert = useShowErrorAlert()
+
+      return (
+        <button
+          onClick={() =>
+            showErrorAlert(`Lorem ipsum`, {
+              linkLabel: `See details`,
+              to: `/local`,
+              target: `_blank`,
+            })
+          }
+        >
+          Show toast
+        </button>
+      )
+    }
+
+    const { getByText, debug } = render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    )
+
+    act(() => {
+      fireEvent.click(getByText(`Show toast`))
+    })
+
+    const link = getByText(`See details`)
+    expect(link).toHaveAttribute(`href`, `/local`)
+    expect(link).not.toHaveAttribute(`target`)
   })
 })

--- a/__tests__/Toast.js
+++ b/__tests__/Toast.js
@@ -1,0 +1,190 @@
+import React from "react"
+import { render, fireEvent, act } from "react-testing-library"
+
+import {
+  ToastType,
+  ToastProvider,
+  ToastConsumer,
+  useShowSuccessToast,
+  useShowErrorToast,
+} from "../src"
+import Toast from "../src/components/Toast/Toast"
+
+describe(`Toast`, () => {
+  const baseProps = {
+    id: 0,
+    message: `Lorem ipsum`,
+    type: ToastType.SUCCESS,
+    onRemove: () => {},
+    closeButtonLabel: `close`,
+  }
+
+  it(`renders unchanged`, async () => {
+    const { container } = render(
+      <React.Fragment>
+        <Toast {...baseProps} />
+        <Toast {...baseProps} id={1} type={ToastType.ERROR} />
+      </React.Fragment>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it(`displays the toast message`, async () => {
+    const { queryByText } = render(<Toast {...baseProps} />)
+
+    expect(queryByText(`Lorem ipsum`)).toBeTruthy()
+  })
+
+  it(`has accessible label for the close button`, async () => {
+    const { container } = render(<Toast {...baseProps} />)
+
+    expect(container.querySelector(`button`)).toHaveAttribute(
+      `aria-label`,
+      `close`
+    )
+  })
+
+  it(`calls onRemove callback when clicking the close button`, async () => {
+    const removeFn = jest.fn()
+    const { getByLabelText } = render(
+      <Toast {...baseProps} id={123} onRemove={removeFn} />
+    )
+
+    fireEvent.click(getByLabelText(`close`))
+
+    expect(removeFn).toHaveBeenCalledWith(123)
+  })
+})
+
+describe(`ToastProvider`, () => {
+  it(`exposes toast tools via context`, () => {
+    const renderFn = jest.fn()
+
+    render(
+      <ToastProvider>
+        <ToastConsumer>{renderFn}</ToastConsumer>
+      </ToastProvider>
+    )
+
+    expect(renderFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        showToast: expect.any(Function),
+      })
+    )
+  })
+
+  function TestComponent({ toastOptions = {} }) {
+    return (
+      <ToastConsumer>
+        {({ showToast }) => (
+          <button onClick={() => showToast(`Lorem ipsum`, toastOptions)}>
+            Show toast
+          </button>
+        )}
+      </ToastConsumer>
+    )
+  }
+
+  it(`allows to specify custom label for the toast close button`, () => {
+    const { getByText, getByTestId } = render(
+      <ToastProvider closeButtonLabel="Zamknąć">
+        <TestComponent toastOptions={{ timeout: 0 }} />
+      </ToastProvider>
+    )
+
+    act(() => {
+      fireEvent.click(getByText(`Show toast`))
+    })
+
+    expect(getByTestId(`toast`).querySelector(`button`)).toHaveAttribute(
+      `aria-label`,
+      `Zamknąć`
+    )
+  })
+
+  it(`removes a toast on timeout`, () => {
+    const { getByText, queryByTestId } = render(
+      <ToastProvider>
+        <TestComponent toastOptions={{ timeout: 500 }} />
+      </ToastProvider>
+    )
+
+    act(() => {
+      fireEvent.click(getByText(`Show toast`))
+    })
+
+    expect(queryByTestId(`toast`)).toBeTruthy()
+
+    setTimeout(() => expect(queryByTestId(`toast`)).toBeFalsy(), 500)
+  })
+
+  it(`persists a toast if the provided timeout is 0`, () => {
+    const { getByText, queryByTestId } = render(
+      <ToastProvider>
+        <TestComponent toastOptions={{ timeout: 0 }} />
+      </ToastProvider>
+    )
+
+    act(() => {
+      fireEvent.click(getByText(`Show toast`))
+    })
+
+    expect(queryByTestId(`toast`)).toBeTruthy()
+
+    setTimeout(() => expect(queryByTestId(`toast`)).toBeTruthy(), 600)
+  })
+})
+
+describe(`useShowSuccessToast hook`, () => {
+  it(`returns a method to show success toast`, () => {
+    function TestComponent() {
+      const showSuccessToast = useShowSuccessToast()
+
+      return (
+        <button onClick={() => showSuccessToast(`Lorem ipsum`)}>
+          Show toast
+        </button>
+      )
+    }
+
+    const { getByText, queryByTestId } = render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    )
+
+    act(() => {
+      fireEvent.click(getByText(`Show toast`))
+    })
+
+    expect(queryByTestId(`toast`)).toBeTruthy()
+  })
+})
+
+describe(`useShowErrorToast hook`, () => {
+  it(`returns a method to show error toast`, () => {
+    function TestComponent() {
+      const showErrorToast = useShowErrorToast()
+
+      return (
+        <button onClick={() => showErrorToast(`Lorem ipsum`)}>
+          Show toast
+        </button>
+      )
+    }
+
+    const { getByText, queryByTestId } = render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    )
+
+    act(() => {
+      fireEvent.click(getByText(`Show toast`))
+    })
+
+    expect(queryByTestId(`toast`)).toBeTruthy()
+    setTimeout(() => expect(queryByTestId(`toast`)).toBeTruthy(), 600)
+  })
+})

--- a/__tests__/__snapshots__/Toast.js.snap
+++ b/__tests__/__snapshots__/Toast.js.snap
@@ -1,0 +1,244 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Toast renders unchanged 1`] = `
+@keyframes animation-0 {
+  100% {
+    -webkit-transform: perspective(1000px) rotateX(0);
+    -ms-transform: perspective(1000px) rotateX(0);
+    transform: perspective(1000px) rotateX(0);
+  }
+}
+
+@keyframes animation-0 {
+  100% {
+    -webkit-transform: perspective(1000px) rotateX(0);
+    -ms-transform: perspective(1000px) rotateX(0);
+    transform: perspective(1000px) rotateX(0);
+  }
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-animation: animation-0 0.5s 0.25s ease forwards;
+  animation: animation-0 0.5s 0.25s ease forwards;
+  background: #232129;
+  border-left: 8px solid #37b635;
+  border-radius: 4px 4px 0 0;
+  color: #f7fdf7;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  min-height: 3rem;
+  max-width: calc(100% - (1.5rem * 2));
+  padding-left: 0.75rem;
+  -webkit-transform: perspective(1000px) rotateX(90deg);
+  -ms-transform: perspective(1000px) rotateX(90deg);
+  transform: perspective(1000px) rotateX(90deg);
+  -webkit-transform-origin: bottom center;
+  -ms-transform-origin: bottom center;
+  transform-origin: bottom center;
+  border-left-color: #37b635;
+}
+
+.emotion-3 svg {
+  height: auto;
+  width: calc(3rem * 0.4);
+}
+
+.emotion-3:not(:first-of-type) {
+  border-radius: 4px;
+  margin-bottom: 0.125rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #37b635;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #37b635;
+}
+
+.emotion-1 {
+  line-height: 1;
+  margin: 0 0.25rem 0 0.5rem;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: none;
+  border: none;
+  color: #b7b5bd;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 3rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 3rem;
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-animation: animation-0 0.5s 0.25s ease forwards;
+  animation: animation-0 0.5s 0.25s ease forwards;
+  background: #232129;
+  border-left: 8px solid #37b635;
+  border-radius: 4px 4px 0 0;
+  color: #f7fdf7;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  min-height: 3rem;
+  max-width: calc(100% - (1.5rem * 2));
+  padding-left: 0.75rem;
+  -webkit-transform: perspective(1000px) rotateX(90deg);
+  -ms-transform: perspective(1000px) rotateX(90deg);
+  transform: perspective(1000px) rotateX(90deg);
+  -webkit-transform-origin: bottom center;
+  -ms-transform-origin: bottom center;
+  transform-origin: bottom center;
+  border-left-color: #ec1818;
+}
+
+.emotion-7 svg {
+  height: auto;
+  width: calc(3rem * 0.4);
+}
+
+.emotion-7:not(:first-of-type) {
+  border-radius: 4px;
+  margin-bottom: 0.125rem;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #37b635;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #ec1818;
+}
+
+<div>
+  <div
+    class="emotion-3"
+    data-reach-alert="true"
+    data-testid="toast"
+  >
+    <span
+      class="emotion-0"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+        />
+      </svg>
+    </span>
+    <div
+      class="emotion-1"
+    >
+      Lorem ipsum
+    </div>
+    <button
+      aria-label="close"
+      class="emotion-2"
+      type="button"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    class="emotion-7"
+    data-reach-alert="true"
+    data-testid="toast"
+  >
+    <span
+      class="emotion-4"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="emotion-1"
+    >
+      Lorem ipsum
+    </div>
+    <button
+      aria-label="close"
+      class="emotion-2"
+      type="button"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@reach/alert": "^0.1.5",
     "gatsby-design-tokens": "^1.0.0"
   },
   "peerDependencies": {

--- a/src/components/Toast/MessageWithLink.js
+++ b/src/components/Toast/MessageWithLink.js
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core"
+import React from "react"
+import { css } from "@emotion/core"
+import PropTypes from "prop-types"
+import { Link } from "../Link"
+
+const messageCss = css`
+  margin-bottom: 8px;
+`
+
+export default function MessageWithLink({ children, linkLabel, ...linkProps }) {
+  return (
+    <React.Fragment>
+      <div css={messageCss}>{children}</div>
+      <Link {...linkProps}>{linkLabel}</Link>
+    </React.Fragment>
+  )
+}
+
+MessageWithLink.propTypes = {
+  children: PropTypes.node.isRequired,
+  linkLabel: PropTypes.node.isRequired,
+  href: PropTypes.string,
+  target: PropTypes.string,
+  to: PropTypes.string,
+}

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -1,0 +1,148 @@
+## Toast
+
+A set of tools to display toast messages.
+
+```javascript
+import {
+  ToastProvider,
+  useShowSuccessToast,
+  useShowErrorToast,
+} from "gatsby-interface"
+
+// Somewehere at the top of your React app tree
+function App({ children }) {
+  return <ToastProvider>{children}</ToastProvider>
+}
+
+function Component() {
+  const showSuccessToast = useShowSuccessToast()
+  const showErrorToast = useShowErrorToast()
+
+  return (
+    <>
+      <button onClick={() => showSuccessToast("Your action was successful!")}>
+        Show success toast
+      </button>
+      <button
+        onClick={() =>
+          showSuccessToast("This message will stay on screen until closed", {
+            timeout: 0,
+          })
+        }
+      >
+        Show and persist success toast
+      </button>
+      <button onClick={() => showErrorToast("An error occured!")}>
+        Show error toast
+      </button>
+    </>
+  )
+}
+```
+
+### Components
+
+#### ToastProvider
+
+This component is required to display toasts. Render it somewhere at the top of your React app tree.
+
+```javascript
+import { ToastProvider } from "gatsby-interface"
+
+// Somewehere at the top of your React app tree
+function App({ children }) {
+  return <ToastProvider>{children}</ToastProvider>
+}
+```
+
+#### ToastConsumer
+
+Use this component to get access to `showToast` function if you can't use hooks for some reason.
+
+```javascript
+import { ToastConsumer, ToastType } from "gatsby-interface"
+
+function Component() {
+  return (
+    <ToastConsumer>
+      {({ showToast }) => (
+        <button
+          onClick={() => showToast(`Your action was successful`, { type: ToastType.SUCCESS })}
+        >
+          Show toast
+        </Button>
+      )}
+    </ToastConsumer>
+  );
+}
+```
+
+### Hooks
+
+#### useShowSuccessToast
+
+Should be used to show a toast that indicates that some action has been successful. The toast will disappear automatically after 5 seconds.
+
+```javascript
+import { useShowSuccessToast } from "gatsby-interface"
+
+function Component() {
+  const showSuccessToast = useShowSuccessToast()
+  const showErrorToast = useShowErrorToast()
+
+  return (
+    <button onClick={() => showSuccessToast("Your action was successful!")}>
+      Show success toast
+    </button>
+  )
+}
+```
+
+#### useShowErrorToast
+
+Should be used to show a toast that indicates that some action has failed. The toast WILL NOT disappear automatically.
+
+```javascript
+import { useShowErrorToast } from "gatsby-interface"
+
+function Component() {
+  const showErrorToast = useShowErrorToast()
+
+  return (
+    <button onClick={() => showErrorToast("An error occured!")}>
+      Show error toast
+    </button>
+  )
+}
+```
+
+#### useShowToast
+
+This is a low-level hook and generally should not be used if you can use one of the previous hooks.
+
+```javascript
+import { useShowToast, ToastType } from "gatsby-interface"
+
+function Component() {
+  const showToast = useShowToast()
+
+  return (
+    <>
+      <button
+        onClick={() =>
+          showToast("Your action was successful!", { type: ToastType.SUCCESS })
+        }
+      >
+        Show success toast
+      </button>
+      <button
+        onClick={() =>
+          showToast("An error occured!", { type: ToastType.ERROR, timeout: 0 })
+        }
+      >
+        Show error toast
+      </button>
+    </>
+  )
+}
+```

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -60,14 +60,14 @@ function App({ children }) {
 Use this component to get access to `showToast` function if you can't use hooks for some reason.
 
 ```javascript
-import { ToastConsumer, ToastType } from "gatsby-interface"
+import { ToastConsumer } from "gatsby-interface"
 
 function Component() {
   return (
     <ToastConsumer>
       {({ showToast }) => (
         <button
-          onClick={() => showToast(`Your action was successful`, { type: ToastType.SUCCESS })}
+          onClick={() => showToast(`Your action was successful`, { tone: 'SUCCESS' })}
         >
           Show toast
         </Button>
@@ -116,12 +116,39 @@ function Component() {
 }
 ```
 
+#### useShowErrorAlert
+
+Allows to show an error toast similar to `useShowErrorToast`; the only difference is that you can provide a link to be displayed in the toast message.
+
+```javascript
+import { useShowErrorAlert } from "gatsby-interface"
+
+function Component() {
+  const showErrorAlert = useShowErrorAlert()
+
+  return (
+    <button
+      onClick={() =>
+        showErrorAlert("An error occured!", {
+          to: "/some-path",
+          linkLabel: "See details",
+        })
+      }
+    >
+      Show error toast
+    </button>
+  )
+}
+```
+
+Similar to [Link](../Link), you can pass either `to` or `href` prop as well as `target`.
+
 #### useShowToast
 
 This is a low-level hook and generally should not be used if you can use one of the previous hooks.
 
 ```javascript
-import { useShowToast, ToastType } from "gatsby-interface"
+import { useShowToast } from "gatsby-interface"
 
 function Component() {
   const showToast = useShowToast()
@@ -130,14 +157,14 @@ function Component() {
     <>
       <button
         onClick={() =>
-          showToast("Your action was successful!", { type: ToastType.SUCCESS })
+          showToast("Your action was successful!", { tone: "SUCCESS" })
         }
       >
         Show success toast
       </button>
       <button
         onClick={() =>
-          showToast("An error occured!", { type: ToastType.ERROR, timeout: 0 })
+          showToast("An error occured!", { tone: "DANGER", timeout: 0 })
         }
       >
         Show error toast

--- a/src/components/Toast/Toast.js
+++ b/src/components/Toast/Toast.js
@@ -1,0 +1,132 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core"
+import React from "react"
+import PropTypes from "prop-types"
+
+import Alert from "@reach/alert"
+import { keyframes, css } from "@emotion/core"
+import { MdDone, MdClose, MdWarning } from "react-icons/md"
+
+import {
+  fontSizes,
+  dimensions,
+  palette,
+  radius,
+  spaces,
+} from "../../utils/presets"
+import { ToastType } from "./constants"
+
+const toastEntryAnimation = keyframes`
+  100% {
+     transform: perspective(1000px) rotateX(0);
+  }
+`
+
+const toastCss = css`
+  align-items: center;
+  animation: ${toastEntryAnimation} 0.5s 0.25s ease forwards;
+  background: ${palette.grey[900]};
+  border-left: 8px solid ${palette.green[500]};
+  border-radius: ${radius.default} ${radius.default} 0 0;
+  color: ${palette.green[50]};
+  display: flex;
+  font-size: ${fontSizes.xs};
+  min-height: ${dimensions.toast.minHeight};
+  max-width: calc(100% - (${spaces.l} * 2));
+  padding-left: ${spaces.s};
+  transform: perspective(1000px) rotateX(90deg);
+  transform-origin: bottom center;
+
+  svg {
+    height: auto;
+    width: calc(${dimensions.toast.minHeight} * 0.4);
+  }
+
+  &:not(:first-of-type) {
+    border-radius: ${radius.default};
+    margin-bottom: ${spaces[`3xs`]};
+  }
+`
+
+const messageCss = css`
+  line-height: 1;
+  margin: 0 ${spaces[`2xs`]} 0 ${spaces.xs};
+`
+
+const statusCss = css`
+  align-items: center;
+  color: ${palette.green[500]};
+  display: flex;
+`
+
+const closeButtonCss = css`
+  align-items: center;
+  background: none;
+  border: none;
+  color: ${palette.grey[400]};
+  cursor: pointer;
+  display: flex;
+  height: ${dimensions.toast.minHeight};
+  justify-content: center;
+  width: ${dimensions.toast.minHeight};
+`
+
+const toastColorByType = {
+  [ToastType.SUCCESS]: palette.green[500],
+  [ToastType.ERROR]: palette.red[600],
+}
+
+const ToastIconByType = {
+  [ToastType.SUCCESS]: MdDone,
+  [ToastType.ERROR]: MdWarning,
+}
+
+export default function Toast({
+  id,
+  message,
+  type,
+  onRemove,
+  closeButtonLabel,
+}) {
+  const IconComponent = ToastIconByType[type]
+
+  return (
+    <Alert
+      css={[
+        toastCss,
+        css({
+          borderLeftColor: toastColorByType[type],
+        }),
+      ]}
+      data-testid="toast"
+      type={type === ToastType.ERROR ? `assertive` : `polite`}
+    >
+      <span
+        css={[
+          statusCss,
+          css({
+            color: toastColorByType[type],
+          }),
+        ]}
+      >
+        <IconComponent />
+      </span>
+      <div css={messageCss}>{message}</div>
+      <button
+        css={closeButtonCss}
+        type="button"
+        onClick={() => onRemove(id)}
+        aria-label={closeButtonLabel}
+      >
+        <MdClose />
+      </button>
+    </Alert>
+  )
+}
+
+Toast.propTypes = {
+  id: PropTypes.number.isRequired,
+  message: PropTypes.node.isRequired,
+  onRemove: PropTypes.func.isRequired,
+  closeButtonLabel: PropTypes.string.isRequired,
+}

--- a/src/components/Toast/Toast.js
+++ b/src/components/Toast/Toast.js
@@ -14,7 +14,7 @@ import {
   radius,
   spaces,
 } from "../../utils/presets"
-import { ToastType } from "./constants"
+import { ToastTones } from "./constants"
 
 const toastEntryAnimation = keyframes`
   100% {
@@ -71,41 +71,41 @@ const closeButtonCss = css`
   width: ${dimensions.toast.minHeight};
 `
 
-const toastColorByType = {
-  [ToastType.SUCCESS]: palette.green[500],
-  [ToastType.ERROR]: palette.red[600],
+const toastColorByTone = {
+  SUCCESS: palette.green[500],
+  DANGER: palette.red[600],
 }
 
-const ToastIconByType = {
-  [ToastType.SUCCESS]: MdDone,
-  [ToastType.ERROR]: MdWarning,
+const ToastIconByTone = {
+  SUCCESS: MdDone,
+  DANGER: MdWarning,
 }
 
 export default function Toast({
   id,
   message,
-  type,
+  tone,
   onRemove,
   closeButtonLabel,
 }) {
-  const IconComponent = ToastIconByType[type]
+  const IconComponent = ToastIconByTone[tone]
 
   return (
     <Alert
       css={[
         toastCss,
         css({
-          borderLeftColor: toastColorByType[type],
+          borderLeftColor: toastColorByTone[tone],
         }),
       ]}
       data-testid="toast"
-      type={type === ToastType.ERROR ? `assertive` : `polite`}
+      type={tone === `DANGER` ? `assertive` : `polite`}
     >
       <span
         css={[
           statusCss,
           css({
-            color: toastColorByType[type],
+            color: toastColorByTone[tone],
           }),
         ]}
       >
@@ -127,6 +127,7 @@ export default function Toast({
 Toast.propTypes = {
   id: PropTypes.number.isRequired,
   message: PropTypes.node.isRequired,
+  tone: PropTypes.oneOf(ToastTones),
   onRemove: PropTypes.func.isRequired,
   closeButtonLabel: PropTypes.string.isRequired,
 }

--- a/src/components/Toast/Toast.stories.js
+++ b/src/components/Toast/Toast.stories.js
@@ -1,0 +1,72 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core"
+import React from "react"
+
+import { storiesOf } from "@storybook/react"
+import { StoryUtils } from "../../utils/storybook"
+import { Button } from "../core/Button"
+import {
+  ToastProvider,
+  ToastConsumer,
+  useShowErrorToast,
+  useShowSuccessToast,
+  useShowToast,
+} from "./"
+import README from "./README.md"
+
+storiesOf(`Toast`, module)
+  .addParameters({
+    options: {
+      showPanel: true,
+    },
+    readme: {
+      sidebar: README,
+    },
+  })
+  .add(`Default`, () => {
+    function ErrorToastExample() {
+      const showErrorToast = useShowErrorToast()
+
+      return (
+        <Button onClick={() => showErrorToast(`An error occured`)}>
+          Show error toast
+        </Button>
+      )
+    }
+    function NoTimeoutExample() {
+      const showSuccessToast = useShowSuccessToast()
+
+      return (
+        <Button
+          onClick={() =>
+            showSuccessToast(`This message will stay on screen until closed`, {
+              timeout: 0,
+            })
+          }
+        >
+          Show toast without auto hide
+        </Button>
+      )
+    }
+    return (
+      <StoryUtils.Container>
+        <StoryUtils.Stack>
+          <ToastProvider>
+            <ToastConsumer>
+              {({ showToast }) => (
+                <React.Fragment>
+                  <Button
+                    onClick={() => showToast(`Your action was successful`)}
+                  >
+                    Show toast
+                  </Button>
+                </React.Fragment>
+              )}
+            </ToastConsumer>
+            <NoTimeoutExample />
+            <ErrorToastExample />
+          </ToastProvider>
+        </StoryUtils.Stack>
+      </StoryUtils.Container>
+    )
+  })

--- a/src/components/Toast/Toast.stories.js
+++ b/src/components/Toast/Toast.stories.js
@@ -10,6 +10,7 @@ import {
   ToastConsumer,
   useShowErrorToast,
   useShowSuccessToast,
+  useShowErrorAlert,
   useShowToast,
 } from "./"
 import README from "./README.md"
@@ -30,6 +31,23 @@ storiesOf(`Toast`, module)
       return (
         <Button onClick={() => showErrorToast(`An error occured`)}>
           Show error toast
+        </Button>
+      )
+    }
+    function ErrorAlertExample() {
+      const showErrorAlert = useShowErrorAlert()
+
+      return (
+        <Button
+          onClick={() =>
+            showErrorAlert(`An error occured`, {
+              href: `https://google.com`,
+              linkLabel: `See details`,
+              target: `_blank`,
+            })
+          }
+        >
+          Show error alert
         </Button>
       )
     }
@@ -65,6 +83,7 @@ storiesOf(`Toast`, module)
             </ToastConsumer>
             <NoTimeoutExample />
             <ErrorToastExample />
+            <ErrorAlertExample />
           </ToastProvider>
         </StoryUtils.Stack>
       </StoryUtils.Container>

--- a/src/components/Toast/ToastContext.js
+++ b/src/components/Toast/ToastContext.js
@@ -1,0 +1,90 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core"
+import React from "react"
+import PropTypes from "prop-types"
+import { css } from "@emotion/core"
+import Toast from "./Toast"
+import { ToastType } from "./constants"
+
+export const ToastContext = React.createContext()
+export const ToastConsumer = ToastContext.Consumer
+
+const containerCss = css`
+  align-items: center;
+  bottom: 0;
+  display: flex;
+  flex-direction: column-reverse;
+  left: 50%;
+  position: fixed;
+  transform: translate(-50%, 0);
+  width: 100%;
+  z-index: 1;
+`
+
+const DEFAULT_TIMEOUT = 5000
+const DEFAULT_TYPE = ToastType.SUCCESS
+
+export function ToastProvider({ children, closeButtonLabel = `Close` }) {
+  const [toasts, setToasts] = React.useState([])
+
+  const timeoutsRef = React.useRef({})
+
+  const removeToast = React.useCallback(toastId => {
+    setToasts(prevToasts => prevToasts.filter(({ id }) => id !== toastId))
+    clearTimeout(timeoutsRef.current[toastId])
+    delete timeoutsRef.current[toastId]
+  }, [])
+
+  const showToast = React.useCallback(
+    (message, { type = DEFAULT_TYPE, timeout = DEFAULT_TIMEOUT } = {}) => {
+      const toastId = Math.random()
+      setToasts(prevToasts => [...prevToasts, { id: toastId, message, type }])
+
+      if (timeout > 0) {
+        timeoutsRef.current[toastId] = setTimeout(() => {
+          removeToast(toastId)
+        }, timeout)
+      }
+    },
+    []
+  )
+
+  const contextValue = React.useMemo(() => {
+    return {
+      showToast,
+    }
+  }, [showToast])
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+      <div css={containerCss}>
+        {toasts.map(toast => (
+            <Toast
+              key={toast.id}
+              {...toast}
+              onRemove={removeToast}
+              closeButtonLabel={closeButtonLabel}
+            />
+          ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}
+
+ToastProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  closeButtonLabel: PropTypes.string,
+}
+
+export function useToastContext() {
+  const context = React.useContext(ToastContext)
+
+  if (!context) {
+    throw new Error(
+      `Toast hooks cannot be used outside the ToastProvider component`
+    )
+  }
+
+  return context
+}

--- a/src/components/Toast/ToastContext.js
+++ b/src/components/Toast/ToastContext.js
@@ -4,7 +4,6 @@ import React from "react"
 import PropTypes from "prop-types"
 import { css } from "@emotion/core"
 import Toast from "./Toast"
-import { ToastType } from "./constants"
 
 export const ToastContext = React.createContext()
 export const ToastConsumer = ToastContext.Consumer
@@ -22,7 +21,7 @@ const containerCss = css`
 `
 
 const DEFAULT_TIMEOUT = 5000
-const DEFAULT_TYPE = ToastType.SUCCESS
+const DEFAULT_TONE = `SUCCESS`
 
 export function ToastProvider({ children, closeButtonLabel = `Close` }) {
   const [toasts, setToasts] = React.useState([])
@@ -36,9 +35,9 @@ export function ToastProvider({ children, closeButtonLabel = `Close` }) {
   }, [])
 
   const showToast = React.useCallback(
-    (message, { type = DEFAULT_TYPE, timeout = DEFAULT_TIMEOUT } = {}) => {
+    (message, { tone = DEFAULT_TONE, timeout = DEFAULT_TIMEOUT } = {}) => {
       const toastId = Math.random()
-      setToasts(prevToasts => [...prevToasts, { id: toastId, message, type }])
+      setToasts(prevToasts => [...prevToasts, { id: toastId, message, tone }])
 
       if (timeout > 0) {
         timeoutsRef.current[toastId] = setTimeout(() => {
@@ -60,13 +59,13 @@ export function ToastProvider({ children, closeButtonLabel = `Close` }) {
       {children}
       <div css={containerCss}>
         {toasts.map(toast => (
-            <Toast
-              key={toast.id}
-              {...toast}
-              onRemove={removeToast}
-              closeButtonLabel={closeButtonLabel}
-            />
-          ))}
+          <Toast
+            key={toast.id}
+            {...toast}
+            onRemove={removeToast}
+            closeButtonLabel={closeButtonLabel}
+          />
+        ))}
       </div>
     </ToastContext.Provider>
   )

--- a/src/components/Toast/constants.js
+++ b/src/components/Toast/constants.js
@@ -1,4 +1,1 @@
-export const ToastType = {
-  SUCCESS: `success`,
-  ERROR: `error`,
-}
+export const ToastTones = [`SUCCESS`, `DANGER`]

--- a/src/components/Toast/constants.js
+++ b/src/components/Toast/constants.js
@@ -1,0 +1,4 @@
+export const ToastType = {
+  SUCCESS: `success`,
+  ERROR: `error`,
+}

--- a/src/components/Toast/hooks.js
+++ b/src/components/Toast/hooks.js
@@ -1,6 +1,6 @@
 import React from "react"
-import { ToastType } from "./constants"
 import { useToastContext } from "./ToastContext"
+import MessageWithLink from "./MessageWithLink"
 
 export function useShowToast() {
   const { showToast } = useToastContext()
@@ -11,7 +11,7 @@ export function useShowSuccessToast() {
   const showToast = useShowToast()
   return React.useCallback(
     (message, options = {}) => {
-      showToast(message, { ...options, type: ToastType.SUCCESS })
+      showToast(message, { ...options, tone: `SUCCESS` })
     },
     [showToast]
   )
@@ -21,7 +21,21 @@ export function useShowErrorToast() {
   const showToast = useShowToast()
   return React.useCallback(
     (message, options = {}) => {
-      showToast(message, { ...options, type: ToastType.ERROR, timeout: 0 })
+      showToast(message, { ...options, tone: `DANGER`, timeout: 0 })
+    },
+    [showToast]
+  )
+}
+
+export function useShowErrorAlert() {
+  const showToast = useShowErrorToast()
+
+  return React.useCallback(
+    (message, linkProps, options = {}) => {
+      showToast(
+        <MessageWithLink {...linkProps}>{message}</MessageWithLink>,
+        options
+      )
     },
     [showToast]
   )

--- a/src/components/Toast/hooks.js
+++ b/src/components/Toast/hooks.js
@@ -1,0 +1,28 @@
+import React from "react"
+import { ToastType } from "./constants"
+import { useToastContext } from "./ToastContext"
+
+export function useShowToast() {
+  const { showToast } = useToastContext()
+  return showToast
+}
+
+export function useShowSuccessToast() {
+  const showToast = useShowToast()
+  return React.useCallback(
+    (message, options = {}) => {
+      showToast(message, { ...options, type: ToastType.SUCCESS })
+    },
+    [showToast]
+  )
+}
+
+export function useShowErrorToast() {
+  const showToast = useShowToast()
+  return React.useCallback(
+    (message, options = {}) => {
+      showToast(message, { ...options, type: ToastType.ERROR, timeout: 0 })
+    },
+    [showToast]
+  )
+}

--- a/src/components/Toast/index.js
+++ b/src/components/Toast/index.js
@@ -1,0 +1,3 @@
+export { ToastProvider, ToastConsumer } from "./ToastContext"
+export { ToastType } from "./constants"
+export * from "./hooks"

--- a/src/components/Toast/index.js
+++ b/src/components/Toast/index.js
@@ -1,3 +1,2 @@
 export { ToastProvider, ToastConsumer } from "./ToastContext"
-export { ToastType } from "./constants"
 export * from "./hooks"

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ export {
   ToastType,
   useShowSuccessToast,
   useShowErrorToast,
+  useShowErrorAlert,
   useShowToast,
 } from "./components/Toast"
 

--- a/src/index.js
+++ b/src/index.js
@@ -47,4 +47,13 @@ export { InputError } from "./components/InputError"
 
 export { SidebarNav } from "./components/SidebarNav"
 
+export {
+  ToastProvider,
+  ToastConsumer,
+  ToastType,
+  useShowSuccessToast,
+  useShowErrorToast,
+  useShowToast,
+} from "./components/Toast"
+
 export * from "./utils/presets"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,6 +1310,19 @@
     string-width "^2.0.0"
     strip-ansi "^3"
 
+"@reach/alert@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@reach/alert/-/alert-0.1.5.tgz#4da79add0055fa4295f51e5295ed3b80257e9153"
+  integrity sha512-Ow+SB7rokGWxmm+AdOpf4eo29OaEYDqlJ1Kc9qulVX2cKjYiHQqAvkiCkSaIPkQbbyNmEXJ0c/rVpzPVvCVIAw==
+  dependencies:
+    "@reach/component-component" "^0.1.3"
+    "@reach/visually-hidden" "^0.1.4"
+
+"@reach/component-component@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.1.3.tgz#5d156319572dc38995b246f81878bc2577c517e5"
+  integrity sha512-a1USH7L3bEfDdPN4iNZGvMEFuBfkdG+QNybeyDv8RloVFgZYRoM+KGXyy2KOfEnTUM8QWDRSROwaL3+ts5Angg==
+
 "@reach/router@^1.1.1", "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
@@ -1320,6 +1333,11 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
+
+"@reach/visually-hidden@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.1.4.tgz#0dc4ecedf523004337214187db70a46183bd945b"
+  integrity sha512-QHbzXjflSlCvDd6vJwdwx16mSB+vUCCQMiU/wK/CgVNPibtpEiIbisyxkpZc55DyDFNUIqP91rSUsNae+ogGDQ==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
This is a port of `Toast` component from cloud; the goal was to keep the styles and see if it can be improved. Main changes when compared to the cloud version:
1. The toast itself now can support different types. As an example, I've added an `error` type — it will not disappear on timeout and has `"assertive"` type that makes screen readers read the message immediately (which is the desired behaviour for an "error" alert).
2. `Toast` does not use `dangerouslySetInnerHTML` to display its message anymore. Judging by its use in cloud, seems like its purpose was to render text containing `<strong>`  tags. The same can be achieved with this new component like this: 
```javascript
showSuccessToast(
  <React.Fragment>
    <strong>User settings</strong> updated sucessfully.
  </React.Fragment<
);
``` 
3. `ToastProvider` now accepts a new prop — `closeButtonLabel`, both to provide an accessible label for the toast close button and to support i18n if needed.
4. Added hooks that allow to show toasts of different types:
a. `useShowSuccessToast`
b. `useShowErrorToast`
b. `useShowToast` (used by the previous hooks under the hood)