### PR TITLE
chore: fix Storyshots tests

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -17,14 +17,18 @@ import { fontFamilies } from "../src/utils/presets"
 import "@storybook/addon-console"
 import "storybook-chromatic"
 
-import "../assets/fonts/futura-pt/Webfonts/futurapt_book_macroman/stylesheet.css"
-import "../assets/fonts/futura-pt/Webfonts/futurapt_bookitalic_macroman/stylesheet.css"
-import "../assets/fonts/futura-pt/Webfonts/futurapt_demi_macroman/stylesheet.css"
-import "../assets/fonts/futura-pt/Webfonts/futurapt_demiitalic_macroman/stylesheet.css"
-import "../assets/fonts/futura-pt/Webfonts/futurapt_bold/MyFontsWebfontsKit.css"
-
 if (process.env.NODE_ENV === "test") {
   require(`babel-plugin-require-context-hook/register`)()
+} else {
+  try {
+    require("../assets/fonts/futura-pt/Webfonts/futurapt_book_macroman/stylesheet.css")
+    require("../assets/fonts/futura-pt/Webfonts/futurapt_bookitalic_macroman/stylesheet.css")
+    require("../assets/fonts/futura-pt/Webfonts/futurapt_demi_macroman/stylesheet.css")
+    require("../assets/fonts/futura-pt/Webfonts/futurapt_demiitalic_macroman/stylesheet.css")
+    require("../assets/fonts/futura-pt/Webfonts/futurapt_bold/stylesheet.css")
+  } catch (e) {
+    console.warn(e)
+  }
 }
 
 global.___loader = {

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -1,1598 +1,1661 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Button BaseButton 1`] = `
-.emotion-0 {
+exports[`Storyshots Breadcrumb default 1`] = `
+.emotion-4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #8a4baf;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  font-size: 1.125rem;
+  margin-right: 0.75rem;
+}
+
+.emotion-1:last-of-type {
+  margin-right: 0;
+}
+
+.emotion-1:last-of-type svg {
+  display: none;
+}
+
+.emotion-1 svg {
+  fill: #8a4baf;
+  margin-left: 0.75rem;
+  vertical-align: middle;
+}
+
+.emotion-0 {
   -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
+  color: inherit;
 }
 
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #232129;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  font-size: 1.125rem;
+  margin-right: 0.75rem;
 }
 
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
+.emotion-2:last-of-type {
+  margin-right: 0;
 }
 
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
+.emotion-2:last-of-type svg {
+  display: none;
+}
+
+.emotion-2 svg {
+  fill: #232129;
+  margin-left: 0.75rem;
+  vertical-align: middle;
 }
 
 <div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
+  className="storybook-readme-story"
 >
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        BaseButton
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
+  <div
+    style={Object {}}
+  >
+    <div>
       <div
-        style={undefined}
+        className="emotion-4"
       >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
+        <nav
+          aria-label="breadcrumb"
+          className="emotion-3"
         >
           <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
+            className="emotion-1"
           >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
+            <a
+              className="emotion-0"
+              href="/"
+              onClick={undefined}
             >
-              Button
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
+              Breadcrumb 1
+            </a>
+            <svg
+              fill="none"
+              height="9"
+              viewBox="0 0 6 9"
+              width="6"
             >
-              BaseButton
-            </h2>
+              <path
+                d="M6 4.5L1.5 8.39711L1.5 0.602886L6 4.5Z"
+                fill="#7F7C82"
+              />
+            </svg>
           </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
+          <div
+            className="emotion-2"
+          >
+            Breadcrumb 2
+             
+            <svg
+              fill="none"
+              height="9"
+              viewBox="0 0 6 9"
+              width="6"
             >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      BaseButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      BaseButton
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      BaseButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
+              <path
+                d="M6 4.5L1.5 8.39711L1.5 0.602886L6 4.5Z"
+                fill="#7F7C82"
+              />
+            </svg>
           </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                BaseButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
+        </nav>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`Storyshots Button ButtonSkeleton 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        ButtonSkeleton
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              ButtonSkeleton
-            </h2>
-          </div>
-          <div
-            style={
-              Object {
-                "marginBottom": 0,
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "fontSize": "15px",
-                }
-              }
-            >
-              It’s a functional building block, on which all other Button components are build on. 
+exports[`Storyshots File Upload File Upload with Custom Components 1`] = `
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
 
-              <strong>
-                Never used directly
-              </strong>
-               in the codebase.
-            </div>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      ButtonSkeleton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      ButtonSkeleton
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      ButtonSkeleton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                ButtonSkeleton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      StyledComponent
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        any
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Styled
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-0"
+      >
+        <p>
+          Using the FileUpload component without setting the GATSBY_FILESTACK_API_KEY will fail
+        </p>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`Storyshots Button CancelButton 1`] = `
+exports[`Storyshots File Upload Multi File Upload 1`] = `
 .emotion-0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
+  width: 100%;
+  padding: 20px;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-0"
+      >
+        <p>
+          Using the FileUpload component without setting the GATSBY_FILESTACK_API_KEY will fail
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots File Upload Single File Upload 1`] = `
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-0"
+      >
+        <p>
+          Using the FileUpload component without setting the GATSBY_FILESTACK_API_KEY will fail
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Introduction/ Welcome to Gatsby Inteface 1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <div>
+    <div
+      className="markdown-body"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>test-file-stub</p>
+",
+        }
+      }
+    />
+  </div>
+  <div
+    style={Object {}}
+  >
+    <div />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Notification default 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  width: 500px;
+}
+
+.emotion-8 > button {
+  margin: 20px;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  width: 100%;
   background: #ffffff;
-  border: 1px solid #D9D7E0;
-  color: #635E69;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-left: 10px solid #663399;
+  padding: 1rem 1.5rem 1rem 1rem;
+}
+
+@media (min-width:1000px) {
+  .emotion-2 {
+    padding: 1rem 1.5rem 1rem 1rem;
+  }
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0 svg {
+  fill: #663399;
+  margin-right: 0.5rem;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #663399;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-1:focus,
+.emotion-1:hover {
+  color: #663399;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  width: 100%;
+  background: #ffffff;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-left: 10px solid #663399;
+  padding: 1rem 1.5rem 1rem 1rem;
+  margin-top: 1rem;
+}
+
+@media (min-width:1000px) {
+  .emotion-5 {
+    padding: 1rem 1.5rem 1rem 1rem;
+  }
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+  padding: 0;
+  min-height: auto;
+  width: 1rem;
+}
+
+.emotion-4[disabled],
+.emotion-4[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-4 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-4 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-4 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-4:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-4:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+.emotion-4 svg {
+  fill: #b7b5bd;
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  width: 100%;
+  background: #fcfaff;
+  padding: 1rem 1.5rem;
+  margin-top: 1rem;
+}
+
+@media (min-width:1000px) {
+  .emotion-7 {
+    padding: 1.5rem 2.5rem;
+  }
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-9"
+      >
+        <div
+          className="emotion-8"
+        >
+          <div
+            className="emotion-2"
+          >
+            <span
+              className="emotion-0"
+            >
+              Notification variant 'PRIMARY'
+            </span>
+            <a
+              className="emotion-1"
+              href="/"
+            >
+              Link
+               
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </a>
+          </div>
+          <div
+            className="emotion-5"
+          >
+            <span
+              className="emotion-0"
+            >
+              Notification variant 'PRIMARY' with close
+            </span>
+            <button
+              className="emotion-4"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </button>
+          </div>
+          <section
+            className="emotion-7"
+          >
+            <span
+              className="emotion-0"
+            >
+              Notification variant 'SECONDARY'
+            </span>
+          </section>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Radio Default 1`] = `
+.emotion-18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  margin-bottom: 1rem;
+  position: relative;
+}
+
+.emotion-0 {
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  left: 0;
+  height: 100%;
+  opacity: 0;
+  position: absolute;
+  width: 22px;
+  z-index: 2;
+}
+
+.emotion-0:checked + label::before {
+  border-color: #663399;
+}
+
+.emotion-0:checked + label::after {
+  opacity: 1;
+}
+
+.emotion-0:hover + label::before {
+  border-color: #b17acc;
+}
+
+.emotion-0:focus + label::before {
+  border-color: #663399;
+  box-shadow: 0 0 0 3px #f1defa;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #36313d;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  font-size: 1rem;
+  line-height: 1;
+  padding-left: calc(calc(22px + (2 * 2px)) + 0.75rem);
+  position: relative;
+  min-height: calc(22px + (2 * 2px));
+}
+
+.emotion-2:after,
+.emotion-2:before {
+  border-radius: 50%;
+  content: "";
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  left: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: 0.15s ease-in-out;
+  transition: 0.15s ease-in-out;
+}
+
+.emotion-2:before {
+  background: #ffffff;
+  border: 2px solid #d9d7e0;
+  height: 22px;
+  width: 22px;
+}
+
+.emotion-2:after {
+  background: #663399;
+  height: 8px;
+  left: 7px;
+  opacity: 0;
+  width: 8px;
+}
+
+.emotion-2 small {
+  color: #78757a;
+  font-size: 0.875rem;
+  line-height: 1.1;
+}
+
+.emotion-2.emphasized {
+  padding: 0.75rem 1rem 0.75rem calc(calc(22px + (2 * 2px)) + 0.75rem + 1rem);
+}
+
+.emotion-2.emphasized:before {
+  left: 1rem;
+}
+
+.emotion-2.emphasized:after {
+  left: calc(1rem + 7px);
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-18"
+      >
+        <div>
+          <div>
+            <div
+              className=" undefined emotion-4 emotion-5"
+            >
+              <input
+                checked={false}
+                className="emotion-0 emotion-1"
+                id="option-1"
+                name="radioExample"
+                onChange={[Function]}
+                type="radio"
+                value="1"
+              />
+              <label
+                className="standard emotion-2 emotion-3"
+                htmlFor="option-1"
+              >
+                Option 1
+              </label>
+            </div>
+            <div
+              className=" undefined emotion-4 emotion-5"
+            >
+              <input
+                checked={false}
+                className="emotion-0 emotion-1"
+                id="option-2"
+                name="radioExample"
+                onChange={[Function]}
+                type="radio"
+                value="2"
+              />
+              <label
+                className="standard emotion-2 emotion-3"
+                htmlFor="option-2"
+              >
+                Option 2
+              </label>
+            </div>
+            <div
+              className=" undefined emotion-4 emotion-5"
+            >
+              <input
+                checked={false}
+                className="emotion-0 emotion-1"
+                id="option-3"
+                name="radioExample"
+                onChange={[Function]}
+                type="radio"
+                value="3"
+              />
+              <label
+                className="standard emotion-2 emotion-3"
+                htmlFor="option-3"
+              >
+                Option 3
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Radio ReactNode as label 1`] = `
+.emotion-12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  margin-bottom: 1rem;
+  position: relative;
+}
+
+.emotion-0 {
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  left: 0;
+  height: 100%;
+  opacity: 0;
+  position: absolute;
+  width: 22px;
+  z-index: 2;
+}
+
+.emotion-0:checked + label::before {
+  border-color: #663399;
+}
+
+.emotion-0:checked + label::after {
+  opacity: 1;
+}
+
+.emotion-0:hover + label::before {
+  border-color: #b17acc;
+}
+
+.emotion-0:focus + label::before {
+  border-color: #663399;
+  box-shadow: 0 0 0 3px #f1defa;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #36313d;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  font-size: 1rem;
+  line-height: 1;
+  padding-left: calc(calc(22px + (2 * 2px)) + 0.75rem);
+  position: relative;
+  min-height: calc(22px + (2 * 2px));
+}
+
+.emotion-2:after,
+.emotion-2:before {
+  border-radius: 50%;
+  content: "";
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  left: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: 0.15s ease-in-out;
+  transition: 0.15s ease-in-out;
+}
+
+.emotion-2:before {
+  background: #ffffff;
+  border: 2px solid #d9d7e0;
+  height: 22px;
+  width: 22px;
+}
+
+.emotion-2:after {
+  background: #663399;
+  height: 8px;
+  left: 7px;
+  opacity: 0;
+  width: 8px;
+}
+
+.emotion-2 small {
+  color: #78757a;
+  font-size: 0.875rem;
+  line-height: 1.1;
+}
+
+.emotion-2.emphasized {
+  padding: 0.75rem 1rem 0.75rem calc(calc(22px + (2 * 2px)) + 0.75rem + 1rem);
+}
+
+.emotion-2.emphasized:before {
+  left: 1rem;
+}
+
+.emotion-2.emphasized:after {
+  left: calc(1rem + 7px);
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-12"
+      >
+        <div>
+          <div>
+            <div
+              className=" undefined emotion-4 emotion-5"
+            >
+              <input
+                checked={false}
+                className="emotion-0 emotion-1"
+                id="option-1"
+                name="radioExample"
+                onChange={[Function]}
+                type="radio"
+                value="1"
+              />
+              <label
+                className="standard emotion-2 emotion-3"
+                htmlFor="option-1"
+              >
+                <div>
+                  <strong>
+                    English
+                  </strong>
+                  <p>
+                    Warszaw is the capital of Poland
+                  </p>
+                </div>
+              </label>
+            </div>
+            <div
+              className=" undefined emotion-4 emotion-5"
+            >
+              <input
+                checked={false}
+                className="emotion-0 emotion-1"
+                id="option-2"
+                name="radioExample"
+                onChange={[Function]}
+                type="radio"
+                value="2"
+              />
+              <label
+                className="standard emotion-2 emotion-3"
+                htmlFor="option-2"
+              >
+                <div>
+                  <strong>
+                    Polish
+                  </strong>
+                  <p>
+                    Warszawa to stolica Polski
+                  </p>
+                </div>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Radio dangerouslySetInnerHtml as label 1`] = `
+.emotion-12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  margin-bottom: 1rem;
+  position: relative;
+}
+
+.emotion-0 {
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  left: 0;
+  height: 100%;
+  opacity: 0;
+  position: absolute;
+  width: 22px;
+  z-index: 2;
+}
+
+.emotion-0:checked + label::before {
+  border-color: #663399;
+}
+
+.emotion-0:checked + label::after {
+  opacity: 1;
+}
+
+.emotion-0:hover + label::before {
+  border-color: #b17acc;
+}
+
+.emotion-0:focus + label::before {
+  border-color: #663399;
+  box-shadow: 0 0 0 3px #f1defa;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #36313d;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  font-size: 1rem;
+  line-height: 1;
+  padding-left: calc(calc(22px + (2 * 2px)) + 0.75rem);
+  position: relative;
+  min-height: calc(22px + (2 * 2px));
+}
+
+.emotion-2:after,
+.emotion-2:before {
+  border-radius: 50%;
+  content: "";
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  left: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: 0.15s ease-in-out;
+  transition: 0.15s ease-in-out;
+}
+
+.emotion-2:before {
+  background: #ffffff;
+  border: 2px solid #d9d7e0;
+  height: 22px;
+  width: 22px;
+}
+
+.emotion-2:after {
+  background: #663399;
+  height: 8px;
+  left: 7px;
+  opacity: 0;
+  width: 8px;
+}
+
+.emotion-2 small {
+  color: #78757a;
+  font-size: 0.875rem;
+  line-height: 1.1;
+}
+
+.emotion-2.emphasized {
+  padding: 0.75rem 1rem 0.75rem calc(calc(22px + (2 * 2px)) + 0.75rem + 1rem);
+}
+
+.emotion-2.emphasized:before {
+  left: 1rem;
+}
+
+.emotion-2.emphasized:after {
+  left: calc(1rem + 7px);
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-12"
+      >
+        <div>
+          <div>
+            <div
+              className=" undefined emotion-4 emotion-5"
+            >
+              <input
+                checked={false}
+                className="emotion-0 emotion-1"
+                id="option-1"
+                name="radioExample"
+                onChange={[Function]}
+                type="radio"
+                value="1"
+              />
+              <label
+                className="standard emotion-2 emotion-3"
+                htmlFor="option-1"
+              >
+                <div
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<strong>English</strong><p>Warszaw is the capital of Poland</p>",
+                    }
+                  }
+                />
+              </label>
+            </div>
+            <div
+              className=" undefined emotion-4 emotion-5"
+            >
+              <input
+                checked={false}
+                className="emotion-0 emotion-1"
+                id="option-2"
+                name="radioExample"
+                onChange={[Function]}
+                type="radio"
+                value="2"
+              />
+              <label
+                className="standard emotion-2 emotion-3"
+                htmlFor="option-2"
+              >
+                <div
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<strong>Polish</strong><p>Warszawa to stolica Polski</p>",
+                    }
+                  }
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots SidebarNav usage example 1`] = `
+.emotion-17 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-16 {
+  padding-left: 2rem;
+}
+
+.emotion-15 {
+  padding-inline-start: 0;
+  margin: 0;
+  max-width: 8rem;
+}
+
+.emotion-1 {
+  margin-bottom: 0;
+  padding: 0.5rem 0;
+  position: relative;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  font-size: 1rem;
+  color: #8a4baf;
+  list-style: none;
+}
+
+.emotion-1:first-of-type {
+  padding-top: 0;
+}
+
+.emotion-1:last-of-type {
+  padding-bottom: 0;
+}
+
+.emotion-1 svg {
+  vertical-align: middle;
+  position: absolute;
+  left: -2rem;
+}
+
+.emotion-0 {
+  color: inherit;
+  line-height: 1.375rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-8 {
+  padding-inline-start: 0;
+  margin: 0;
+  padding: 0.5rem 0;
+}
+
+.emotion-3 {
+  padding: 0.25rem 1rem;
+  margin-bottom: 0;
+  border-left: 1px solid #8a4baf;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  font-size: 1rem;
+  color: #8a4baf;
+  list-style: none;
+}
+
+.emotion-3:first-of-type {
+  padding-top: 0;
+}
+
+.emotion-3:last-of-type {
+  padding-bottom: 0;
+}
+
+.emotion-5 {
+  padding: 0.25rem 1rem;
+  margin-bottom: 0;
+  border-left: 1px solid #d9d7e0;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  font-size: 1rem;
+  color: #635e69;
+  list-style: none;
+}
+
+.emotion-5:first-of-type {
+  padding-top: 0;
+}
+
+.emotion-5:last-of-type {
+  padding-bottom: 0;
+}
+
+.emotion-10 {
+  margin-bottom: 0;
+  padding: 0.5rem 0;
+  position: relative;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  font-size: 1rem;
+  color: #635e69;
+  list-style: none;
+}
+
+.emotion-10:first-of-type {
+  padding-top: 0;
+}
+
+.emotion-10:last-of-type {
+  padding-bottom: 0;
+}
+
+.emotion-10 svg {
+  vertical-align: middle;
+  position: absolute;
+  left: -2rem;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-17"
+      >
+        <nav
+          aria-label="sidebar-nav"
+          className="emotion-16"
+        >
+          <ul
+            className="emotion-15"
+          >
+            <li
+              className="emotion-1"
+            >
+              <a
+                className="emotion-0"
+                href="/"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="12"
+                    cy="4"
+                    fill="#B17ACC"
+                    r="1"
+                    transform="rotate(90 12 4)"
+                  />
+                  <circle
+                    cx="12"
+                    cy="12"
+                    fill="#8954A8"
+                    r="4"
+                    transform="rotate(45 12 12)"
+                  />
+                  <circle
+                    cx="4"
+                    cy="12"
+                    fill="#232129"
+                    r="1"
+                    transform="rotate(90 4 12)"
+                  />
+                  <circle
+                    cx="6.34302"
+                    cy="6.34317"
+                    fill="#232129"
+                    r="1"
+                    transform="rotate(45 6.34302 6.34317)"
+                  />
+                  <circle
+                    cx="6.34302"
+                    cy="17.6568"
+                    fill="#B17ACC"
+                    r="1"
+                    transform="rotate(45 6.34302 17.6568)"
+                  />
+                  <path
+                    d="M12 3.99994C16.4183 3.99994 20 7.58166 20 11.9999C20 16.4182 16.4183 19.9999 12 19.9999C9.86958 19.9999 7.93366 19.1672 6.5 17.8094"
+                    stroke="#B17ACC"
+                  />
+                </svg>
+                General
+              </a>
+            </li>
+            <ul
+              className="emotion-8"
+            >
+              <li
+                className="emotion-3"
+              >
+                <a
+                  className="emotion-0"
+                  href="#"
+                  onClick={[Function]}
+                >
+                  Site Details
+                </a>
+              </li>
+              <li
+                className="emotion-5"
+              >
+                <a
+                  className="emotion-0"
+                  href="#"
+                  onClick={[Function]}
+                >
+                  Contributors
+                </a>
+              </li>
+              <li
+                className="emotion-5"
+              >
+                <a
+                  className="emotion-0"
+                  href="#"
+                  onClick={[Function]}
+                >
+                  Environment Variables
+                </a>
+              </li>
+            </ul>
+            <li
+              className="emotion-10"
+            >
+              <a
+                className="emotion-0"
+                href="/"
+                onClick={[Function]}
+              >
+                Integrations
+              </a>
+            </li>
+            <li
+              className="emotion-10"
+            >
+              <a
+                className="emotion-0"
+                href="/"
+                onClick={[Function]}
+              >
+                Preview
+              </a>
+            </li>
+            <li
+              className="emotion-10"
+            >
+              <a
+                className="emotion-0"
+                href="/"
+                onClick={[Function]}
+              >
+                Danger Zone
+              </a>
+            </li>
+          </ul>
+          <div />
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots TextInput Default 1`] = `
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-0 {
+  border: 1px solid #d9d7e0;
+  border-radius: 4px;
+  color: #232129;
+  font-size: 1rem;
+  height: 2.25rem;
+  padding: 0 0.75rem;
+  width: 100%;
+}
+
+.emotion-0:focus {
+  border-color: #b17acc;
+  box-shadow: 0 0 0 3px #f1defa;
+  outline: 0;
+  -webkit-transition: box-shadow 0.15s ease-in-out;
+  transition: box-shadow 0.15s ease-in-out;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-1"
+      >
+        <input
+          className="emotion-0"
+          defaultValue={undefined}
+          disabled={false}
+          id={undefined}
+          onChange={undefined}
+          placeholder="Placeholder text"
+          type="text"
+          value={undefined}
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Toast Default 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-5 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
 }
 
 .emotion-0[disabled],
@@ -1605,731 +1668,4555 @@ exports[`Storyshots Button CancelButton 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
 }
 
 .emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
 }
 
