### PR TITLE
Accept React nodes as label for Radio component

### DIFF
--- a/src/components/Radio/Radio.Skeleton.js
+++ b/src/components/Radio/Radio.Skeleton.js
@@ -9,7 +9,7 @@ const SkeletonStyledInput = styled(`input`)``
 const SkeletonStyledLabel = styled(`label`)``
 
 export const radioPropTypes = {
-  label: PropTypes.string,
+  label: PropTypes.node,
   htmlLabel: PropTypes.any,
   fieldName: PropTypes.string.isRequired,
   id: PropTypes.string,
@@ -70,8 +70,9 @@ export function RadioSkeleton({
         selectionStyle={selectionStyle}
         className={`${selectionStyle}`}
         htmlFor={id}
-        dangerouslySetInnerHTML={{ __html: label }}
-      />
+      >
+        {label}
+      </StyledLabel>
       {children}
     </StyledContainer>
   )

--- a/src/components/Radio/Radio.js
+++ b/src/components/Radio/Radio.js
@@ -76,11 +76,13 @@ const Label = styled(`label`)`
 
 const RadioInput = styled(`input`)`
   cursor: pointer;
+  margin: 0;
+  padding: 0;
   left: 0;
-  height: 20px;
+  height: 100%;
   opacity: 0;
   position: absolute;
-  width: 20px;
+  width: ${INPUT_INNER_DIA};
   z-index: 2;
 
   &:checked + label::before {

--- a/src/components/Radio/Radio.stories.js
+++ b/src/components/Radio/Radio.stories.js
@@ -17,9 +17,10 @@ function ControlledRadio({ name = `radioExample`, options = [] }) {
 
   return (
     <div>
-      {options.map(({ value: optionValue, label }) => (
+      {options.map(({ value: optionValue, label, id }) => (
         <Radio
           key={optionValue}
+          id={id}
           label={label}
           selectionStyle={selectionStyle}
           fieldName={name}
@@ -32,16 +33,79 @@ function ControlledRadio({ name = `radioExample`, options = [] }) {
   )
 }
 
-storiesOf(`Radio`, module).add(`Default`, () => (
-  <StoryUtils.Container>
-    <div>
-      <ControlledRadio
-        options={[
-          { value: `1`, label: `Option 1` },
-          { value: `2`, label: `Option 2` },
-          { value: `3`, label: `Option 3` },
-        ]}
-      />
-    </div>
-  </StoryUtils.Container>
-))
+storiesOf(`Radio`, module)
+  .add(`Default`, () => (
+    <StoryUtils.Container>
+      <div>
+        <ControlledRadio
+          options={[
+            { value: `1`, label: `Option 1`, id: `option-1` },
+            { value: `2`, label: `Option 2`, id: `option-2` },
+            { value: `3`, label: `Option 3`, id: `option-3` },
+          ]}
+        />
+      </div>
+    </StoryUtils.Container>
+  ))
+  .add(`ReactNode as label`, () => (
+    <StoryUtils.Container>
+      <div>
+        <ControlledRadio
+          options={[
+            {
+              value: `1`,
+              id: `option-1`,
+              label: (
+                <div>
+                  <strong>English</strong>
+                  <p>Warszaw is the capital of Poland</p>
+                </div>
+              ),
+            },
+            {
+              value: `2`,
+              id: `option-2`,
+              label: (
+                <div>
+                  <strong>Polish</strong>
+                  <p>Warszawa to stolica Polski</p>
+                </div>
+              ),
+            },
+          ]}
+        />
+      </div>
+    </StoryUtils.Container>
+  ))
+  .add(`dangerouslySetInnerHtml as label`, () => (
+    <StoryUtils.Container>
+      <div>
+        <ControlledRadio
+          options={[
+            {
+              value: `1`,
+              id: `option-1`,
+              label: (
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: `<strong>English</strong><p>Warszaw is the capital of Poland</p>`,
+                  }}
+                />
+              ),
+            },
+            {
+              value: `2`,
+              id: `option-2`,
+              label: (
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: `<strong>Polish</strong><p>Warszawa to stolica Polski</p>`,
+                  }}
+                />
+              ),
+            },
+          ]}
+        />
+      </div>
+    </StoryUtils.Container>
+  ))


### PR DESCRIPTION
1. Allow to pass React nodes in `label` prop to `Radio`. This will allow to implement complex labels without drawbacks of forced `dangerouslySetInnerHTML`. It is also still possible to use `dangerouslySetInnerHTML` to render user-generated labels if needed as seen in new stories.
1. Fix an issue that occurs when the radio label is higher than the input itself. Previously, it would make the input unclickable since it had fixed height. Now the input fills all available height, making it impossible to miss it when clicking :)