### PR TITLE
Prevent radio labels from causing other options to jump

### DIFF
--- a/src/components/Radio/Radio.js
+++ b/src/components/Radio/Radio.js
@@ -72,11 +72,6 @@ const Label = styled(`label`)`
       left: calc(${spaces.m} + 7px);
     }
   }
-
-  .selected &.emphasized {
-    padding: ${spaces.m} ${spaces.m} ${spaces.m}
-      calc(${INPUT_OUTER_DIA} + ${spaces.s} + ${spaces.m});
-  }
 `
 
 const RadioInput = styled(`input`)`

--- a/src/components/Radio/Radio.stories.js
+++ b/src/components/Radio/Radio.stories.js
@@ -6,8 +6,42 @@ import { text, boolean, radios } from "@storybook/addon-knobs"
 import Radio from "./Radio"
 import { StoryUtils } from "../../utils/storybook"
 
+function ControlledRadio({ name = `radioExample`, options = [] }) {
+  const [value, setValue] = React.useState()
+
+  const selectionStyle = radios(
+    `selectionStyle`,
+    [`standard`, `emphasized`],
+    `standard`
+  )
+
+  return (
+    <div>
+      {options.map(({ value: optionValue, label }) => (
+          <Radio
+            key={optionValue}
+            label={label}
+            selectionStyle={selectionStyle}
+            fieldName={name}
+            optionValue={optionValue}
+            value={value}
+            onChange={e => setValue(e.target.value)}
+          />
+        ))}
+    </div>
+  )
+}
+
 storiesOf(`Radio`, module).add(`Default`, () => (
   <StoryUtils.Container>
-    <Radio label="lorem ipsum" selectionStyle="emphasized" />
+    <div>
+      <ControlledRadio
+        options={[
+          { value: `1`, label: `Option 1` },
+          { value: `2`, label: `Option 2` },
+          { value: `3`, label: `Option 3` },
+        ]}
+      />
+    </div>
   </StoryUtils.Container>
 ))


### PR DESCRIPTION
Seems like labels for `emphasized` radios had a larger padding applied. I guess it was meant as an additional indication for a selected option, but it also causes the "jumpiness" in the radio group.