-.emotion-0:focus,
 .emotion-0:hover {
-  border: 1px solid #635E69;
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  bottom: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  left: 50%;
+  position: fixed;
+  -webkit-transform: translate(-50%,0);
+  -ms-transform: translate(-50%,0);
+  transform: translate(-50%,0);
+  width: 100%;
+  z-index: 1;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-6"
+      >
+        <div
+          className="emotion-5"
+        >
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Show toast
+            </span>
+          </button>
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Show toast without auto hide
+            </span>
+          </button>
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Show error toast
+            </span>
+          </button>
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Show error alert
+            </span>
+          </button>
+          <div
+            className="emotion-4"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Announcement default usage 1`] = `
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-1 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #f7ffff;
+  color: #008577;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  padding: 1rem 2.5rem;
+  background-image: url(test-file-stub);
+  background-position: right center;
+  background-repeat: no-repeat;
+}
+
+.emotion-0:not(:first-child) {
+  border-top: 1px solid #dcfffd;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-2"
+      >
+        <div
+          className="emotion-1"
+        >
+          <div
+            className="emotion-0"
+          >
+            We are working on adding more integrations all the time—watch your inbox!
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Badge shortcut usage 1`] = `
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-1 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  border-radius: 4px;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-weight: bold;
+  line-height: 1;
+  background: #37b635;
+  color: #ffffff;
+  font-size: 13px;
+  -webkit-letter-spacing: 0.05em;
+  -moz-letter-spacing: 0.05em;
+  -ms-letter-spacing: 0.05em;
+  letter-spacing: 0.05em;
+  padding: 4px 5px 2px;
+  text-transform: uppercase;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-2"
+      >
+        <div
+          className="emotion-1"
+        >
+          <span
+            className="emotion-0"
+          >
+            New
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Badge variants 1`] = `
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  border-radius: 4px;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-weight: bold;
+  line-height: 1;
+  background: #37b635;
+  color: #ffffff;
+  font-size: 13px;
+  -webkit-letter-spacing: 0.05em;
+  -moz-letter-spacing: 0.05em;
+  -ms-letter-spacing: 0.05em;
+  letter-spacing: 0.05em;
+  padding: 4px 5px 2px;
+  text-transform: uppercase;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  border-radius: 4px;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-weight: bold;
+  line-height: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #f7fdf7;
+  color: #37b635;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 1rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.emotion-1 svg:last-child {
+  margin-left: 0.25rem;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eee;
+  color: green;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: .9rem;
+  font-weight: normal;
+  margin-left: 2em;
+  padding: .3em .6em;
+  vertical-align: text-bottom;
+}
+
+.emotion-2 svg {
+  margin-right: 0.2em;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-5"
+      >
+        <div
+          className="emotion-4"
+        >
+          <span
+            className="emotion-0"
+          >
+            New
+          </span>
+          <div
+            className="emotion-3"
+          >
+            <span
+              className="emotion-1"
+            >
+              Connected 
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7 2v11h3v9l7-12h-4l4-8z"
+                />
+              </svg>
+            </span>
+            <div
+              className="emotion-2"
+            >
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                />
+              </svg>
+               default
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button in 'loading' state 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0);
+    -ms-transform: rotate(0);
+    transform: rotate(0);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-2 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.9;
+}
+
+.emotion-0 svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-3"
+      >
+        <div
+          className="emotion-2"
+        >
+          <button
+            className="emotion-0"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Loading
+            </span>
+             
+            <svg
+              className={undefined}
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              strokeWidth="0"
+              style={
+                Object {
+                  "color": undefined,
+                }
+              }
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+              />
+            </svg>
+          </button>
+          <button
+            className="emotion-0"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Custom loading label
+            </span>
+             
+            <svg
+              className={undefined}
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              strokeWidth="0"
+              style={
+                Object {
+                  "color": undefined,
+                }
+              }
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button legacy Buttons 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-7 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f1defa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  border-color: #663399;
+  color: #663399;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-4[disabled],
+.emotion-4[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-4 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-4 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-4 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-4:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-4:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #2ca72c;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #2ca72c;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-3[disabled],
+.emotion-3[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-3 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-3 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-3 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-3:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-3:hover {
+  background: #1d9520;
+  border: 1px solid #1d9520;
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #da0013;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #da0013;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-5[disabled],
+.emotion-5[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-5 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-5 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-5 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-5:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-5:hover {
+  background: #ce0009;
+  border: 1px solid #ce0009;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f0f0f2;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #78757a;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-2 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  border-color: #78757a;
+  color: #78757a;
+}
+
+.emotion-6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #ffbab8;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #da0013;
+}
+
+.emotion-6[disabled],
+.emotion-6[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-6 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-6 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-6 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-6:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-6:hover {
+  border-color: #da0013;
+  color: #da0013;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-8"
+      >
+        <div
+          className="emotion-7"
+        >
+          <button
+            className="emotion-0"
+            disabled={false}
+            type="button"
+          >
+            <span>
+              PrimaryButton
+            </span>
+          </button>
+          <button
+            className="emotion-1"
+            disabled={false}
+            type="button"
+          >
+            <span>
+              SecondaryButton
+            </span>
+          </button>
+          <button
+            className="emotion-2"
+            disabled={false}
+            type="button"
+          >
+            <span>
+              CancelButton
+            </span>
+          </button>
+          <button
+            className="emotion-3"
+            disabled={false}
+            type="button"
+          >
+            <span>
+              SuccessButton
+            </span>
+          </button>
+          <button
+            className="emotion-4"
+            disabled={false}
+            type="button"
+          >
+            <span>
+              TextButton
+            </span>
+          </button>
+          <button
+            className="emotion-5"
+            disabled={false}
+            type="button"
+          >
+            <span>
+              PrimaryDeleteButton
+            </span>
+          </button>
+          <button
+            className="emotion-6"
+            disabled={false}
+            type="button"
+          >
+            <span>
+              SecondaryDeleteButton
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button manually applied styles 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-1 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-2"
+      >
+        <div
+          className="emotion-1"
+        >
+          <button
+            className="emotion-0"
+          >
+            I'm a &lt;button&gt; but I look like the &lt;Button&gt;
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button override/extend styles 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-1 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+  color: #663399;
+  background: #fec21e;
+  border-color: #fec21e;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-0:hover:not([disabled]) {
+  color: #ffffff;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-2"
+      >
+        <div
+          className="emotion-1"
+        >
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button with custom style
+            </span>
+             
+            <svg
+              className={undefined}
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              strokeWidth="0"
+              style={
+                Object {
+                  "color": undefined,
+                }
+              }
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button sizes 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.5rem;
+  min-height: 3.25rem;
+  padding: 0.65rem 1.25rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  min-height: 2rem;
+  padding: 0.45rem 0.75rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-2 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 0.875rem;
+  min-height: 1.6rem;
+  padding: 0.3rem 0.5rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-3[disabled],
+.emotion-3[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-3 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-3 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-3 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-3:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-3:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-5"
+      >
+        <div
+          className="emotion-4"
+        >
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button size 'XL'
+            </span>
+          </button>
+          <button
+            className="emotion-1"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button size 'L'
+            </span>
+          </button>
+          <button
+            className="emotion-2"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button size 'M'
+            </span>
+          </button>
+          <button
+            className="emotion-3"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button size 'S'
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button tones 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #2ca72c;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #2ca72c;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #1d9520;
+  border: 1px solid #1d9520;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #da0013;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #da0013;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-2 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #ce0009;
+  border: 1px solid #ce0009;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #78757a;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #78757a;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-3[disabled],
+.emotion-3[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-3 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-3 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-3 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-3:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-3:hover {
+  background: #635e69;
+  border: 1px solid #635e69;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-5"
+      >
+        <div
+          className="emotion-4"
+        >
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button tone 'BRAND'
+            </span>
+          </button>
+          <button
+            className="emotion-1"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button tone 'SUCCESS'
+            </span>
+          </button>
+          <button
+            className="emotion-2"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button tone 'DANGER'
+            </span>
+          </button>
+          <button
+            className="emotion-3"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button tone 'NEUTRAL'
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button variants 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-3 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f1defa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  border-color: #663399;
+  color: #663399;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-2 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-4"
+      >
+        <div
+          className="emotion-3"
+        >
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button variant 'PRIMARY'
+            </span>
+          </button>
+          <button
+            className="emotion-1"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button variant 'SECONDARY'
+            </span>
+          </button>
+          <button
+            className="emotion-2"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button variant 'GHOST'
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button with icons 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-3 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-4"
+      >
+        <div
+          className="emotion-3"
+        >
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              On the right
+            </span>
+            <svg
+              className={undefined}
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              strokeWidth="0"
+              style={
+                Object {
+                  "color": undefined,
+                }
+              }
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+              />
+            </svg>
+          </button>
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              className={undefined}
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              strokeWidth="0"
+              style={
+                Object {
+                  "color": undefined,
+                }
+              }
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+              />
+            </svg>
+            <span>
+               On the left
+            </span>
+          </button>
+          <button
+            className="emotion-0"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              With default icon
+            </span>
+             
+            <svg
+              className={undefined}
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              strokeWidth="0"
+              style={
+                Object {
+                  "color": undefined,
+                }
+              }
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Heading redered 'as' 1`] = `
+.emotion-8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-7 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eee;
+  color: green;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: .9rem;
+  font-weight: normal;
+  margin-left: 2em;
+  padding: .3em .6em;
+  vertical-align: text-bottom;
+}
+
+.emotion-1 svg {
+  margin-right: 0.2em;
+}
+
+.emotion-0 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-8"
+      >
+        <div
+          className="emotion-7"
+        >
+          <h1
+            className="emotion-0"
+          >
+            Heading rendered as &lt;h1&gt; tag
+          </h1>
+          <h2
+            className="emotion-0"
+          >
+            Heading rendered as &lt;h2&gt; tag 
+            <div
+              className="emotion-1"
+            >
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                />
+              </svg>
+               default
+            </div>
+          </h2>
+          <h3
+            className="emotion-0"
+          >
+            Heading rendered as &lt;h3&gt; tag
+          </h3>
+          <h4
+            className="emotion-0"
+          >
+            Heading rendered as &lt;h4&gt; tag
+          </h4>
+          <h5
+            className="emotion-0"
+          >
+            Heading rendered as &lt;h5&gt; tag
+          </h5>
+          <span
+            className="emotion-0"
+          >
+            Heading rendered as &lt;span&gt; tag
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Heading tones 1`] = `
+.emotion-6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-5 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eee;
+  color: green;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: .9rem;
+  font-weight: normal;
+  margin-left: 2em;
+  padding: .3em .6em;
+  vertical-align: text-bottom;
+}
+
+.emotion-0 svg {
+  margin-right: 0.2em;
+}
+
+.emotion-1 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+}
+
+.emotion-2 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #362066;
+  line-height: 1.125;
+  font-weight: bold;
+}
+
+.emotion-3 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #b80000;
+  line-height: 1.125;
+  font-weight: bold;
+}
+
+.emotion-4 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #006500;
+  line-height: 1.125;
+  font-weight: bold;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-6"
+      >
+        <div
+          className="emotion-5"
+        >
+          <h2
+            className="emotion-1"
+          >
+            Heading tone - NEUTRAL 
+            <div
+              className="emotion-0"
+            >
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                />
+              </svg>
+               default
+            </div>
+          </h2>
+          <h2
+            className="emotion-2"
+          >
+            Heading tone - BRAND
+          </h2>
+          <h2
+            className="emotion-3"
+          >
+            Heading tone - DANGER
+          </h2>
+          <h2
+            className="emotion-4"
+          >
+            Heading tone - SUCCESS
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Heading variants 1`] = `
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eee;
+  color: green;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: .9rem;
+  font-weight: normal;
+  margin-left: 2em;
+  padding: .3em .6em;
+  vertical-align: text-bottom;
+}
+
+.emotion-0 svg {
+  margin-right: 0.2em;
+}
+
+.emotion-1 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+}
+
+.emotion-2 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: 800;
+}
+
+.emotion-3 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #78757a;
+  line-height: 1.125;
+  font-weight: 100;
+  text-transform: uppercase;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-5"
+      >
+        <div
+          className="emotion-4"
+        >
+          <h2
+            className="emotion-1"
+          >
+            Heading variant - PRIMARY 
+            <div
+              className="emotion-0"
+            >
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                />
+              </svg>
+               default
+            </div>
+          </h2>
+          <h2
+            className="emotion-2"
+          >
+            Heading variant - EMPHASIZED
+          </h2>
+          <h2
+            className="emotion-3"
+          >
+            Heading variant - LIGHT
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/IntegrationRow default usage 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #663399;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-7:focus,
+.emotion-7:hover {
+  color: #663399;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-15 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-16 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #ffffff;
+  border-top: 1px solid #f0f0f2;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: auto auto 1fr;
+  width: 100%;
+  padding: 1rem 2.5rem;
+}
+
+.emotion-2:last-of-type {
+  margin-bottom: 0;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+}
+
+.emotion-0 img,
+.emotion-0 svg {
+  height: 24px;
+  width: auto;
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+  grid-column: 3 / 4;
+  grid-row: 1 / 2;
+  justify-self: end;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+.emotion-14 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #ffffff;
+  border-top: 1px solid #f0f0f2;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: auto auto 1fr;
+  width: 100%;
+  padding: 2rem 2.5rem 2.5rem;
+}
+
+.emotion-14:last-of-type {
+  margin-bottom: 0;
+}
+
+.emotion-3 {
+  border-radius: 4px;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-weight: bold;
+  line-height: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #f7fdf7;
+  color: #37b635;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 1rem;
+  padding: 0.5rem 0.75rem;
+  grid-column: 2 / 3;
+  grid-row: 1 / 2;
+}
+
+.emotion-3 svg:last-child {
+  margin-left: 0.25rem;
+}
+
+.emotion-13 {
+  grid-column: 1 / 4;
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+}
+
+.emotion-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  font-size: 0.875rem;
+  grid-template-columns: 0;
+  margin-top: inherit;
+}
+
+.emotion-9:first-of-type {
+  margin-top: inherit;
+}
+
+.emotion-6 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #78757a;
+  line-height: 1.125;
+  font-weight: 100;
+  text-transform: uppercase;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  text-transform: uppercase;
+}
+
+.emotion-8 {
+  margin-top: 0.25rem;
   color: #232129;
 }
 
 <div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
