### PR TITLE
Forward Radio and RadioSkeleton refs to radio input

### DIFF
--- a/src/components/Radio/Radio.Skeleton.js
+++ b/src/components/Radio/Radio.Skeleton.js
@@ -36,47 +36,51 @@ const radioSkeletonDefaultPropTypes = {
   StyledLabel: SkeletonStyledLabel,
 }
 
-export function RadioSkeleton({
-  StyledContainer,
-  StyledInput,
-  StyledLabel,
-  label,
-  InnerLabelComponent,
-  fieldName,
-  id,
-  optionValue,
-  value,
-  className,
-  children,
-  onChange,
-  type,
-  selectionStyle,
-  ...rest
-}) {
-  return (
-    <StyledContainer
-      className={`${optionValue === value ? `selected` : ``} ${className}`}
-    >
-      <StyledInput
-        type="radio"
-        name={fieldName}
-        id={id}
-        value={optionValue}
-        checked={optionValue === value}
-        onChange={onChange}
-        {...rest}
-      />
-      <StyledLabel
-        selectionStyle={selectionStyle}
-        className={`${selectionStyle}`}
-        htmlFor={id}
+export const RadioSkeleton = React.forwardRef(
+  (
+    {
+      StyledContainer,
+      StyledInput,
+      StyledLabel,
+      label,
+      InnerLabelComponent,
+      fieldName,
+      id,
+      optionValue,
+      value,
+      className,
+      children,
+      onChange,
+      type,
+      selectionStyle,
+      ...rest
+    },
+    ref
+  ) => (
+      <StyledContainer
+        className={`${optionValue === value ? `selected` : ``} ${className}`}
       >
-        {label}
-      </StyledLabel>
-      {children}
-    </StyledContainer>
-  )
-}
+        <StyledInput
+          ref={ref}
+          type="radio"
+          name={fieldName}
+          id={id}
+          value={optionValue}
+          checked={optionValue === value}
+          onChange={onChange}
+          {...rest}
+        />
+        <StyledLabel
+          selectionStyle={selectionStyle}
+          className={`${selectionStyle}`}
+          htmlFor={id}
+        >
+          {label}
+        </StyledLabel>
+        {children}
+      </StyledContainer>
+    )
+)
 
 RadioSkeleton.propTypes = radioSkeletonPropTypes
 RadioSkeleton.defaultProps = radioSkeletonDefaultPropTypes

--- a/src/components/Radio/Radio.js
+++ b/src/components/Radio/Radio.js
@@ -30,7 +30,7 @@ const Label = styled(`label`)`
   :after,
   :before {
     border-radius: 50%;
-    content: "";
+    qcontent: "";
     flex-grow: 0;
     flex-shrink: 0;
     left: 0;
@@ -159,11 +159,12 @@ const ColourfulContainer = styled(StandardContainer)`
   }
 `
 
-const Radio = props => {
+const Radio = React.forwardRef((props, ref) => {
   const { selectionStyle } = props
 
   return (
     <RadioSkeleton
+      ref={ref}
       StyledContainer={
         selectionStyle === `emphasized` ? ColourfulContainer : StandardContainer
       }
@@ -172,7 +173,7 @@ const Radio = props => {
       {...props}
     />
   )
-}
+})
 
 Radio.propTypes = radioPropTypes
 Radio.defaultProps = radioDefaultPropTypes

--- a/src/components/Radio/Radio.js
+++ b/src/components/Radio/Radio.js
@@ -30,7 +30,7 @@ const Label = styled(`label`)`
   :after,
   :before {
     border-radius: 50%;
-    qcontent: "";
+    content: "";
     flex-grow: 0;
     flex-shrink: 0;
     left: 0;


### PR DESCRIPTION
Now it will be possible to pass `ref` to `Radio` or `RadioSkeleton` allowing for more control over the input.

Most of the changes here are by prettier :)