### PR TITLE
Add an alternative variant to integration row content details

### DIFF
--- a/src/components/core/IntegrationRow/IntegrationRow.js
+++ b/src/components/core/IntegrationRow/IntegrationRow.js
@@ -11,6 +11,7 @@ import { Heading } from "../Heading"
 import { Badge } from "../Badge"
 import { spaces, fontFamilies } from "../../../utils/presets"
 import fontSizes from "../../../theme/fontSizes"
+import fonts from "../../../theme/fonts"
 import colors from "../../../theme/colors"
 import cardStyles from "../../../theme/styles/card"
 function IntegrationRow({
@@ -164,8 +165,8 @@ function renderData(data = [], primaryStyling) {
           variant="LIGHT"
           css={{
             fontFamily: primaryStyling
-              ? fontFamilies.headerFontFamily
-              : fontFamilies.bodyFontFamily,
+              ? fonts.header.join(`,`)
+              : fontFamilies.system.join(`,`),
             textTransform: primaryStyling ? `uppercase` : `capitalize`,
           }}
         >

--- a/src/components/core/IntegrationRow/IntegrationRow.js
+++ b/src/components/core/IntegrationRow/IntegrationRow.js
@@ -9,13 +9,10 @@ import { Link } from "../../Link"
 import { Button } from "../Button"
 import { Heading } from "../Heading"
 import { Badge } from "../Badge"
-import { breakpoints, spaces } from "../../../utils/presets"
+import { spaces, fontFamilies } from "../../../utils/presets"
 import fontSizes from "../../../theme/fontSizes"
-import fonts from "../../../theme/fonts"
 import colors from "../../../theme/colors"
 import cardStyles from "../../../theme/styles/card"
-import { styles as headingStyles } from "../../../theme/styles/heading"
-
 function IntegrationRow({
   isConnected = false,
   title,
@@ -23,6 +20,7 @@ function IntegrationRow({
   button = {},
   link = {},
   details,
+  detailsVariant = `PRIMARY`,
   children,
   ...rest
 }) {
@@ -64,7 +62,12 @@ function IntegrationRow({
         <IntegrationRow.EditButton label={linkLabel} {...linkRest} />
       )}
 
-      {details && <IntegrationRow.Content details={details} />}
+      {details && (
+        <IntegrationRow.Content
+          details={details}
+          detailsVariant={detailsVariant}
+        />
+      )}
 
       {isConnected && (
         <IntegrationRow.Badge>
@@ -140,23 +143,37 @@ IntegrationRow.EditButton = ({ children, label = `Connect`, ...rest }) => {
   )
 }
 
-function renderData(data = []) {
+function renderData(data = [], primaryStyling) {
   if (data.length > 0) {
     return data.map((item, idx) => (
       <div
         key={`data-${item.name}`}
         css={{
-          display: `flex`,
-          flexDirection: `column`,
+          display: primaryStyling ? `flex` : `grid`,
+          flexDirection: primaryStyling ? `column` : `row`,
           fontSize: fontSizes[1],
+          gridTemplateColumns: primaryStyling ? `0` : `0.35fr 1fr`,
+          marginTop: primaryStyling ? `inherit` : spaces.s,
+          "&:first-of-type": {
+            marginTop: primaryStyling ? `inherit` : `0`,
+          },
         }}
       >
-        <Heading as="span" variant="LIGHT">
+        <Heading
+          as="span"
+          variant="LIGHT"
+          css={{
+            fontFamily: primaryStyling
+              ? fontFamilies.headerFontFamily
+              : fontFamilies.bodyFontFamily,
+            textTransform: primaryStyling ? `uppercase` : `capitalize`,
+          }}
+        >
           {item.name}
         </Heading>
         <span
           css={{
-            marginTop: spaces[`2xs`],
+            marginTop: primaryStyling ? spaces[`2xs`] : `0`,
             color: colors.grey[90],
           }}
         >
@@ -179,21 +196,24 @@ function renderData(data = []) {
 IntegrationRow.Content = ({
   children,
   details,
+  detailsVariant = `PRIMARY`,
   variant = `SECONDARY`,
   ...rest
-}) =>
-  details || children ? (
+}) => {
+  const primaryStyling = detailsVariant === `PRIMARY`
+  return details || children ? (
     <ContentBox.Content
       variant={variant}
       css={{
         gridColumn: `1 / 4`,
         display: `grid`,
-        gridTemplateColumns: `1.5fr 1fr`,
+        gridTemplateColumns: primaryStyling ? `1.5fr 1fr` : `1.5fr`,
       }}
       {...rest}
     >
-      {!details ? children : renderData(details)}
+      {!details ? children : renderData(details, primaryStyling)}
     </ContentBox.Content>
   ) : null
+}
 
 export default IntegrationRow

--- a/src/components/core/IntegrationRow/IntegrationRow.stories.js
+++ b/src/components/core/IntegrationRow/IntegrationRow.stories.js
@@ -1,12 +1,15 @@
 import React from "react"
 
 import { storiesOf } from "@storybook/react"
+import { radios } from "@storybook/addon-knobs"
 
 import { IntegrationRow } from "./"
 import { StoryUtils } from "../../../utils/storybook"
 import NetlifyLogo from "../../../assets/NetlifyLogo"
 import contentfulLogo from "../../../assets/contentfulLogo.png"
 import netlifyLogo from "../../../assets/netlifyLogo.svg"
+
+const DETAILS_VARIANT = [`PRIMARY`, `SECONDARY`]
 
 storiesOf(`core/IntegrationRow`, module)
   .add(`default usage`, () => (
@@ -25,6 +28,11 @@ storiesOf(`core/IntegrationRow`, module)
           </IntegrationRow.Logo>
           <IntegrationRow.EditButton />
           <IntegrationRow.Content
+            detailsVariant={radios(
+              `details variant`,
+              DETAILS_VARIANT,
+              `PRIMARY`
+            )}
             details={[
               {
                 name: `space name`,
@@ -56,6 +64,7 @@ storiesOf(`core/IntegrationRow`, module)
           logoUrl={netlifyLogo}
           button={{ onClick: () => alert(`onClickEdit()`) }}
           isConnected={true}
+          detailsVariant={radios(`details variant`, DETAILS_VARIANT, `PRIMARY`)}
           details={[
             {
               name: `site`,


### PR DESCRIPTION
This allows the user to specify a variant for the integration row content details component

Currently, it only supports details as a row but this allows it to be a column as well. This is for the new designs for cms integrations