+  className="storybook-readme-story"
 >
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        CancelButton
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
+  <div
+    style={Object {}}
+  >
+    <div>
       <div
-        style={undefined}
+        className="emotion-16"
       >
         <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
+          className="emotion-15"
+          width="35em"
         >
           <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
+            className="emotion-2"
           >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
+            <span
+              className="emotion-0"
             >
-              Button
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
+              <img
+                alt=""
+                src="test-file-stub"
+              />
+            </span>
+            <button
+              className="emotion-1"
+              disabled={false}
+              type="button"
             >
-              CancelButton
-            </h2>
+              <span>
+                Connect
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </button>
           </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
+          <div
+            className="emotion-14"
+          >
+            <span
+              className="emotion-3"
             >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
+              Connected 
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
                 }
-              }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7 2v11h3v9l7-12h-4l4-8z"
+                />
+              </svg>
+            </span>
+            <span
+              className="emotion-0"
             >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
+              <img
+                alt=""
+                src="test-file-stub"
+              />
+            </span>
+            <button
+              className="emotion-1"
+              disabled={false}
+              type="button"
+            >
+              <span>
+                Edit
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+            </button>
+            <div
+              className="emotion-13"
+            >
+              <div
+                className="emotion-9"
+              >
+                <span
+                  className="emotion-6"
+                >
+                  space name
+                </span>
+                <span
+                  className="emotion-8"
+                >
+                  <a
+                    className="emotion-7"
+                    href="https://gatsbyjs.com"
+                    rel=""
+                    target={undefined}
                   >
-                    <span
+                    gatsby-provisioned-blog-fba42
+                    <svg
+                      className={undefined}
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      strokeWidth="0"
                       style={
                         Object {
-                          "color": "#444",
+                          "color": undefined,
                         }
                       }
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      &lt;
-                      CancelButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      CancelButton
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      CancelButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
+                      <path
+                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                      />
+                    </svg>
+                  </a>
+                </span>
               </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
+              <div
+                className="emotion-9"
               >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                CancelButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
+                <span
+                  className="emotion-6"
+                >
+                  space id
+                </span>
+                <span
+                  className="emotion-8"
+                >
+                  vkdbses99qqt
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -2339,8189 +6226,14075 @@ exports[`Storyshots Button CancelButton 1`] = `
 </div>
 `;
 
-exports[`Storyshots Button PrimaryButton 1`] = `
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #663399;
-  border: 0;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  background: #542C85;
-}
-
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
+exports[`Storyshots core/IntegrationRow shortcut usage 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
   }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        PrimaryButton
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              PrimaryButton
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      PrimaryButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      PrimaryButton
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      PrimaryButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                PrimaryButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
 
-exports[`Storyshots Button PrimaryDeleteButton 1`] = `
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #EC1818;
-  border: 1px solid #EC1818;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  background: #DA0013;
-  border-color: #B80000;
-}
-
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
   }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        PrimaryDeleteButton
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              PrimaryDeleteButton
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      PrimaryDeleteButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      PrimaryDeleteButton
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      PrimaryDeleteButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                PrimaryDeleteButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
+}
 
-exports[`Storyshots Button SecondaryButton 1`] = `
-.emotion-0 {
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #ffffff;
-  border: 1px solid #F1DEFA;
-  color: #8a4baf;
-}
-
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover:not([disabled]) {
-  border: 1px solid #663399;
   color: #663399;
-}
-
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        SecondaryButton
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              SecondaryButton
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      SecondaryButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      SecondaryButton
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      SecondaryButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                SecondaryButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Button SecondaryDeleteButton 1`] = `
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #ffffff;
-  border: 1px solid #FFBAB8;
-  color: #FA2915;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  border-color: #EC1818;
-  color: #EC1818;
-}
-
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        SecondaryDeleteButton
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              SecondaryDeleteButton
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      SecondaryDeleteButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      SecondaryDeleteButton
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      SecondaryDeleteButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                SecondaryDeleteButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Button SuccessButton 1`] = `
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #2CA72C;
-  border: 1px solid #2CA72C;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  background: #1D9520;
-  border-color: #006500;
-}
-
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        SuccessButton
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              SuccessButton
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      SuccessButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      SuccessButton
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      SuccessButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                SuccessButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Button TextButton 1`] = `
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #ffffff;
-  border: 1px solid #ffffff;
-  color: #8a4baf;
-}
-
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
+.emotion-6:focus,
+.emotion-6:hover {
   color: #663399;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        TextButton
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              TextButton
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      TextButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      TextButton
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      TextButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                TextButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
+.emotion-18 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
 
-exports[`Storyshots Button/in use Button as a Gatsby Link 1`] = `
-.emotion-0 {
+.emotion-19 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #663399;
-  border: 0;
-  color: #ffffff;
-  font-weight: bold;
+  width: 100%;
+  padding: 20px;
 }
 
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  background: #542C85;
-}
-
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <a
-        className="emotion-0 emotion-1"
-        href="/"
-        onClick={[Function]}
-        size="L"
-      >
-        Button as &lt;Link&gt;
-      </a>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button/in use
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              Button as a Gatsby Link
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      PrimaryButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          to
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            "
-                            <span
-                              style={
-                                Object {
-                                  "color": "#22a",
-                                  "wordBreak": "break-word",
-                                }
-                              }
-                            >
-                              /
-                            </span>
-                            "
-                          </span>
-                        </span>
-                      </span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      Button as &lt;Link&gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      PrimaryButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                PrimaryButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Button/in use Button as an external link 1`] = `
-.emotion-0 {
+.emotion-2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #663399;
-  border: 0;
-  color: #ffffff;
-  font-weight: bold;
+  background: #ffffff;
+  border-top: 1px solid #f0f0f2;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: auto auto 1fr;
+  width: 100%;
+  padding: 1rem 2.5rem;
 }
 
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
+.emotion-2:last-of-type {
+  margin-bottom: 0;
 }
 
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  background: #542C85;
-}
-
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <a
-        className="emotion-0 emotion-1"
-        href="https://gatsbyjs.com"
-        onClick={[Function]}
-        size="L"
-      >
-        Button as &lt;a&gt; tag
-      </a>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button/in use
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              Button as an external link
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      PrimaryButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          href
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            "
-                            <span
-                              style={
-                                Object {
-                                  "color": "#22a",
-                                  "wordBreak": "break-word",
-                                }
-                              }
-                            >
-                              https://gatsbyjs.com
-                            </span>
-                            "
-                          </span>
-                        </span>
-                      </span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      Button as &lt;a&gt; tag
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      PrimaryButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                PrimaryButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Button/in use Button in loading state 1`] = `
 .emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #663399;
-  border: 0;
-  color: #ffffff;
-  font-weight: bold;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
 }
 
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
+.emotion-0 img,
 .emotion-0 svg {
-  -webkit-animation: animation-ptf7ag 1s linear infinite;
-  animation: animation-ptf7ag 1s linear infinite;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  background: #542C85;
-}
-
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        Loading
-         
-        <svg
-          className={undefined}
-          fill="currentColor"
-          height="1em"
-          stroke="currentColor"
-          strokeWidth="0"
-          style={
-            Object {
-              "color": undefined,
-            }
-          }
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-          />
-        </svg>
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button/in use
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              Button in loading state
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      PrimaryButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                      </span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          loading
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      Button
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      PrimaryButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                PrimaryButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Button/in use Button with icon 1`] = `
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: #635E69;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 1.125rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1;
-  min-height: 2.25rem;
-  padding: 0.55rem 1rem;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: 0.5s;
-  transition: 0.5s;
-  background: #663399;
-  border: 0;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-transform: translateX(0.2em) scale(1);
-  -ms-transform: translateX(0.2em) scale(1);
-  transform: translateX(0.2em) scale(1);
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-1hbxf4 1s linear infinite;
-  animation: animation-1hbxf4 1s linear infinite;
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  background: #542C85;
-}
-
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
->
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
-      <button
-        className="emotion-0 emotion-1"
-        disabled={false}
-        onClick={[Function]}
-        size="L"
-      >
-        ButtonWithIcon 
-        <svg
-          className={undefined}
-          fill="currentColor"
-          height="1em"
-          stroke="currentColor"
-          strokeWidth="0"
-          style={
-            Object {
-              "color": undefined,
-            }
-          }
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-          />
-        </svg>
-      </button>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
-      >
-        <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
-          >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
-            >
-              Button/in use
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
-            >
-              Button with icon
-            </h2>
-          </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
-            >
-              <div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      PrimaryButton
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          onClick
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            {
-                            <span
-                              style={
-                                Object {
-                                  "color": "#170",
-                                }
-                              }
-                            >
-                              action
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      ButtonWithIcon 
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      MdArrowForward
-                    </span>
-                    <span />
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      /&gt;
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      PrimaryButton
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
-              >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                MdArrowForward
-                " Component
-              </h3>
-              <small>
-                No propTypes defined!
-              </small>
-            </div>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
-                  }
-                }
-              >
-                "
-                PrimaryButton
-                " Component
-              </h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      property
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      propType
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      required
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      default
-                    </th>
-                    <th
-                      style={
-                        Object {
-                          "textAlign": "left",
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      disabled
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loading
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        bool
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        false
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      loadingLabel
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        Loading
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      href
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      size
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span
-                        style={undefined}
-                      >
-                        L
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                  <tr>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      to
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      <span>
-                        string
-                      </span>
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    >
-                      -
-                    </td>
-                    <td
-                      style={
-                        Object {
-                          "paddingRight": 10,
-                          "verticalAlign": "top",
-                        }
-                      }
-                    />
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Welcome to Gatsby Inteface 1`] = `
-.emotion-0 {
-  font-family: sans-serif;
-  padding: 2rem;
-}
-
-.emotion-0 h1 {
-  font-size: 2rem;
+  height: 24px;
+  width: auto;
   margin: 0;
 }
 
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+  grid-column: 3 / 4;
+  grid-row: 1 / 2;
+  justify-self: end;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+.emotion-14 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #ffffff;
+  border-top: 1px solid #f0f0f2;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: auto auto 1fr;
+  width: 100%;
+  padding: 2rem 2.5rem 2.5rem;
+}
+
+.emotion-14:last-of-type {
+  margin-bottom: 0;
+}
+
+.emotion-13 {
+  border-radius: 4px;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-weight: bold;
+  line-height: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #f7fdf7;
+  color: #37b635;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 1rem;
+  padding: 0.5rem 0.75rem;
+  grid-column: 2 / 3;
+  grid-row: 1 / 2;
+}
+
+.emotion-13 svg:last-child {
+  margin-left: 0.25rem;
+}
+
+.emotion-12 {
+  grid-column: 1 / 4;
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  font-size: 0.875rem;
+  grid-template-columns: 0;
+  margin-top: inherit;
+}
+
+.emotion-8:first-of-type {
+  margin-top: inherit;
+}
+
+.emotion-5 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #78757a;
+  line-height: 1.125;
+  font-weight: 100;
+  text-transform: uppercase;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  text-transform: uppercase;
+}
+
+.emotion-7 {
+  margin-top: 0.25rem;
+  color: #232129;
+}
+
 <div
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "justifyContent": "center",
-      "margin": "30px 0",
-      "minHeight": "68vh",
-      "padding": "10vh 20vh",
-    }
-  }
+  className="storybook-readme-story"
 >
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 0,
-        }
-      }
-    >
+  <div
+    style={Object {}}
+  >
+    <div>
       <div
-        className="emotion-0 emotion-1"
-      >
-        <h1>
-          Welcome to Gatsby Interface
-        </h1>
-        <p>
-          Shared User Interface components for use with Gatsby Cloud
-        </p>
-      </div>
-    </div>
-    <button
-      className="info__show-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#027ac5",
-          "border": "none",
-          "borderRadius": "0 0 0 5px",
-          "color": "#fff",
-          "cursor": "pointer",
-          "display": "block",
-          "fontFamily": "sans-serif",
-          "fontSize": "12px",
-          "padding": "5px 15px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      type="button"
-    >
-      Show Info
-    </button>
-    <div
-      className="info__overlay"
-      style={
-        Object {
-          "background": "white",
-          "bottom": 0,
-          "display": "none",
-          "left": 0,
-          "overflow": "auto",
-          "padding": "0 40px",
-          "position": "fixed",
-          "right": 0,
-          "top": 0,
-          "zIndex": 99999,
-        }
-      }
-    >
-      <button
-        className="info__close-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        ×
-      </button>
-      <div
-        style={undefined}
+        className="emotion-19"
       >
         <div
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "border": "1px solid #eee",
-              "borderRadius": "2px",
-              "color": "black",
-              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 300,
-              "lineHeight": 1.45,
-              "marginBottom": "20px",
-              "marginTop": "20px",
-              "padding": "20px 40px 40px",
-            }
-          }
+          className="emotion-18"
+          width="35em"
         >
           <div
-            style={
-              Object {
-                "borderBottom": "1px solid #eee",
-                "marginBottom": 10,
-                "paddingTop": 10,
-              }
-            }
+            className="emotion-2"
           >
-            <h1
-              style={
-                Object {
-                  "fontSize": "35px",
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
+            <span
+              className="emotion-0"
             >
-              Welcome
-            </h1>
-            <h2
-              style={
-                Object {
-                  "fontSize": "22px",
-                  "fontWeight": 400,
-                  "margin": "0 0 10px 0",
-                  "padding": 0,
-                }
-              }
+              <img
+                alt="Netlify"
+                src="test-file-stub"
+              />
+            </span>
+            <button
+              className="emotion-1"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
             >
-              to Gatsby Inteface
-            </h2>
+              <span>
+                Connect
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </button>
           </div>
-          
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
+          <div
+            className="emotion-14"
+          >
+            <span
+              className="emotion-0"
             >
-              Story Source
-            </h1>
-            <pre
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "#fafafa",
-                  "display": "flex",
-                  "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
-                  "fontSize": ".88em",
-                  "justifyContent": "space-between",
-                  "lineHeight": 1.5,
-                  "overflowX": "scroll",
-                  "padding": ".5rem",
-                }
-              }
+              <img
+                alt="Netlify"
+                src="test-file-stub"
+              />
+            </span>
+            <button
+              className="emotion-1"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
             >
-              <div>
+              <span>
+                Edit
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+            </button>
+            <div
+              className="emotion-12"
+            >
+              <div
+                className="emotion-8"
+              >
+                <span
+                  className="emotion-5"
+                >
+                  site
+                </span>
+                <span
+                  className="emotion-7"
+                >
+                  <a
+                    className="emotion-6"
+                    href="https://gatsbyjs.com"
+                    rel=""
+                    target={undefined}
+                  >
+                    hello-world-01
+                    <svg
+                      className={undefined}
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      strokeWidth="0"
+                      style={
+                        Object {
+                          "color": undefined,
+                        }
+                      }
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                      />
+                    </svg>
+                  </a>
+                </span>
+              </div>
+              <div
+                className="emotion-8"
+              >
+                <span
+                  className="emotion-5"
+                >
+                  team
+                </span>
+                <span
+                  className="emotion-7"
+                >
+                  shannonb_ux
+                </span>
+              </div>
+            </div>
+            <span
+              className="emotion-13"
+            >
+              Connected 
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7 2v11h3v9l7-12h-4l4-8z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <span
+              className="emotion-0"
+            >
+              <img
+                alt="Netlify"
+                src="test-file-stub"
+              />
+            </span>
+            <a
+              className="emotion-1"
+              href="/"
+              rel=" noopener noreferrer"
+              role="button"
+              target="_blank"
+            >
+              <span>
+                Setup instructions
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/IntegrationRow with inline SVG as logo 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-3 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #ffffff;
+  border-top: 1px solid #f0f0f2;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: auto auto 1fr;
+  width: 100%;
+  padding: 1rem 2.5rem;
+}
+
+.emotion-2:last-of-type {
+  margin-bottom: 0;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+}
+
+.emotion-0 img,
+.emotion-0 svg {
+  height: 24px;
+  width: auto;
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+  grid-column: 3 / 4;
+  grid-row: 1 / 2;
+  justify-self: end;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-4"
+      >
+        <div
+          className="emotion-3"
+          width="35em"
+        >
+          <div
+            className="emotion-2"
+          >
+            <span
+              className="emotion-0"
+            >
+              <svg
+                fill="none"
+                height={28}
+                viewBox="0 0 147 40"
+                width={102}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <radialGradient
+                  cy="0%"
+                  gradientTransform="matrix(0 .9989 -1.152 0 .5 -.5)"
+                  id="a"
+                  r="100.11%"
+                >
+                  <stop
+                    offset="0"
+                    stopColor="#20c6b7"
+                  />
+                  <stop
+                    offset="1"
+                    stopColor="#4d9abf"
+                  />
+                </radialGradient>
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                >
+                  <path
+                    d="m53.37 12.978.123 2.198c1.403-1.7 3.245-2.55 5.525-2.55 3.951 0 5.962 2.268 6.032 6.804v12.568h-4.26v-12.322c0-1.207-.26-2.1-.78-2.681-.52-.58-1.371-.87-2.552-.87-1.719 0-3 .78-3.84 2.338v13.535h-4.262v-19.02h4.016zm24.378 19.372c-2.7 0-4.89-.852-6.567-2.557-1.678-1.705-2.517-3.976-2.517-6.812v-.527c0-1.898.365-3.595 1.096-5.089.73-1.494 1.757-2.657 3.078-3.49 1.321-.831 2.794-1.247 4.42-1.247 2.583 0 4.58.826 5.988 2.478 1.41 1.653 2.114 3.99 2.114 7.014v1.723h-12.4c.13 1.57.652 2.812 1.57 3.726s2.073 1.371 3.464 1.371c1.952 0 3.542-.79 4.77-2.373l2.297 2.198c-.76 1.136-1.774 2.018-3.042 2.645-1.269.627-2.692.94-4.27.94zm-.508-16.294c-1.17 0-2.113.41-2.832 1.23-.72.82-1.178 1.963-1.377 3.428h8.12v-.317c-.094-1.43-.474-2.51-1.14-3.243-.667-.732-1.59-1.098-2.771-1.098zm16.765-7.7v4.623h3.35v3.164h-3.35v10.617c0 .726.144 1.25.43 1.573.286.322.798.483 1.535.483a6.55 6.55 0 0 0 1.49-.176v3.305c-.97.27-1.905.404-2.806.404-3.273 0-4.91-1.81-4.91-5.431v-10.776h-3.124v-3.164h3.122v-4.623h4.261zm11.137 23.643h-4.262v-27h4.262zm9.172 0h-4.262v-19.02h4.262zm-4.525-23.96c0-.655.207-1.2.622-1.634.416-.433 1.009-.65 1.78-.65.772 0 1.368.217 1.79.65.42.434.63.979.63 1.635 0 .644-.21 1.18-.63 1.608-.422.428-1.018.642-1.79.642-.771 0-1.364-.214-1.78-.642-.415-.427-.622-.964-.622-1.608zm10.663 23.96v-15.857h-2.894v-3.164h2.894v-1.74c0-2.11.584-3.738 1.753-4.887 1.17-1.148 2.806-1.722 4.91-1.722.749 0 1.544.105 2.386.316l-.105 3.34a8.375 8.375 0 0 0 -1.631-.14c-2.035 0-3.052 1.048-3.052 3.146v1.687h3.858v3.164h-3.858v15.856h-4.261zm17.87-6.117 3.858-12.903h4.542l-7.54 21.903c-1.158 3.199-3.122 4.799-5.893 4.799-.62 0-1.304-.106-2.052-.317v-3.305l.807.053c1.075 0 1.885-.196 2.429-.589.543-.392.973-1.051 1.289-1.977l.613-1.635-6.664-18.932h4.595z"
+                    fill="#0e1e25"
+                  />
+                  <path
+                    d="m28.589 14.135-.014-.006c-.008-.003-.016-.006-.023-.013a.11.11 0 0 1 -.028-.093l.773-4.726 3.625 3.626-3.77 1.604a.083.083 0 0 1 -.033.006h-.015c-.005-.003-.01-.007-.02-.017a1.716 1.716 0 0 0 -.495-.381zm5.258-.288 3.876 3.876c.805.806 1.208 1.208 1.355 1.674.022.069.04.138.054.209l-9.263-3.923a.728.728 0 0 0 -.015-.006c-.037-.015-.08-.032-.08-.07s.044-.056.081-.071l.012-.005zm5.127 7.003c-.2.376-.59.766-1.25 1.427l-4.37 4.369-5.652-1.177-.03-.006c-.05-.008-.103-.017-.103-.062a1.706 1.706 0 0 0 -.655-1.193c-.023-.023-.017-.059-.01-.092 0-.005 0-.01.002-.014l1.063-6.526.004-.022c.006-.05.015-.108.06-.108a1.73 1.73 0 0 0 1.16-.665c.009-.01.015-.021.027-.027.032-.015.07 0 .103.014l9.65 4.082zm-6.625 6.801-7.186 7.186 1.23-7.56.002-.01c.001-.01.003-.02.006-.029.01-.024.036-.034.061-.044l.012-.005a1.85 1.85 0 0 0 .695-.517c.024-.028.053-.055.09-.06a.09.09 0 0 1 .029 0l5.06 1.04zm-8.707 8.707-.81.81-8.955-12.942a.424.424 0 0 0 -.01-.014c-.014-.019-.029-.038-.026-.06 0-.016.011-.03.022-.042l.01-.013c.027-.04.05-.08.075-.123l.02-.035.003-.003c.014-.024.027-.047.051-.06.021-.01.05-.006.073-.001l9.921 2.046a.164.164 0 0 1 .076.033c.013.013.016.027.019.043a1.757 1.757 0 0 0 1.028 1.175c.028.014.016.045.003.078a.238.238 0 0 0 -.015.045c-.125.76-1.197 7.298-1.485 9.063zm-1.692 1.691c-.597.591-.949.904-1.347 1.03a2 2 0 0 1 -1.206 0c-.466-.148-.869-.55-1.674-1.356l-8.993-8.993 2.349-3.643c.011-.018.022-.034.04-.047.025-.018.061-.01.091 0a2.434 2.434 0 0 0 1.638-.083c.027-.01.054-.017.075.002a.19.19 0 0 1 .028.032l8.999 13.059zm-14.087-10.186-2.063-2.063 4.074-1.738a.084.084 0 0 1 .033-.007c.034 0 .054.034.072.065a2.91 2.91 0 0 0 .13.184l.013.016c.012.017.004.034-.008.05l-2.25 3.493zm-2.976-2.976-2.61-2.61c-.444-.444-.766-.766-.99-1.043l7.936 1.646a.84.84 0 0 0 .03.005c.049.008.103.017.103.063 0 .05-.059.073-.109.092l-.023.01zm-4.056-4.995a2 2 0 0 1 .09-.495c.148-.466.55-.868 1.356-1.674l3.34-3.34a2175.525 2175.525 0 0 0 4.626 6.687c.027.036.057.076.026.106-.146.161-.292.337-.395.528a.16.16 0 0 1 -.05.062c-.013.008-.027.005-.042.002h-.002l-8.949-1.877zm5.68-6.403 4.489-4.491c.423.185 1.96.834 3.333 1.414 1.04.44 1.988.84 2.286.97.03.012.057.024.07.054.008.018.004.041 0 .06a2.003 2.003 0 0 0 .523 1.828c.03.03 0 .073-.026.11l-.014.021-4.56 7.063c-.012.02-.023.037-.043.05-.024.015-.058.008-.086.001a2.274 2.274 0 0 0 -.543-.074c-.164 0-.342.03-.522.063h-.001c-.02.003-.038.007-.054-.005a.21.21 0 0 1 -.045-.051l-4.808-7.013zm5.398-5.398 5.814-5.814c.805-.805 1.208-1.208 1.674-1.355a2 2 0 0 1 1.206 0c.466.147.869.55 1.674 1.355l1.26 1.26-4.135 6.404a.155.155 0 0 1 -.041.048c-.025.017-.06.01-.09 0a2.097 2.097 0 0 0 -1.92.37c-.027.028-.067.012-.101-.003-.54-.235-4.74-2.01-5.341-2.265zm12.506-3.676 3.818 3.818-.92 5.698v.015a.135.135 0 0 1 -.008.038c-.01.02-.03.024-.05.03a1.83 1.83 0 0 0 -.548.273.154.154 0 0 0 -.02.017c-.011.012-.022.023-.04.025a.114.114 0 0 1 -.043-.007l-5.818-2.472-.011-.005c-.037-.015-.081-.033-.081-.071a2.198 2.198 0 0 0 -.31-.915c-.028-.046-.059-.094-.035-.141zm-3.932 8.606 5.454 2.31c.03.014.063.027.076.058a.106.106 0 0 1 0 .057c-.016.08-.03.171-.03.263v.153c0 .038-.039.054-.075.069l-.011.004c-.864.369-12.13 5.173-12.147 5.173s-.035 0-.052-.017c-.03-.03 0-.072.027-.11a.76.76 0 0 0 .014-.02l4.482-6.94.008-.012c.026-.042.056-.089.104-.089l.045.007c.102.014.192.027.283.027.68 0 1.31-.331 1.69-.897a.16.16 0 0 1 .034-.04c.027-.02.067-.01.098.004zm-6.246 9.185 12.28-5.237s.018 0 .035.017c.067.067.124.112.179.154l.027.017c.025.014.05.03.052.056 0 .01 0 .016-.002.025l-1.052 6.462-.004.026c-.007.05-.014.107-.061.107a1.729 1.729 0 0 0 -1.373.847l-.005.008c-.014.023-.027.045-.05.057-.021.01-.048.006-.07.001l-9.793-2.02c-.01-.002-.152-.519-.163-.52z"
+                    fill="url(#a)"
+                    fillRule="nonzero"
+                    transform="translate(-.702)"
+                  />
+                </g>
+              </svg>
+            </span>
+            <button
+              className="emotion-1"
+              disabled={false}
+              type="button"
+            >
+              <span>
+                Connect
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-54 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-53 {
+  box-shadow: 0px 2px 4px rgba(46,41,51,0.08),0px 4px 8px rgba(71,63,79,0.16);
+  background-color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 8px;
+}
+
+.emotion-52 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  height: 100%;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 50px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-bottom: 0.5rem;
+  width: 50px;
+}
+
+.emotion-3 {
+  margin: 0;
+}
+
+.emotion-6 {
+  text-align: center;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #635e69;
+  line-height: 1.4;
+}
+
+.emotion-6 p {
+  margin: 0;
+}
+
+.emotion-10 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin-top: 1.5rem;
+  line-height: 1;
+}
+
+.emotion-7 {
+  color: #78757a;
+  font-size: 1rem;
+  display: inline-block;
+  -webkit-transform: translate(-.1rem,-.7rem);
+  -ms-transform: translate(-.1rem,-.7rem);
+  transform: translate(-.1rem,-.7rem);
+}
+
+.emotion-8 {
+  font-size: 2.25rem;
+}
+
+.emotion-9 {
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  color: #78757a;
+  font-size: 0.75rem;
+  display: inline-block;
+  -webkit-transform: translateX(.2rem);
+  -ms-transform: translateX(.2rem);
+  transform: translateX(.2rem);
+}
+
+.emotion-23 {
+  font-size: 0.875rem;
+  color: #78757a;
+  width: 100%;
+  margin-top: 1.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-22 {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: auto;
+}
+
+.emotion-13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0.5rem 0;
+  position: relative;
+  line-height: 1.3;
+}
+
+.emotion-11 {
+  width: 1.5em;
+  height: 1.5em;
+  fill: #d9d7e0;
+  margin-right: 0.5rem;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-transform: translateY(-.2em);
+  -ms-transform: translateY(-.2em);
+  transform: translateY(-.2em);
+}
+
+.emotion-12 {
+  position: relative;
+  outline: none;
+}
+
+.emotion-12 p {
+  display: inline;
+}
+
+.emotion-50 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  margin-top: 2.5rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-bottom: 4rem;
+}
+
+.emotion-55 {
+  width: 880px;
+  max-width: 94%;
+  margin: 0 auto;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  border-bottom: 1px solid #f0f0f2;
+}
+
+@media (min-width:750px) {
+  .emotion-2 {
+    display: none;
+  }
+}
+
+.emotion-0 {
+  background: transparent;
+  border: none;
+  color: #f67300;
+  cursor: pointer;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-size: 1rem;
+  padding: 1rem 0.75rem 0.75rem;
+  position: relative;
+}
+
+.emotion-0:after {
+  background: #f67300;
+  content: "";
+  display: block;
+  width: 100%;
+  height: 2px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.emotion-1 {
+  background: transparent;
+  border: none;
+  color: #48434f;
+  cursor: pointer;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-size: 1rem;
+  padding: 1rem 0.75rem 0.75rem;
+  position: relative;
+}
+
+.emotion-1:after {
+  background: #047bd3;
+  content: "";
+  display: none;
+  width: 100%;
+  height: 2px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.emotion-5 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  color: #f67300;
+  font-size: 1.25rem;
+}
+
+.emotion-17 {
+  position: relative;
+  margin-left: 0.5rem;
+}
+
+.emotion-16 {
+  background: transparent;
+  cursor: pointer;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 1.4em;
+  padding: 0;
+  vertical-align: text-bottom;
+  width: 1.4em;
+  border-radius: 50%;
+}
+
+.emotion-16:focus {
+  box-shadow: 0 0 0 3px #d9bae8;
+  outline: none;
+}
+
+.emotion-16 svg {
+  height: 100%;
+  color: #78757a;
+  width: 100%;
+}
+
+.emotion-30 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  color: #047bd3;
+  font-size: 1.25rem;
+}
+
+.emotion-27 {
+  padding: 1.5rem 1.5rem 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 100%;
+}
+
+.emotion-27:not(:first-child) {
+  border-left: 1px solid #f0f0f2;
+}
+
+@media (min-width:750px) {
+  .emotion-27 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-shrink: 1;
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+    -webkit-flex-basis: calc(100% / 2);
+    -ms-flex-preferred-size: calc(100% / 2);
+    flex-basis: calc(100% / 2);
+  }
+}
+
+.emotion-26 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-top: 2.5rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-bottom: 4rem;
+}
+
+.emotion-25 {
+  width: 3rem;
+  height: 3rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: #37b635;
+  border-radius: 50%;
+}
+
+.emotion-24 {
+  fill: #ffffff;
+  width: 70%;
+  height: 70%;
+}
+
+.emotion-51 {
+  padding: 1.5rem 1.5rem 0;
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 100%;
+}
+
+.emotion-51:not(:first-child) {
+  border-left: 1px solid #f0f0f2;
+}
+
+@media (min-width:750px) {
+  .emotion-51 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-shrink: 1;
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+    -webkit-flex-basis: calc(100% / 2);
+    -ms-flex-preferred-size: calc(100% / 2);
+    flex-basis: calc(100% / 2);
+  }
+}
+
+.emotion-49 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+  width: 100%;
+  background: #ffffff;
+  color: #047bd3;
+  border-color: #047bd3;
+}
+
+.emotion-49[disabled],
+.emotion-49[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-49 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-49 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-49 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-49:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-49:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-49:hover {
+  color: #ffffff;
+  background: #047bd3;
+  border-color: #047bd3;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-55"
+      >
+        <div
+          className="emotion-54"
+        >
+          <div
+            className="emotion-53"
+          >
+            <nav
+              className="emotion-2"
+            >
+              <button
+                className="emotion-0"
+                onClick={[Function]}
+              >
+                Free
+              </button>
+              <button
+                className="emotion-1"
+                onClick={[Function]}
+              >
+                Professional
+              </button>
+            </nav>
+            <div
+              className="emotion-52"
+            >
+              <div
+                className="emotion-27"
+              >
                 <div
-                  style={
+                  className="emotion-4"
+                >
+                  <img
+                    alt="Free"
+                    className="emotion-3"
+                    src="test-file-stub"
+                  />
+                </div>
+                <h2
+                  className="emotion-5"
+                >
+                  Free
+                </h2>
+                <div
+                  className="emotion-6"
+                  dangerouslySetInnerHTML={
                     Object {
-                      "paddingLeft": 18,
-                      "paddingRight": 3,
+                      "__html": "For personal projects and single-purpose sites",
                     }
                   }
+                />
+                <div
+                  className="emotion-10"
                 >
                   <span
-                    style={
-                      Object {
-                        "color": "#444",
-                      }
-                    }
+                    className="emotion-7"
                   >
-                    &lt;
-                    _default
+                    $
                   </span>
-                  <span />
-                  <span
-                    style={
-                      Object {
-                        "color": "#444",
-                      }
-                    }
+                  <strong
+                    className="emotion-8"
                   >
-                    /&gt;
+                    0
+                  </strong>
+                  <span
+                    className="emotion-9"
+                  >
+                    / month
                   </span>
                 </div>
+                <div
+                  className="emotion-23"
+                >
+                  <ul
+                    className="emotion-22"
+                  >
+                    <li
+                      className="emotion-13"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-11"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-12"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Builds and Preview",
+                          }
+                        }
+                      />
+                    </li>
+                    <li
+                      className="emotion-13"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-11"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-12"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "10 real-time edits/day",
+                          }
+                        }
+                      />
+                      <span
+                        className="emotion-17"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup="true"
+                          aria-label="more info"
+                          className="emotion-16"
+                          onClick={[Function]}
+                        >
+                          <svg
+                            className={undefined}
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                            />
+                          </svg>
+                        </button>
+                        <span
+                          css={null}
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": null,
+                            }
+                          }
+                          role="status"
+                        />
+                      </span>
+                    </li>
+                    <li
+                      className="emotion-13"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-11"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-12"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Online documentation",
+                          }
+                        }
+                      />
+                    </li>
+                  </ul>
+                </div>
+                <div
+                  className="emotion-26"
+                >
+                  <div
+                    className="emotion-25"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="emotion-24"
+                      data-testid="icon-check"
+                      fill="currentColor"
+                      fillRule="evenodd"
+                      height="24px"
+                      preserveAspectRatio="xMidYMid meet"
+                      stroke="none"
+                      strokeWidth="1"
+                      style={
+                        Object {
+                          "verticalAlign": "middle",
+                        }
+                      }
+                      viewBox="0 0 24 24"
+                      width="24px"
+                    >
+                      <path
+                        d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                      />
+                      <path
+                        d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                      />
+                      <path
+                        d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                      />
+                    </svg>
+                  </div>
+                </div>
               </div>
-              <button
-                onClick={[Function]}
-                style={
-                  Object {
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "rgb(255, 255, 255)",
-                    "borderColor": "rgb(238, 238, 238)",
-                    "borderImage": "initial",
-                    "borderRadius": "3px",
-                    "borderStyle": "solid",
-                    "borderWidth": "1px",
-                    "cursor": "pointer",
-                    "flexShrink": "0",
-                    "fontSize": "13px",
-                    "overflow": "hidden",
-                    "padding": "3px 10px",
-                  }
-                }
-                type="button"
+              <div
+                className="emotion-51"
               >
-                Copy
-              </button>
-            </pre>
-          </div>
-          <div>
-            <h1
-              style={
-                Object {
-                  "borderBottom": "1px solid #EEE",
-                  "fontSize": "25px",
-                  "margin": "20px 0 0 0",
-                  "padding": "0 0 5px 0",
-                }
-              }
-            >
-              Prop Types
-            </h1>
-            <div>
-              <h3
-                style={
-                  Object {
-                    "margin": "20px 0 0 0",
+                <div
+                  className="emotion-4"
+                >
+                  <img
+                    alt="Professional"
+                    className="emotion-3"
+                    src="test-file-stub"
+                  />
+                </div>
+                <h2
+                  className="emotion-30"
+                >
+                  Professional
+                </h2>
+                <div
+                  className="emotion-6"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "For personal projects and single-purpose sites",
+                    }
                   }
-                }
-              >
-                "
-                _default
-                " Component
-              </h3>
-              <small>
-                No propTypes defined!
-              </small>
+                />
+                <div
+                  className="emotion-10"
+                >
+                  <span
+                    className="emotion-7"
+                  >
+                    $
+                  </span>
+                  <strong
+                    className="emotion-8"
+                  >
+                    42
+                  </strong>
+                  <span
+                    className="emotion-9"
+                  >
+                    / month
+                  </span>
+                </div>
+                <div
+                  className="emotion-23"
+                >
+                  <ul
+                    className="emotion-22"
+                  >
+                    <li
+                      className="emotion-13"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-11"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-12"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Builds and Preview",
+                          }
+                        }
+                      />
+                    </li>
+                    <li
+                      className="emotion-13"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-11"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-12"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "100 real-time edits/day",
+                          }
+                        }
+                      />
+                      <span
+                        className="emotion-17"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup="true"
+                          aria-label="more info"
+                          className="emotion-16"
+                          onClick={[Function]}
+                        >
+                          <svg
+                            className={undefined}
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                            />
+                          </svg>
+                        </button>
+                        <span
+                          css={null}
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": null,
+                            }
+                          }
+                          role="status"
+                        />
+                      </span>
+                    </li>
+                    <li
+                      className="emotion-13"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-11"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-12"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Online documentation",
+                          }
+                        }
+                      />
+                    </li>
+                  </ul>
+                </div>
+                <div
+                  className="emotion-50"
+                >
+                  <a
+                    className="emotion-49"
+                    href="/"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span>
+                      Pick
+                    </span>
+                  </a>
+                </div>
+              </div>
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/PricingCard multiplan card 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-75 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-74 {
+  box-shadow: 0px 2px 4px rgba(46,41,51,0.08),0px 4px 8px rgba(71,63,79,0.16);
+  background-color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 8px;
+}
+
+.emotion-70 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  height: 100%;
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 50px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-bottom: 0.5rem;
+  width: 50px;
+}
+
+.emotion-4 {
+  margin: 0;
+}
+
+.emotion-7 {
+  text-align: center;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #635e69;
+  line-height: 1.4;
+}
+
+.emotion-7 p {
+  margin: 0;
+}
+
+.emotion-11 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin-top: 1.5rem;
+  line-height: 1;
+}
+
+.emotion-8 {
+  color: #78757a;
+  font-size: 1rem;
+  display: inline-block;
+  -webkit-transform: translate(-.1rem,-.7rem);
+  -ms-transform: translate(-.1rem,-.7rem);
+  transform: translate(-.1rem,-.7rem);
+}
+
+.emotion-9 {
+  font-size: 2.25rem;
+}
+
+.emotion-10 {
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  color: #78757a;
+  font-size: 0.75rem;
+  display: inline-block;
+  -webkit-transform: translateX(.2rem);
+  -ms-transform: translateX(.2rem);
+  transform: translateX(.2rem);
+}
+
+.emotion-24 {
+  font-size: 0.875rem;
+  color: #78757a;
+  width: 100%;
+  margin-top: 1.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-23 {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: auto;
+}
+
+.emotion-14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0.5rem 0;
+  position: relative;
+  line-height: 1.3;
+}
+
+.emotion-12 {
+  width: 1.5em;
+  height: 1.5em;
+  fill: #d9d7e0;
+  margin-right: 0.5rem;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-transform: translateY(-.2em);
+  -ms-transform: translateY(-.2em);
+  transform: translateY(-.2em);
+}
+
+.emotion-13 {
+  position: relative;
+  outline: none;
+}
+
+.emotion-13 p {
+  display: inline;
+}
+
+.emotion-76 {
+  width: 880px;
+  max-width: 94%;
+  margin: 0 auto;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  border-bottom: 1px solid #f0f0f2;
+}
+
+@media (min-width:750px) {
+  .emotion-3 {
+    display: none;
+  }
+}
+
+.emotion-0 {
+  background: transparent;
+  border: none;
+  color: #f67300;
+  cursor: pointer;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-size: 1rem;
+  padding: 1rem 0.75rem 0.75rem;
+  position: relative;
+}
+
+.emotion-0:after {
+  background: #f67300;
+  content: "";
+  display: block;
+  width: 100%;
+  height: 2px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.emotion-1 {
+  background: transparent;
+  border: none;
+  color: #48434f;
+  cursor: pointer;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-size: 1rem;
+  padding: 1rem 0.75rem 0.75rem;
+  position: relative;
+}
+
+.emotion-1:after {
+  background: #047bd3;
+  content: "";
+  display: none;
+  width: 100%;
+  height: 2px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.emotion-2 {
+  background: transparent;
+  border: none;
+  color: #48434f;
+  cursor: pointer;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-size: 1rem;
+  padding: 1rem 0.75rem 0.75rem;
+  position: relative;
+}
+
+.emotion-2:after {
+  background: #663399;
+  content: "";
+  display: none;
+  width: 100%;
+  height: 2px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.emotion-25 {
+  padding: 1.5rem 1.5rem 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 100%;
+}
+
+.emotion-25:not(:first-child) {
+  border-left: 1px solid #f0f0f2;
+}
+
+@media (min-width:750px) {
+  .emotion-25 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-shrink: 1;
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+    -webkit-flex-basis: calc(100% / 3);
+    -ms-flex-preferred-size: calc(100% / 3);
+    flex-basis: calc(100% / 3);
+  }
+}
+
+.emotion-6 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  color: #f67300;
+  font-size: 1.25rem;
+}
+
+.emotion-18 {
+  position: relative;
+  margin-left: 0.5rem;
+}
+
+.emotion-17 {
+  background: transparent;
+  cursor: pointer;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 1.4em;
+  padding: 0;
+  vertical-align: text-bottom;
+  width: 1.4em;
+  border-radius: 50%;
+}
+
+.emotion-17:focus {
+  box-shadow: 0 0 0 3px #d9bae8;
+  outline: none;
+}
+
+.emotion-17 svg {
+  height: 100%;
+  color: #78757a;
+  width: 100%;
+}
+
+.emotion-47 {
+  padding: 1.5rem 1.5rem 0;
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 100%;
+}
+
+.emotion-47:not(:first-child) {
+  border-left: 1px solid #f0f0f2;
+}
+
+@media (min-width:750px) {
+  .emotion-47 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-shrink: 1;
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+    -webkit-flex-basis: calc(100% / 3);
+    -ms-flex-preferred-size: calc(100% / 3);
+    flex-basis: calc(100% / 3);
+  }
+}
+
+.emotion-28 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  color: #047bd3;
+  font-size: 1.25rem;
+}
+
+.emotion-50 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  color: #663399;
+  font-size: 1.25rem;
+}
+
+.emotion-73 {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 2rem 1.5rem 1.5rem;
+}
+
+.emotion-71 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #2ca72c;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #2ca72c;
+  color: #ffffff;
+  font-weight: bold;
+  min-width: 45%;
+}
+
+.emotion-71[disabled],
+.emotion-71[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-71 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-71 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-71 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-71:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-71:hover {
+  background: #1d9520;
+  border: 1px solid #1d9520;
+}
+
+.emotion-72 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  color: #78757a;
+  font-size: 1rem;
+  margin: 0;
+  margin-top: 0.5rem;
+  text-align: center;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-76"
+      >
+        <div
+          className="emotion-75"
+        >
+          <div
+            className="emotion-74"
+          >
+            <nav
+              className="emotion-3"
+            >
+              <button
+                className="emotion-0"
+                onClick={[Function]}
+              >
+                Free
+              </button>
+              <button
+                className="emotion-1"
+                onClick={[Function]}
+              >
+                Professional
+              </button>
+              <button
+                className="emotion-2"
+                onClick={[Function]}
+              >
+                Bussines
+              </button>
+            </nav>
+            <div
+              className="emotion-70"
+            >
+              <div
+                className="emotion-25"
+              >
+                <div
+                  className="emotion-5"
+                >
+                  <img
+                    alt="Free"
+                    className="emotion-4"
+                    src="test-file-stub"
+                  />
+                </div>
+                <h2
+                  className="emotion-6"
+                >
+                  Free
+                </h2>
+                <div
+                  className="emotion-7"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "For personal projects and single-purpose sites",
+                    }
+                  }
+                />
+                <div
+                  className="emotion-11"
+                >
+                  <span
+                    className="emotion-8"
+                  >
+                    $
+                  </span>
+                  <strong
+                    className="emotion-9"
+                  >
+                    0
+                  </strong>
+                  <span
+                    className="emotion-10"
+                  >
+                    / month
+                  </span>
+                </div>
+                <div
+                  className="emotion-24"
+                >
+                  <ul
+                    className="emotion-23"
+                  >
+                    <li
+                      className="emotion-14"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-12"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-13"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Builds and Preview",
+                          }
+                        }
+                      />
+                    </li>
+                    <li
+                      className="emotion-14"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-12"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-13"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "10 real-time edits/day",
+                          }
+                        }
+                      />
+                      <span
+                        className="emotion-18"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup="true"
+                          aria-label="more info"
+                          className="emotion-17"
+                          onClick={[Function]}
+                        >
+                          <svg
+                            className={undefined}
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                            />
+                          </svg>
+                        </button>
+                        <span
+                          css={null}
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": null,
+                            }
+                          }
+                          role="status"
+                        />
+                      </span>
+                    </li>
+                    <li
+                      className="emotion-14"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-12"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-13"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Online documentation",
+                          }
+                        }
+                      />
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div
+                className="emotion-47"
+              >
+                <div
+                  className="emotion-5"
+                >
+                  <img
+                    alt="Professional"
+                    className="emotion-4"
+                    src="test-file-stub"
+                  />
+                </div>
+                <h2
+                  className="emotion-28"
+                >
+                  Professional
+                </h2>
+                <div
+                  className="emotion-7"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "For personal projects and single-purpose sites",
+                    }
+                  }
+                />
+                <div
+                  className="emotion-11"
+                >
+                  <span
+                    className="emotion-8"
+                  >
+                    $
+                  </span>
+                  <strong
+                    className="emotion-9"
+                  >
+                    42
+                  </strong>
+                  <span
+                    className="emotion-10"
+                  >
+                    / month
+                  </span>
+                </div>
+                <div
+                  className="emotion-24"
+                >
+                  <ul
+                    className="emotion-23"
+                  >
+                    <li
+                      className="emotion-14"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-12"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-13"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Builds and Preview",
+                          }
+                        }
+                      />
+                    </li>
+                    <li
+                      className="emotion-14"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-12"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-13"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "100 real-time edits/day",
+                          }
+                        }
+                      />
+                      <span
+                        className="emotion-18"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup="true"
+                          aria-label="more info"
+                          className="emotion-17"
+                          onClick={[Function]}
+                        >
+                          <svg
+                            className={undefined}
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                            />
+                          </svg>
+                        </button>
+                        <span
+                          css={null}
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": null,
+                            }
+                          }
+                          role="status"
+                        />
+                      </span>
+                    </li>
+                    <li
+                      className="emotion-14"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-12"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-13"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Online documentation",
+                          }
+                        }
+                      />
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div
+                className="emotion-47"
+              >
+                <div
+                  className="emotion-5"
+                >
+                  <img
+                    alt="Bussines"
+                    className="emotion-4"
+                    src="test-file-stub"
+                  />
+                </div>
+                <h2
+                  className="emotion-50"
+                >
+                  Bussines
+                </h2>
+                <div
+                  className="emotion-7"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "For personal projects and single-purpose sites",
+                    }
+                  }
+                />
+                <div
+                  className="emotion-11"
+                >
+                  <span
+                    className="emotion-8"
+                  >
+                    $
+                  </span>
+                  <strong
+                    className="emotion-9"
+                  >
+                    722
+                  </strong>
+                  <span
+                    className="emotion-10"
+                  >
+                    / month
+                  </span>
+                </div>
+                <div
+                  className="emotion-24"
+                >
+                  <ul
+                    className="emotion-23"
+                  >
+                    <li
+                      className="emotion-14"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-12"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-13"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Builds and Preview",
+                          }
+                        }
+                      />
+                    </li>
+                    <li
+                      className="emotion-14"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-12"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-13"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<p>1000 real-time edits/day</p>",
+                          }
+                        }
+                      />
+                      <span
+                        className="emotion-18"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup="true"
+                          aria-label="more info"
+                          className="emotion-17"
+                          onClick={[Function]}
+                        >
+                          <svg
+                            className={undefined}
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                            />
+                          </svg>
+                        </button>
+                        <span
+                          css={null}
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": null,
+                            }
+                          }
+                          role="status"
+                        />
+                      </span>
+                    </li>
+                    <li
+                      className="emotion-14"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="emotion-12"
+                        data-testid="icon-check"
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        height="24px"
+                        preserveAspectRatio="xMidYMid meet"
+                        stroke="none"
+                        strokeWidth="1"
+                        style={
+                          Object {
+                            "verticalAlign": "middle",
+                          }
+                        }
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                        />
+                        <path
+                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                        />
+                        <path
+                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                        />
+                      </svg>
+                      <div
+                        className="emotion-13"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "Online documentation",
+                          }
+                        }
+                      />
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div
+              className="emotion-73"
+            >
+              <a
+                className="emotion-71"
+                href="/"
+                role="button"
+              >
+                <span>
+                  Get started for free
+                </span>
+              </a>
+              <span
+                className="emotion-72"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "No commitment, no credit card required. All you need is a Github account.",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/PricingCard variants 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-48 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-49 {
+  width: 660px;
+  max-width: 94%;
+  margin: 0 auto;
+}
+
+.emotion-47 {
+  display: grid;
+  grid-gap: 2rem;
+  grid-template-columns: 1fr 1fr;
+}
+
+.emotion-23 {
+  box-shadow: 0px 2px 4px rgba(46,41,51,0.08),0px 4px 8px rgba(71,63,79,0.16);
+  background-color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 8px;
+}
+
+.emotion-22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  height: 100%;
+}
+
+.emotion-21 {
+  padding: 1.5rem 1.5rem 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 100%;
+}
+
+.emotion-21:not(:first-child) {
+  border-left: 1px solid #f0f0f2;
+}
+
+@media (min-width:750px) {
+  .emotion-21 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-shrink: 1;
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+    -webkit-flex-basis: calc(100% / 1);
+    -ms-flex-preferred-size: calc(100% / 1);
+    flex-basis: calc(100% / 1);
+  }
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 50px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-bottom: 0.5rem;
+  width: 50px;
+}
+
+.emotion-0 {
+  margin: 0;
+}
+
+.emotion-2 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  color: #b17acc;
+  font-size: 1.25rem;
+}
+
+.emotion-3 {
+  text-align: center;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #635e69;
+  line-height: 1.4;
+}
+
+.emotion-3 p {
+  margin: 0;
+}
+
+.emotion-7 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin-top: 1.5rem;
+  line-height: 1;
+}
+
+.emotion-4 {
+  color: #78757a;
+  font-size: 1rem;
+  display: inline-block;
+  -webkit-transform: translate(-.1rem,-.7rem);
+  -ms-transform: translate(-.1rem,-.7rem);
+  transform: translate(-.1rem,-.7rem);
+}
+
+.emotion-5 {
+  font-size: 2.25rem;
+}
+
+.emotion-6 {
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  color: #78757a;
+  font-size: 0.75rem;
+  display: inline-block;
+  -webkit-transform: translateX(.2rem);
+  -ms-transform: translateX(.2rem);
+  transform: translateX(.2rem);
+}
+
+.emotion-18 {
+  font-size: 0.875rem;
+  color: #78757a;
+  width: 100%;
+  margin-top: 1.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-17 {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: auto;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0.5rem 0;
+  position: relative;
+  line-height: 1.3;
+}
+
+.emotion-8 {
+  width: 1.5em;
+  height: 1.5em;
+  fill: #d9d7e0;
+  margin-right: 0.5rem;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-transform: translateY(-.2em);
+  -ms-transform: translateY(-.2em);
+  transform: translateY(-.2em);
+}
+
+.emotion-9 {
+  position: relative;
+  outline: none;
+}
+
+.emotion-9 p {
+  display: inline;
+}
+
+.emotion-20 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  margin-top: 2.5rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-bottom: 4rem;
+}
+
+.emotion-19 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+  width: 100%;
+  background: #8a4baf;
+  color: #ffffff;
+  border-color: #8a4baf;
+}
+
+.emotion-19[disabled],
+.emotion-19[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-19 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-19 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-19 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-19:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-19:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-19:hover {
+  color: #ffffff;
+  background: #8a4baf;
+  border-color: #8a4baf;
+}
+
+.emotion-46 {
+  box-shadow: 0px 2px 4px rgba(46,41,51,0.08),0px 4px 8px rgba(71,63,79,0.16);
+  background-color: #362066;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 8px;
+}
+
+.emotion-26 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  color: #ffffff;
+  font-size: 1.25rem;
+}
+
+.emotion-27 {
+  text-align: center;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #d9bae8;
+  line-height: 1.4;
+}
+
+.emotion-27 p {
+  margin: 0;
+}
+
+.emotion-41 {
+  font-size: 0.875rem;
+  color: #d9bae8;
+  width: 100%;
+  margin-top: 1.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-28 {
+  width: 1.5em;
+  height: 1.5em;
+  fill: #8a4baf;
+  margin-right: 0.5rem;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-transform: translateY(-.2em);
+  -ms-transform: translateY(-.2em);
+  transform: translateY(-.2em);
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-49"
+      >
+        <div
+          className="emotion-48"
+        >
+          <div
+            className="emotion-47"
+          >
+            <div
+              className="emotion-23"
+            >
+              <div
+                className="emotion-22"
+              >
+                <div
+                  className="emotion-21"
+                >
+                  <div
+                    className="emotion-1"
+                  >
+                    <img
+                      alt="Free"
+                      className="emotion-0"
+                      src="test-file-stub"
+                    />
+                  </div>
+                  <h2
+                    className="emotion-2"
+                  >
+                    Free
+                  </h2>
+                  <div
+                    className="emotion-3"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "For personal projects and single-purpose sites",
+                      }
+                    }
+                  />
+                  <div
+                    className="emotion-7"
+                  >
+                    <span
+                      className="emotion-4"
+                    >
+                      $
+                    </span>
+                    <strong
+                      className="emotion-5"
+                    >
+                      0
+                    </strong>
+                    <span
+                      className="emotion-6"
+                    >
+                      / month
+                    </span>
+                  </div>
+                  <div
+                    className="emotion-18"
+                  >
+                    <ul
+                      className="emotion-17"
+                    >
+                      <li
+                        className="emotion-10"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="emotion-8"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fillRule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          strokeWidth="1"
+                          style={
+                            Object {
+                              "verticalAlign": "middle",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          className="emotion-9"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "Builds and Preview",
+                            }
+                          }
+                        />
+                      </li>
+                      <li
+                        className="emotion-10"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="emotion-8"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fillRule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          strokeWidth="1"
+                          style={
+                            Object {
+                              "verticalAlign": "middle",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          className="emotion-9"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "10 real-time edits/day",
+                            }
+                          }
+                        />
+                      </li>
+                      <li
+                        className="emotion-10"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="emotion-8"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fillRule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          strokeWidth="1"
+                          style={
+                            Object {
+                              "verticalAlign": "middle",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          className="emotion-9"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "nline documentation",
+                            }
+                          }
+                        />
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    className="emotion-20"
+                  >
+                    <a
+                      className="emotion-19"
+                      href="/"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      <span>
+                        Subscribe
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="emotion-46"
+            >
+              <div
+                className="emotion-22"
+              >
+                <div
+                  className="emotion-21"
+                >
+                  <div
+                    className="emotion-1"
+                  >
+                    <img
+                      alt="Enterprise"
+                      className="emotion-0"
+                      src="test-file-stub"
+                    />
+                  </div>
+                  <h2
+                    className="emotion-26"
+                  >
+                    Enterprise
+                  </h2>
+                  <div
+                    className="emotion-27"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "Custom packages designed for your company",
+                      }
+                    }
+                  />
+                  <div
+                    className="emotion-41"
+                  >
+                    <ul
+                      className="emotion-17"
+                    >
+                      <li
+                        className="emotion-10"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="emotion-28"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fillRule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          strokeWidth="1"
+                          style={
+                            Object {
+                              "verticalAlign": "middle",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          className="emotion-9"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "Builds and Preview",
+                            }
+                          }
+                        />
+                      </li>
+                      <li
+                        className="emotion-10"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="emotion-28"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fillRule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          strokeWidth="1"
+                          style={
+                            Object {
+                              "verticalAlign": "middle",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          className="emotion-9"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "1000 real-time edits/day",
+                            }
+                          }
+                        />
+                      </li>
+                      <li
+                        className="emotion-10"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="emotion-28"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fillRule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          strokeWidth="1"
+                          style={
+                            Object {
+                              "verticalAlign": "middle",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          className="emotion-9"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "Online documentation",
+                            }
+                          }
+                        />
+                      </li>
+                      <li
+                        className="emotion-10"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="emotion-28"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fillRule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          strokeWidth="1"
+                          style={
+                            Object {
+                              "verticalAlign": "middle",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          className="emotion-9"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "Dedicated account manager",
+                            }
+                          }
+                        />
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    className="emotion-20"
+                  >
+                    <a
+                      className="emotion-19"
+                      href="/"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      <span>
+                        Contact sales
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/SettingsBlock default usage 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-21 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-22 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-5 {
+  background: #ffffff;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  width: 100%;
+}
+
+.emotion-2 {
+  font-size: 1.25rem;
+  padding: 1.5rem 2.5rem 2rem;
+}
+
+.emotion-1 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1.25rem;
+  line-height: 1;
+  min-height: 2.25rem;
+}
+
+.emotion-1:last-child {
+  margin-bottom: -.5rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #78757a;
+  margin-left: 0.25rem;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-0 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #fbfbfb;
+  color: #78757a;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  color: #78757a;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 6rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.emotion-8 {
+  color: #78757a;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.emotion-8:first-of-type {
+  margin-top: 0.75rem;
+}
+
+.emotion-8:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width:1000px) {
+  .emotion-8 {
+    grid-column: 1 / 2;
+  }
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-22"
+      >
+        <div
+          className="emotion-21"
+          width="35em"
+        >
+          <div
+            className="emotion-5"
+          >
+            <header
+              className="emotion-2"
+            >
+              <h3
+                className="emotion-1"
+              >
+                Automated Integrations
+                <a
+                  className="emotion-0"
+                  href="/"
+                  role="button"
+                >
+                  <svg
+                    className={undefined}
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    strokeWidth="0"
+                    style={
+                      Object {
+                        "color": undefined,
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
+                    />
+                  </svg>
+                </a>
+              </h3>
+            </header>
+            <div
+              className="emotion-4"
+            >
+              <div
+                className="emotion-3"
+              >
+                This is the Block's content section
+              </div>
+            </div>
+          </div>
+          <div
+            className="emotion-5"
+          >
+            <header
+              className="emotion-2"
+            >
+              <h3
+                className="emotion-1"
+              >
+                Automated Integrations 
+                <a
+                  className="emotion-0"
+                  href="/"
+                  role="button"
+                >
+                  <svg
+                    className={undefined}
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    strokeWidth="0"
+                    style={
+                      Object {
+                        "color": undefined,
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
+                    />
+                  </svg>
+                </a>
+              </h3>
+              <p
+                className="emotion-8"
+              >
+                Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+              </p>
+            </header>
+            <div
+              className="emotion-4"
+            >
+              <div
+                className="emotion-3"
+              >
+                This is the Block's content section
+              </div>
+            </div>
+          </div>
+          <div
+            className="emotion-5"
+          >
+            <header
+              className="emotion-2"
+            >
+              <h3
+                className="emotion-1"
+              >
+                Automated Integrations 
+                <a
+                  className="emotion-0"
+                  href="/"
+                  role="button"
+                >
+                  <svg
+                    className={undefined}
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    strokeWidth="0"
+                    style={
+                      Object {
+                        "color": undefined,
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
+                    />
+                  </svg>
+                </a>
+              </h3>
+              <p
+                className="emotion-8"
+              >
+                Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+              </p>
+              <p
+                className="emotion-8"
+              >
+                CDN hosts of your choice—just connect and you are good to go!
+              </p>
+            </header>
+            <div
+              className="emotion-4"
+            >
+              <div
+                className="emotion-3"
+              >
+                This is the Block's content section
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/SettingsBlock shortcut usage 1`] = `
+.emotion-6 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-5 {
+  background: #ffffff;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  width: 100%;
+}
+
+.emotion-2 {
+  font-size: 1.25rem;
+  padding: 1.5rem 2.5rem 2rem;
+}
+
+.emotion-0 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1.25rem;
+  line-height: 1;
+  min-height: 2.25rem;
+}
+
+.emotion-0:last-child {
+  margin-bottom: -.5rem;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  color: #78757a;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 6rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.emotion-1 {
+  color: #78757a;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.emotion-1:first-of-type {
+  margin-top: 0.75rem;
+}
+
+.emotion-1:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width:1000px) {
+  .emotion-1 {
+    grid-column: 1 / 2;
+  }
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-7"
+      >
+        <div
+          className="emotion-6"
+          width="35em"
+        >
+          <div
+            className="emotion-5"
+            doclink="/"
+          >
+            <header
+              className="emotion-2"
+            >
+              <h3
+                className="emotion-0"
+              >
+                Automated Integrations
+                 
+              </h3>
+              <p
+                className="emotion-1"
+              >
+                 Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+              </p>
+            </header>
+            <div
+              className="emotion-4"
+            >
+              <div
+                className="emotion-3"
+              >
+                This is the Block's content section
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/SettingsBlock with Announcement 1`] = `
+.emotion-10 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #f7ffff;
+  color: #008577;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  padding: 1rem 2.5rem;
+  background-image: url(test-file-stub);
+  background-position: right center;
+  background-repeat: no-repeat;
+}
+
+.emotion-7:not(:first-child) {
+  border-top: 1px solid #dcfffd;
+}
+
+.emotion-11 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #ffffff;
+  border-top: 1px solid #f0f0f2;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: auto auto 1fr;
+  width: 100%;
+  padding: 1rem 2.5rem;
+}
+
+.emotion-4:last-of-type {
+  margin-bottom: 0;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+}
+
+.emotion-3 img,
+.emotion-3 svg {
+  height: 24px;
+  width: auto;
+  margin: 0;
+}
+
+.emotion-9 {
+  background: #ffffff;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  width: 100%;
+}
+
+.emotion-2 {
+  font-size: 1.25rem;
+  padding: 1.5rem 2.5rem 2rem;
+}
+
+.emotion-0 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1.25rem;
+  line-height: 1;
+  min-height: 2.25rem;
+}
+
+.emotion-0:last-child {
+  margin-bottom: -.5rem;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-1 {
+  color: #78757a;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.emotion-1:first-of-type {
+  margin-top: 0.75rem;
+}
+
+.emotion-1:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width:1000px) {
+  .emotion-1 {
+    grid-column: 1 / 2;
+  }
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-11"
+      >
+        <div
+          className="emotion-10"
+          width="35em"
+        >
+          <div
+            className="emotion-9"
+            doclink="/"
+          >
+            <header
+              className="emotion-2"
+            >
+              <h3
+                className="emotion-0"
+              >
+                Automated Integrations
+                 
+              </h3>
+              <p
+                className="emotion-1"
+              >
+                 Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+              </p>
+            </header>
+            <div
+              className="emotion-8"
+            >
+              <div
+                className="emotion-4"
+                onClickEdit={[Function]}
+              >
+                <span
+                  className="emotion-3"
+                >
+                  <img
+                    alt="Contentful"
+                    src="test-file-stub"
+                  />
+                </span>
+              </div>
+              <div
+                className="emotion-4"
+                onClickEdit={[Function]}
+              >
+                <span
+                  className="emotion-3"
+                >
+                  <img
+                    alt="Netlify"
+                    src="test-file-stub"
+                  />
+                </span>
+              </div>
+              <div
+                className="emotion-7"
+              >
+                We are working on adding more integrations all the time—watch your inbox!
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/SettingsBlock with items 1`] = `
+.emotion-9 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-10 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #ffffff;
+  border-top: 1px solid #f0f0f2;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: auto auto 1fr;
+  width: 100%;
+  padding: 1rem 2.5rem;
+}
+
+.emotion-4:last-of-type {
+  margin-bottom: 0;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+}
+
+.emotion-3 img,
+.emotion-3 svg {
+  height: 24px;
+  width: auto;
+  margin: 0;
+}
+
+.emotion-8 {
+  background: #ffffff;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  width: 100%;
+}
+
+.emotion-2 {
+  font-size: 1.25rem;
+  padding: 1.5rem 2.5rem 2rem;
+}
+
+.emotion-0 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1.25rem;
+  line-height: 1;
+  min-height: 2.25rem;
+}
+
+.emotion-0:last-child {
+  margin-bottom: -.5rem;
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-1 {
+  color: #78757a;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.emotion-1:first-of-type {
+  margin-top: 0.75rem;
+}
+
+.emotion-1:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width:1000px) {
+  .emotion-1 {
+    grid-column: 1 / 2;
+  }
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-10"
+      >
+        <div
+          className="emotion-9"
+          width="35em"
+        >
+          <div
+            className="emotion-8"
+            doclink="/"
+          >
+            <header
+              className="emotion-2"
+            >
+              <h3
+                className="emotion-0"
+              >
+                Automated Integrations
+                 
+              </h3>
+              <p
+                className="emotion-1"
+              >
+                 Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+              </p>
+            </header>
+            <div
+              className="emotion-7"
+            >
+              <div
+                className="emotion-4"
+                onClickEdit={[Function]}
+              >
+                <span
+                  className="emotion-3"
+                >
+                  <img
+                    alt="Contentful"
+                    src="test-file-stub"
+                  />
+                </span>
+              </div>
+              <div
+                className="emotion-4"
+                onClickEdit={[Function]}
+              >
+                <span
+                  className="emotion-3"
+                >
+                  <img
+                    alt="Netlify"
+                    src="test-file-stub"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/SettingsCard custom EditButton 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-10 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+.emotion-11 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  background: #ffffff;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  padding: 1.5rem 2.5rem 2rem;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+}
+
+.emotion-0 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #362066;
+  line-height: 1.125;
+  font-weight: bold;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1.25rem;
+  line-height: 1;
+  min-height: 2.25rem;
+}
+
+.emotion-3 {
+  grid-column: 1 / 3;
+}
+
+.emotion-2 {
+  color: #78757a;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.emotion-2:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-11"
+      >
+        <div
+          className="emotion-10"
+          width="35em"
+        >
+          <div
+            className="emotion-4"
+          >
+            <h3
+              className="emotion-0"
+            >
+              Card's title
+            </h3>
+            <button
+              className="emotion-1"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span>
+                Change
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+            </button>
+            <div
+              className="emotion-3"
+            >
+              <p
+                className="emotion-2"
+              >
+                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+              </p>
+            </div>
+          </div>
+          <div
+            className="emotion-4"
+          >
+            <h3
+              className="emotion-0"
+            >
+              Card's title
+            </h3>
+            <button
+              className="emotion-1"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span>
+                Add 
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                />
+              </svg>
+            </button>
+            <div
+              className="emotion-3"
+            >
+              <p
+                className="emotion-2"
+              >
+                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+              </p>
+            </div>
+          </div>
+        </div>
+         
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/SettingsCard default usage 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-5 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+.emotion-6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  background: #ffffff;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  padding: 1.5rem 2.5rem 2rem;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+}
+
+.emotion-0 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #362066;
+  line-height: 1.125;
+  font-weight: bold;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1.25rem;
+  line-height: 1;
+  min-height: 2.25rem;
+}
+
+.emotion-3 {
+  grid-column: 1 / 3;
+}
+
+.emotion-2 {
+  color: #78757a;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.emotion-2:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-6"
+      >
+        <div
+          className="emotion-5"
+          width="35em"
+        >
+          <div
+            className="emotion-4"
+          >
+            <h3
+              className="emotion-0"
+            >
+              Card's title
+            </h3>
+            <button
+              className="emotion-1"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span>
+                Edit
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+            </button>
+            <div
+              className="emotion-3"
+            >
+              <p
+                className="emotion-2"
+              >
+                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/SettingsCard no secondary conent 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-12 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+.emotion-13 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  color: #78757a;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 6rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.emotion-4 {
+  background: #ffffff;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  padding: 1.5rem 2.5rem 2rem;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+}
+
+.emotion-0 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #362066;
+  line-height: 1.125;
+  font-weight: bold;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1.25rem;
+  line-height: 1;
+  min-height: 2.25rem;
+}
+
+.emotion-3 {
+  grid-column: 1 / 3;
+}
+
+.emotion-2 {
+  color: #78757a;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.emotion-2:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-13"
+      >
+        <div
+          className="emotion-12"
+          width="35em"
+        >
+          <div
+            className="emotion-4"
+          >
+            <h3
+              className="emotion-0"
+            >
+              Card's title
+            </h3>
+            <button
+              className="emotion-1"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span>
+                Edit
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+            </button>
+            <div
+              className="emotion-3"
+            >
+              <p
+                className="emotion-2"
+              >
+                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+              </p>
+            </div>
+          </div>
+          <div
+            className="emotion-4"
+          >
+            <h3
+              className="emotion-0"
+            >
+              Card's title
+            </h3>
+            <button
+              className="emotion-1"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span>
+                Edit
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+            </button>
+            <div
+              className="emotion-3"
+            >
+              <p
+                className="emotion-2"
+              >
+                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+              </p>
+              <p
+                className="emotion-2"
+              >
+                Amaranth tatsoi tomatillo melon azuki bean garlic.
+              </p>
+              <div
+                className="emotion-9"
+              >
+                PRIMARY CONTENT
+              </div>
+            </div>
+          </div>
+        </div>
+         
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/SettingsCard with custom tone 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-5 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fbfbfb;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  background: #ffffff;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  padding: 1.5rem 2.5rem 2rem;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+}
+
+.emotion-3 {
+  grid-column: 1 / 3;
+}
+
+.emotion-2 {
+  color: #78757a;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji !important;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.emotion-2:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-0 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #b80000;
+  line-height: 1.125;
+  font-weight: bold;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1.25rem;
+  line-height: 1;
+  min-height: 2.25rem;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #da0013;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1 svg:last-child {
+  margin-right: -0.25em;
+}
+
+.emotion-1 svg:first-child {
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #fffafa;
+  color: #da0013;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-6"
+      >
+        <div
+          className="emotion-5"
+          width="35em"
+        >
+          <div
+            className="emotion-4"
+          >
+            <h3
+              className="emotion-0"
+            >
+              Delete ite
+            </h3>
+            <button
+              className="emotion-1"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span>
+                Delete site 
+              </span>
+              <svg
+                className={undefined}
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                />
+              </svg>
+            </button>
+            <div
+              className="emotion-3"
+            >
+              <p
+                className="emotion-2"
+              >
+                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Switch usage 1`] = `
+.emotion-6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #232129;
+  cursor: pointer;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-letter-spacing: 0.03em;
+  -moz-letter-spacing: 0.03em;
+  -ms-letter-spacing: 0.03em;
+  letter-spacing: 0.03em;
+}
+
+.emotion-5 span:last-child {
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.emotion-0 {
+  margin-right: 0.5rem;
+}
+
+.emotion-1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+.emotion-2 {
+  background: #d9d7e0;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-block;
+  height: 24px;
+  margin-right: 0.5rem;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  padding: 3px;
+  -webkit-transition: all .3s ease,background .5s;
+  transition: all .3s ease,background .5s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 48px;
+  margin-left: 0;
+}
+
+label:focus-within > .emotion-2 {
+  box-shadow: 0 0 0 3px #f1defa;
+  outline: 0;
+}
+
+.emotion-2:after {
+  background: #ffffff;
+  left: 0;
+  position: relative;
+  display: block;
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  -webkit-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.emotion-2:active:after {
+  left: 0;
+  width: 24px;
+}
+
+.emotion-4 {
+  text-transform: uppercase;
+}
+
+.emotion-3 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-6"
+      >
+        <label
+          className="emotion-5"
+          htmlFor="interval_primary"
+        >
+          <span
+            aria-hidden={true}
+            className="emotion-0"
+          >
+            MONTHLY
+          </span>
+          <input
+            checked={false}
+            className="emotion-1"
+            id="interval_primary"
+            name="interval_primary"
+            onChange={[Function]}
+            type="checkbox"
+            value={true}
+          />
+          <span
+            aria-hidden={true}
+            className="emotion-2"
+          />
+          <span
+            className="emotion-4"
+          >
+            <span
+              aria-hidden={true}
+            >
+              YEARLY
+            </span>
+            <span
+              className="emotion-3"
+            >
+               
+              YEARLY PAYMENT
+            </span>
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Switch with Formik 1`] = `
+.emotion-10 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-9 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #232129;
+  cursor: pointer;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-letter-spacing: 0.03em;
+  -moz-letter-spacing: 0.03em;
+  -ms-letter-spacing: 0.03em;
+  letter-spacing: 0.03em;
+}
+
+.emotion-5 span:last-child {
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.emotion-0 {
+  margin-right: 0.5rem;
+}
+
+.emotion-1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+.emotion-2 {
+  background: #d9d7e0;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-block;
+  height: 24px;
+  margin-right: 0.5rem;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  padding: 3px;
+  -webkit-transition: all .3s ease,background .5s;
+  transition: all .3s ease,background .5s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 48px;
+  margin-left: 0;
+}
+
+label:focus-within > .emotion-2 {
+  box-shadow: 0 0 0 3px #f1defa;
+  outline: 0;
+}
+
+.emotion-2:after {
+  background: #ffffff;
+  left: 0;
+  position: relative;
+  display: block;
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  -webkit-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.emotion-2:active:after {
+  left: 0;
+  width: 24px;
+}
+
+.emotion-4 {
+  text-transform: uppercase;
+}
+
+.emotion-3 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+.emotion-8 {
+  margin: 3rem 0;
+  border-radius: 4px;
+  background: #f6f8fa;
+  box-shadow: 0 0 1px #eee inset;
+}
+
+.emotion-6 {
+  text-transform: uppercase;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  font-weight: 500;
+  padding: .5rem;
+  background: #555;
+  color: #fff;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-7 {
+  padding: .25rem .5rem;
+  overflow-x: scroll;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-10"
+      >
+        <form
+          className="emotion-9"
+        >
+          <label
+            className="emotion-5"
+            htmlFor="subInterval_primary"
+          >
+            <span
+              aria-hidden={true}
+              className="emotion-0"
+            >
+              MONTHLY
+            </span>
+            <input
+              checked={false}
+              className="emotion-1"
+              id="subInterval_primary"
+              name="subInterval_primary"
+              onChange={[Function]}
+              type="checkbox"
+              value={true}
+            />
+            <span
+              aria-hidden={true}
+              className="emotion-2"
+            />
+            <span
+              className="emotion-4"
+            >
+              <span
+                aria-hidden={true}
+              >
+                YEARLY
+              </span>
+              <span
+                className="emotion-3"
+              >
+                 
+                YEARLY PAYMENT
+              </span>
+            </span>
+          </label>
+          <div
+            className="emotion-8"
+          >
+            <div
+              className="emotion-6"
+            >
+              Formik State
+            </div>
+            <pre
+              className="emotion-7"
+            >
+              {
+  "values": {
+    "subInterval": "MONTHLY"
+  },
+  "errors": {},
+  "touched": {},
+  "isSubmitting": false,
+  "isValidating": false,
+  "submitCount": 0,
+  "dirty": false,
+  "isValid": false,
+  "initialValues": {
+    "subInterval": "MONTHLY"
+  },
+  "validateOnChange": true,
+  "validateOnBlur": true
+}
+            </pre>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Toggle before or after label 1`] = `
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-8 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #232129;
+  cursor: pointer;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+}
+
+.emotion-3 span:last-child {
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.emotion-1 {
+  background: #8a4baf;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-block;
+  height: 24px;
+  margin-right: 0.5rem;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  padding: 3px;
+  -webkit-transition: all .3s ease,background .5s;
+  transition: all .3s ease,background .5s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 48px;
+  margin-left: 0;
+}
+
+label:focus-within > .emotion-1 {
+  box-shadow: 0 0 0 3px #f1defa;
+  outline: 0;
+}
+
+.emotion-1:after {
+  background: #ffffff;
+  left: 24px;
+  position: relative;
+  display: block;
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  -webkit-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.emotion-1:active:after {
+  left: 18px;
+  width: 24px;
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #232129;
+  cursor: pointer;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+}
+
+.emotion-7 span:last-child {
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+}
+
+.emotion-5 {
+  background: #8a4baf;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-block;
+  height: 24px;
+  margin-right: 0;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  padding: 3px;
+  -webkit-transition: all .3s ease,background .5s;
+  transition: all .3s ease,background .5s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 48px;
+  margin-left: 0.5rem;
+}
+
+label:focus-within > .emotion-5 {
+  box-shadow: 0 0 0 3px #f1defa;
+  outline: 0;
+}
+
+.emotion-5:after {
+  background: #ffffff;
+  left: 0;
+  position: relative;
+  display: block;
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  -webkit-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.emotion-5:active:after {
+  left: 0;
+  width: 24px;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-9"
+      >
+        <div
+          className="emotion-8"
+        >
+          <label
+            className="emotion-3"
+            htmlFor="subInterval"
+          >
+            <input
+              checked={true}
+              className="emotion-0"
+              id="subInterval"
+              name="subInterval"
+              onChange={[Function]}
+              type="checkbox"
+              value={true}
+            />
+            <span
+              aria-hidden={true}
+              className="emotion-1"
+            />
+            <span
+              className="emotion-2"
+            >
+              Yearly payment
+            </span>
+          </label>
+          <label
+            className="emotion-7"
+            htmlFor="renew"
+          >
+            <input
+              checked={true}
+              className="emotion-0"
+              id="renew"
+              name="renew"
+              onChange={[Function]}
+              type="checkbox"
+              value={true}
+            />
+            <span
+              aria-hidden={true}
+              className="emotion-5"
+            />
+            <span
+              className="emotion-2"
+            >
+              Automaticaly renew
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Toggle shortcut usage 1`] = `
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-8 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+.emotion-5 {
+  background: #d9d7e0;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-block;
+  height: 24px;
+  margin-right: 0.5rem;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  padding: 3px;
+  -webkit-transition: all .3s ease,background .5s;
+  transition: all .3s ease,background .5s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 48px;
+  margin-left: 0;
+}
+
+label:focus-within > .emotion-5 {
+  box-shadow: 0 0 0 3px #f1defa;
+  outline: 0;
+}
+
+.emotion-5:after {
+  background: #ffffff;
+  left: 0;
+  position: relative;
+  display: block;
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  -webkit-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.emotion-5:active:after {
+  left: 0;
+  width: 24px;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #232129;
+  cursor: pointer;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+}
+
+.emotion-3 span:last-child {
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.emotion-1 {
+  background: #8a4baf;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-block;
+  height: 24px;
+  margin-right: 0.5rem;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  padding: 3px;
+  -webkit-transition: all .3s ease,background .5s;
+  transition: all .3s ease,background .5s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 48px;
+  margin-left: 0;
+}
+
+label:focus-within > .emotion-1 {
+  box-shadow: 0 0 0 3px #f1defa;
+  outline: 0;
+}
+
+.emotion-1:after {
+  background: #ffffff;
+  left: 24px;
+  position: relative;
+  display: block;
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  -webkit-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.emotion-1:active:after {
+  left: 18px;
+  width: 24px;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-9"
+      >
+        <div
+          className="emotion-8"
+        >
+          <label
+            className="emotion-3"
+            htmlFor="subInterval"
+          >
+            <input
+              checked={true}
+              className="emotion-0"
+              id="subInterval"
+              name="subInterval"
+              onChange={[Function]}
+              type="checkbox"
+              value={true}
+            />
+            <span
+              aria-hidden={true}
+              className="emotion-1"
+            />
+            <span
+              className="emotion-2"
+            >
+              Yearly payment
+            </span>
+          </label>
+          <label
+            className="emotion-3"
+            htmlFor="renew"
+          >
+            <input
+              checked={false}
+              className="emotion-0"
+              id="renew"
+              name="renew"
+              onChange={[Function]}
+              type="checkbox"
+              value={true}
+            />
+            <span
+              aria-hidden={true}
+              className="emotion-5"
+            />
+            <span
+              className="emotion-2"
+            >
+              Automaticaly renew
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Toggle with Formik 1`] = `
+.emotion-8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-7 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+.emotion-1 {
+  background: #d9d7e0;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-block;
+  height: 24px;
+  margin-right: 0.5rem;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  padding: 3px;
+  -webkit-transition: all .3s ease,background .5s;
+  transition: all .3s ease,background .5s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 48px;
+  margin-left: 0;
+}
+
+label:focus-within > .emotion-1 {
+  box-shadow: 0 0 0 3px #f1defa;
+  outline: 0;
+}
+
+.emotion-1:after {
+  background: #ffffff;
+  left: 0;
+  position: relative;
+  display: block;
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  -webkit-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.emotion-1:active:after {
+  left: 0;
+  width: 24px;
+}
+
+.emotion-6 {
+  margin: 3rem 0;
+  border-radius: 4px;
+  background: #f6f8fa;
+  box-shadow: 0 0 1px #eee inset;
+}
+
+.emotion-4 {
+  text-transform: uppercase;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  font-weight: 500;
+  padding: .5rem;
+  background: #555;
+  color: #fff;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-5 {
+  padding: .25rem .5rem;
+  overflow-x: scroll;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #232129;
+  cursor: pointer;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+}
+
+.emotion-3 span:last-child {
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-8"
+      >
+        <form
+          className="emotion-7"
+        >
+          <label
+            className="emotion-3"
+            htmlFor="subscriptionInterval"
+          >
+            <input
+              checked={false}
+              className="emotion-0"
+              id="subscriptionInterval"
+              name="subscriptionInterval"
+              onChange={[Function]}
+              type="checkbox"
+              value={true}
+            />
+            <span
+              aria-hidden={true}
+              className="emotion-1"
+            />
+            <span
+              className="emotion-2"
+            >
+              Yearly payment
+            </span>
+          </label>
+          <div
+            className="emotion-6"
+          >
+            <div
+              className="emotion-4"
+            >
+              Formik State
+            </div>
+            <pre
+              className="emotion-5"
+            >
+              {
+  "values": {
+    "subscriptionInterval": false,
+    "automaticalRenew": false
+  },
+  "errors": {},
+  "touched": {},
+  "isSubmitting": false,
+  "isValidating": false,
+  "submitCount": 0,
+  "dirty": false,
+  "isValid": false,
+  "initialValues": {
+    "subscriptionInterval": false,
+    "automaticalRenew": false
+  },
+  "validateOnChange": true,
+  "validateOnBlur": true
+}
+            </pre>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Toggle with a rich label 1`] = `
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-6 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+.emotion-1 {
+  background: #d9d7e0;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-block;
+  height: 24px;
+  margin-right: 0.5rem;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  padding: 3px;
+  -webkit-transition: all .3s ease,background .5s;
+  transition: all .3s ease,background .5s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 48px;
+  margin-left: 0;
+}
+
+label:focus-within > .emotion-1 {
+  box-shadow: 0 0 0 3px #f1defa;
+  outline: 0;
+}
+
+.emotion-1:after {
+  background: #ffffff;
+  left: 0;
+  position: relative;
+  display: block;
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  -webkit-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.emotion-1:active:after {
+  left: 0;
+  width: 24px;
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #232129;
+  cursor: pointer;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin-left: 0.75rem;
+}
+
+.emotion-5 span:last-child {
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.emotion-4 {
+  margin-left: 0.5rem;
+}
+
+.emotion-2 {
+  margin: 0;
+  color: #78757a;
+}
+
+.emotion-3 {
+  margin: 0.25rem 0 0 0;
+  font-size: 0.875rem;
+  color: #78757a;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-7"
+      >
+        <div
+          className="emotion-6"
+        >
+          <label
+            className="emotion-5"
+            htmlFor="subInterval"
+          >
+            <input
+              checked={false}
+              className="emotion-0"
+              id="subInterval"
+              name="subInterval"
+              onChange={[Function]}
+              type="checkbox"
+              value={true}
+            />
+            <span
+              aria-hidden={true}
+              className="emotion-1"
+            />
+            <span
+              className="emotion-4"
+            >
+              <strong
+                className="emotion-2"
+              >
+                Yearly payment
+              </strong>
+              <p
+                className="emotion-3"
+              >
+                This is label with HTML
+              </p>
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/ToggleTip shortcut usage 1`] = `
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-2 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  background: transparent;
+  cursor: pointer;
+  border: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 1.4em;
+  padding: 0;
+  vertical-align: text-bottom;
+  width: 1.4em;
+  border-radius: 50%;
+}
+
+.emotion-0:focus {
+  box-shadow: 0 0 0 3px #d9bae8;
+  outline: none;
+}
+
+.emotion-0 svg {
+  height: 100%;
+  color: #78757a;
+  width: 100%;
+}
+
+.emotion-1 {
+  position: relative;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-3"
+      >
+        <div
+          className="emotion-2"
+        >
+          <p>
+            This is a text with ToggleTip
+             
+            <span
+              className="emotion-1"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup="true"
+                aria-label="more info"
+                className="emotion-0"
+                onClick={[Function]}
+              >
+                <svg
+                  className={undefined}
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  strokeWidth="0"
+                  style={
+                    Object {
+                      "color": undefined,
+                    }
+                  }
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                  />
+                </svg>
+              </button>
+              <span
+                css={null}
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": null,
+                  }
+                }
+                role="status"
+              />
+            </span>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots icons All icons 1`] = `
+.emotion-14 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-13 {
+  max-width: 640px;
+  margin: 0 auto;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.emotion-12 {
+  margin: 1rem 0;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px dotted #bbb;
+  margin-bottom: 1rem;
+}
+
+.emotion-0 {
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  font-family: monospace;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.emotion-1 {
+  border-left: 1px dotted #bbb;
+  -webkit-flex: 0 0 72px;
+  -ms-flex: 0 0 72px;
+  flex: 0 0 72px;
+  height: 72px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-14"
+      >
+        <div
+          className="emotion-13"
+        >
+          <h2>
+            4
+             icon(s):
+          </h2>
+          <div
+            className="emotion-12"
+          >
+            <div
+              className="emotion-2"
+            >
+              <div
+                className="emotion-0"
+              >
+                BlogIcon
+              </div>
+              <div
+                className="emotion-1"
+              >
+                <svg
+                  aria-hidden={true}
+                  color="#000"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fillRule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  strokeWidth="1"
+                  style={
+                    Object {
+                      "verticalAlign": "middle",
+                    }
+                  }
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              className="emotion-2"
+            >
+              <div
+                className="emotion-0"
+              >
+                CheckIcon
+              </div>
+              <div
+                className="emotion-1"
+              >
+                <svg
+                  aria-hidden={true}
+                  color="#000"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  strokeWidth="1"
+                  style={
+                    Object {
+                      "verticalAlign": "middle",
+                    }
+                  }
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              className="emotion-2"
+            >
+              <div
+                className="emotion-0"
+              >
+                EcommerceIcon
+              </div>
+              <div
+                className="emotion-1"
+              >
+                <svg
+                  aria-hidden={true}
+                  color="#000"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fillRule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  strokeWidth="1"
+                  style={
+                    Object {
+                      "verticalAlign": "middle",
+                    }
+                  }
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              className="emotion-2"
+            >
+              <div
+                className="emotion-0"
+              >
+                PortfolioIcon
+              </div>
+              <div
+                className="emotion-1"
+              >
+                <svg
+                  aria-hidden={true}
+                  color="#000"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fillRule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  strokeWidth="1"
+                  style={
+                    Object {
+                      "verticalAlign": "middle",
+                    }
+                  }
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots icons/Single icons BlogIcon 1`] = `
+.emotion-43 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-42 {
+  margin: 1rem 0;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px dotted #bbb;
+  margin-bottom: 1rem;
+}
+
+.emotion-0 {
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  font-family: monospace;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.emotion-1 {
+  border-left: 1px dotted #bbb;
+  -webkit-flex: 0 0 72px;
+  -ms-flex: 0 0 72px;
+  flex: 0 0 72px;
+  height: 72px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-43"
+      >
+        <div
+          className="emotion-42"
+        >
+          <h1>
+            &lt;BlogIcon /&gt;
+          </h1>
+          <h2>
+            Size:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              xsmall
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="16px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="16px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              small
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="24px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              medium
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="32px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              large
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="40px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="40px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Custom size:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=1em
+              <br />
+              width=1em
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=16px
+              <br />
+              width=16px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="16px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="16px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=24px
+              <br />
+              width=24px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="24px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=32px
+              <br />
+              width=32px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="32px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=40px
+              <br />
+              width=40px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="40px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="40px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=64px
+              <br />
+              width=64px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="64px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="64px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Color:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#663399",
+                  }
+                }
+              >
+                #663399
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#663399"
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#ffb238",
+                  }
+                }
+              >
+                #ffb238
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#ffb238"
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#e899ce",
+                  }
+                }
+              >
+                #e899ce
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#e899ce"
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#b80000",
+                  }
+                }
+              >
+                #b80000
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#b80000"
+                data-testid="icon-blog"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Inline
+          </h2>
+          <p>
+            Lorem ipsum 
+            <svg
+              aria-hidden={true}
+              data-testid="icon-blog"
+              fill="none"
+              fillRule="evenodd"
+              height="1em"
+              preserveAspectRatio="xMidYMid meet"
+              stroke="currentColor"
+              strokeWidth="1"
+              style={
+                Object {
+                  "verticalAlign": "middle",
+                }
+              }
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+             foo bar
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots icons/Single icons CheckIcon 1`] = `
+.emotion-43 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-42 {
+  margin: 1rem 0;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px dotted #bbb;
+  margin-bottom: 1rem;
+}
+
+.emotion-0 {
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  font-family: monospace;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.emotion-1 {
+  border-left: 1px dotted #bbb;
+  -webkit-flex: 0 0 72px;
+  -ms-flex: 0 0 72px;
+  flex: 0 0 72px;
+  height: 72px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-43"
+      >
+        <div
+          className="emotion-42"
+        >
+          <h1>
+            &lt;CheckIcon /&gt;
+          </h1>
+          <h2>
+            Size:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              xsmall
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="16px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="16px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              small
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="24px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              medium
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="32px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              large
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="40px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="40px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Custom size:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=1em
+              <br />
+              width=1em
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=16px
+              <br />
+              width=16px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="16px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="16px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=24px
+              <br />
+              width=24px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="24px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=32px
+              <br />
+              width=32px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="32px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=40px
+              <br />
+              width=40px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="40px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="40px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=64px
+              <br />
+              width=64px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="64px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="64px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Color:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#663399",
+                  }
+                }
+              >
+                #663399
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#663399"
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#ffb238",
+                  }
+                }
+              >
+                #ffb238
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#ffb238"
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#e899ce",
+                  }
+                }
+              >
+                #e899ce
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#e899ce"
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#b80000",
+                  }
+                }
+              >
+                #b80000
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#b80000"
+                data-testid="icon-check"
+                fill="currentColor"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="none"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                />
+                <path
+                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                />
+                <path
+                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Inline
+          </h2>
+          <p>
+            Lorem ipsum 
+            <svg
+              aria-hidden={true}
+              data-testid="icon-check"
+              fill="currentColor"
+              fillRule="evenodd"
+              height="1em"
+              preserveAspectRatio="xMidYMid meet"
+              stroke="none"
+              strokeWidth="1"
+              style={
+                Object {
+                  "verticalAlign": "middle",
+                }
+              }
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+              />
+              <path
+                d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+              />
+              <path
+                d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+              />
+            </svg>
+             foo bar
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots icons/Single icons EcommerceIcon 1`] = `
+.emotion-43 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-42 {
+  margin: 1rem 0;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px dotted #bbb;
+  margin-bottom: 1rem;
+}
+
+.emotion-0 {
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  font-family: monospace;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.emotion-1 {
+  border-left: 1px dotted #bbb;
+  -webkit-flex: 0 0 72px;
+  -ms-flex: 0 0 72px;
+  flex: 0 0 72px;
+  height: 72px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-43"
+      >
+        <div
+          className="emotion-42"
+        >
+          <h1>
+            &lt;EcommerceIcon /&gt;
+          </h1>
+          <h2>
+            Size:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              xsmall
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="16px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="16px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              small
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="24px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              medium
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="32px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              large
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="40px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="40px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Custom size:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=1em
+              <br />
+              width=1em
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=16px
+              <br />
+              width=16px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="16px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="16px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=24px
+              <br />
+              width=24px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="24px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=32px
+              <br />
+              width=32px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="32px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=40px
+              <br />
+              width=40px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="40px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="40px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=64px
+              <br />
+              width=64px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="64px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="64px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Color:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#663399",
+                  }
+                }
+              >
+                #663399
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#663399"
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#ffb238",
+                  }
+                }
+              >
+                #ffb238
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#ffb238"
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#e899ce",
+                  }
+                }
+              >
+                #e899ce
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#e899ce"
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#b80000",
+                  }
+                }
+              >
+                #b80000
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#b80000"
+                data-testid="icon-ecommerce"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M16.4999 7.5L15.6709 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 7.5L9.828 3.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Inline
+          </h2>
+          <p>
+            Lorem ipsum 
+            <svg
+              aria-hidden={true}
+              data-testid="icon-ecommerce"
+              fill="none"
+              fillRule="evenodd"
+              height="1em"
+              preserveAspectRatio="xMidYMid meet"
+              stroke="currentColor"
+              strokeWidth="1"
+              style={
+                Object {
+                  "verticalAlign": "middle",
+                }
+              }
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M16.4999 7.5L15.6709 3.75"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M9 7.5L9.828 3.75"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+             foo bar
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots icons/Single icons PortfolioIcon 1`] = `
+.emotion-43 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-42 {
+  margin: 1rem 0;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px dotted #bbb;
+  margin-bottom: 1rem;
+}
+
+.emotion-0 {
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  font-family: monospace;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.emotion-1 {
+  border-left: 1px dotted #bbb;
+  -webkit-flex: 0 0 72px;
+  -ms-flex: 0 0 72px;
+  flex: 0 0 72px;
+  height: 72px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-43"
+      >
+        <div
+          className="emotion-42"
+        >
+          <h1>
+            &lt;PortfolioIcon /&gt;
+          </h1>
+          <h2>
+            Size:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              xsmall
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="16px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="16px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              small
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="24px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              medium
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="32px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              large
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="40px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="40px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Custom size:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=1em
+              <br />
+              width=1em
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="1em"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=16px
+              <br />
+              width=16px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="16px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="16px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=24px
+              <br />
+              width=24px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="24px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=32px
+              <br />
+              width=32px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="32px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=40px
+              <br />
+              width=40px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="40px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="40px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              height=64px
+              <br />
+              width=64px
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="64px"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="64px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Color:
+          </h2>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#663399",
+                  }
+                }
+              >
+                #663399
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#663399"
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#ffb238",
+                  }
+                }
+              >
+                #ffb238
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#ffb238"
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#e899ce",
+                  }
+                }
+              >
+                #e899ce
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#e899ce"
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="emotion-2"
+          >
+            <div
+              className="emotion-0"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#b80000",
+                  }
+                }
+              >
+                #b80000
+              </span>
+            </div>
+            <div
+              className="emotion-1"
+            >
+              <svg
+                aria-hidden={true}
+                color="#b80000"
+                data-testid="icon-portfolio"
+                fill="none"
+                fillRule="evenodd"
+                height="3em"
+                preserveAspectRatio="xMidYMid meet"
+                stroke="currentColor"
+                strokeWidth="1"
+                style={
+                  Object {
+                    "verticalAlign": "middle",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path
+                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M6.74609 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M17.2461 2.24799V0.747986"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </div>
+          <h2>
+            Inline
+          </h2>
+          <p>
+            Lorem ipsum 
+            <svg
+              aria-hidden={true}
+              data-testid="icon-portfolio"
+              fill="none"
+              fillRule="evenodd"
+              height="1em"
+              preserveAspectRatio="xMidYMid meet"
+              stroke="currentColor"
+              strokeWidth="1"
+              style={
+                Object {
+                  "verticalAlign": "middle",
+                }
+              }
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M6.74609 2.24799V0.747986"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M17.2461 2.24799V0.747986"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+             foo bar
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/BaseButton tags/components 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.emotion-0 > * {
+  margin: 20px;
+}
+
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        className="emotion-0"
+      >
+        <button
+          disabled={false}
+          type="button"
+        >
+          <span>
+            Button
+          </span>
+        </button>
+        <a
+          href="https://gatsbyjs.com"
+          rel=" noopener noreferrer"
+          role="button"
+          target="_blank"
+        >
+          <span>
+            &lt;a&gt; tag
+          </span>
+        </a>
+        <a
+          LinkComponent={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "children": "Breadcrumb 1",
+                    "className": "css-nn640c",
+                    "onClick": undefined,
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": <UNDEFINED>
+                      Link
+                       
+                      <MdArrowForward />
+                    </UNDEFINED>,
+                    "className": "css-16iroc0-Link",
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": Array [
+                      <_default />,
+                      "General",
+                    ],
+                    "className": "css-1whqxin",
+                    "onClick": [Function],
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": "Site Details",
+                    "className": "css-1whqxin",
+                    "onClick": [Function],
+                    "to": "#",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": "Contributors",
+                    "className": "css-1whqxin",
+                    "onClick": [Function],
+                    "to": "#",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": "Environment Variables",
+                    "className": "css-1whqxin",
+                    "onClick": [Function],
+                    "to": "#",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": Array [
+                      false,
+                      "Integrations",
+                    ],
+                    "className": "css-1whqxin",
+                    "onClick": [Function],
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": Array [
+                      false,
+                      "Preview",
+                    ],
+                    "className": "css-1whqxin",
+                    "onClick": [Function],
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": Array [
+                      false,
+                      "Danger Zone",
+                    ],
+                    "className": "css-1whqxin",
+                    "onClick": [Function],
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": <Content
+                      DefaultIcon={[Function]}
+                      label={undefined}
+                    >
+                      Subscribe
+                    </Content>,
+                    "className": "css-1kidtzk-Button",
+                    "onClick": [Function],
+                    "role": "button",
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": <Content
+                      DefaultIcon={[Function]}
+                      label={undefined}
+                    >
+                      Contact sales
+                    </Content>,
+                    "className": "css-1kidtzk-Button",
+                    "onClick": [Function],
+                    "role": "button",
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": <Content
+                      DefaultIcon={[Function]}
+                      label={undefined}
+                    >
+                      Get started for free
+                    </Content>,
+                    "className": "css-1o2e1oz-Button",
+                    "role": "button",
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": <Content
+                      DefaultIcon={[Function]}
+                      label={undefined}
+                    >
+                      Pick
+                    </Content>,
+                    "className": "css-1w2nrqi-Button",
+                    "onClick": [Function],
+                    "role": "button",
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": <Content
+                      DefaultIcon={false}
+                      label={undefined}
+                    >
+                      <MdHelpOutline />
+                    </Content>,
+                    "className": "css-1tdli1t-Button",
+                    "role": "button",
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": <Content
+                      DefaultIcon={false}
+                      label={undefined}
+                    >
+                      <MdHelpOutline />
+                    </Content>,
+                    "className": "css-1tdli1t-Button",
+                    "role": "button",
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "children": <Content
+                      DefaultIcon={false}
+                      label={undefined}
+                    >
+                      <MdHelpOutline />
+                    </Content>,
+                    "className": "css-1tdli1t-Button",
+                    "role": "button",
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+                Array [
+                  Object {
+                    "LinkComponent": [MockFunction] {
+                      "calls": [Circular],
+                    },
+                    "children": <Content
+                      DefaultIcon={undefined}
+                      label={undefined}
+                    >
+                      Gatsby &lt;Link&gt; component
+                    </Content>,
+                    "role": "button",
+                    "to": "/",
+                  },
+                  Object {},
+                ],
+              ],
+            }
+          }
+          href="/"
+          role="button"
+        >
+          <span>
+            Gatsby &lt;Link&gt; component
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/ContentBox 'toggle' (default) behaviour with a static button 1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div>
+        <div>
+          This is a PRIMARY content of this ContentBox
+        </div>
+        <button
+          onClick={[Function]}
+          tone="BRAND"
+        >
+          Toggle
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/ContentBox 'toggle' behaviour with buttons swap  1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div>
+        <div>
+          This is a PRIMARY content of this ContentBox
+          <button
+            onClick={[Function]}
+            tone="BRAND"
+          >
+            Show SECONDARY content
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/ContentBox 'unfold' behaviour with  a static button 1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div>
+        <div>
+          This is a PRIMARY content of this ContentBox
+        </div>
+        <button
+          onClick={[Function]}
+          tone="BRAND"
+        >
+          Toggle
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/ContentBox 'unfold' behaviour with buttons swap 1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div>
+        <div>
+          This is a PRIMARY content of this ContentBox
+        </div>
+        <button
+          onClick={[Function]}
+          tone="BRAND"
+        >
+          Unfold
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/ContentBox 'unfold' behaviour with no PRIMARY content 1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div>
+        <button
+          onClick={[Function]}
+          tone="BRAND"
+        >
+          Toggle
+        </button>
       </div>
     </div>
   </div>

--- a/__tests__/__snapshots__/icons.test.js.snap
+++ b/__tests__/__snapshots__/icons.test.js.snap
@@ -3,6 +3,7 @@
 exports[`icons <BlogIcon /> renders unchanged 1`] = `
 <div>
   <svg
+    aria-hidden="true"
     data-testid="icon-blog"
     fill="none"
     fill-rule="evenodd"
@@ -41,6 +42,7 @@ exports[`icons <BlogIcon /> renders unchanged 1`] = `
 exports[`icons <CheckIcon /> renders unchanged 1`] = `
 <div>
   <svg
+    aria-hidden="true"
     data-testid="icon-check"
     fill="currentColor"
     fill-rule="evenodd"
@@ -68,6 +70,7 @@ exports[`icons <CheckIcon /> renders unchanged 1`] = `
 exports[`icons <EcommerceIcon /> renders unchanged 1`] = `
 <div>
   <svg
+    aria-hidden="true"
     data-testid="icon-ecommerce"
     fill="none"
     fill-rule="evenodd"
@@ -116,6 +119,7 @@ exports[`icons <EcommerceIcon /> renders unchanged 1`] = `
 exports[`icons <PortfolioIcon /> renders unchanged 1`] = `
 <div>
   <svg
+    aria-hidden="true"
     data-testid="icon-portfolio"
     fill="none"
     fill-rule="evenodd"

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,9 @@ module.exports = {
     "^.+\\.jsx?$": `<rootDir>/jest-preprocess.js`,
   },
   moduleNameMapper: {
+    ".+prismCodeThemes.+\\.(css|styl|less|sass|scss)$": `<rootDir>/__mocks__/styleMock.js`,
     ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
-    ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/fileMock.js`,
+    ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|md)$": `<rootDir>/__mocks__/fileMock.js`,
   },
   testPathIgnorePatterns: [`node_modules`, `.cache`, `cypress`],
   transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],

--- a/src/components/Radio/Radio.stories.js
+++ b/src/components/Radio/Radio.stories.js
@@ -7,7 +7,7 @@ import Radio from "./Radio"
 import { StoryUtils } from "../../utils/storybook"
 
 function ControlledRadio({ name = `radioExample`, options = [] }) {
-  const [value, setValue] = React.useState()
+  const [value, setValue] = React.useState(``)
 
   const selectionStyle = radios(
     `selectionStyle`,

--- a/src/components/icons/icons.stories.js
+++ b/src/components/icons/icons.stories.js
@@ -70,7 +70,10 @@ const iconBlockCss = css`
   margin: 1rem 0;
 `
 
-const sortedIconComponentNames = Object.keys(icons).sort()
+const sortedIconComponentNames = Object.keys(icons)
+  // filter out __esModule
+  .filter(componentName => typeof icons[componentName] !== `boolean`)
+  .sort()
 
 storiesOf(`icons`, module)
   .addDecorator(withKnobs)
@@ -78,7 +81,7 @@ storiesOf(`icons`, module)
     <StoryUtils.Container>
       <div css={allIconsCss}>
         <h2>{sortedIconComponentNames.length} icon(s):</h2>
-        <div css={[iconBlockCss]}>
+        <div css={iconBlockCss}>
           {sortedIconComponentNames.map(componentName => {
             const Component = icons[componentName]
 
@@ -102,7 +105,7 @@ sortedIconComponentNames.forEach(componentName => {
 
     return (
       <StoryUtils.Container>
-        <div key={componentName} className={iconBlockCss}>
+        <div key={componentName} css={iconBlockCss}>
           <h1>{`<${componentName} />`}</h1>
           <h2>Size:</h2>
           {sizes.map(size => (


### PR DESCRIPTION
This PR fixes several issues that caused Storyshots tests to fail:
* We were importing fonts that are not part of this repo which by default broke Storybook; now `require` is used instead of `import` which allows us Storybook to keep running. In the future we could perhaps add an env variable `STORYBOOK_FONTS_PATH`?
* `storybook-readme` is importing its styles using `import A from "./prismCodeThemes/a11y-dark.css"` yet the actual file was `./prismCodeThemes/a11y-dark.css.js`. This resulted in our `moduleNameMapper ` setup not working properly. I've added another rule to that config to handle this case
* Two minor issues with icon stories would still allow Storybook to run but crashed storyshots tests. Fixed them as well. 