### PR TITLE
Add font info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 yarn storybook
 ```
 
-### Patterns and best practices for contributing
-
 These are some patterns and best practices we use when contributing to `gatsby-interface`
 
 - Use React hooks and functional components - https://reactjs.org/docs/hooks-intro.html
@@ -21,6 +19,12 @@ These are some patterns and best practices we use when contributing to `gatsby-i
 - Write Storybook stories for any component created - https://storybook.js.org/docs/basics/writing-stories/
 - Typscript coming soon!
 - Unit tests coming soon!
+
+### Required assets
+
+Gatsby Interface requires the `futura PT` webfont in several different weights. These files are git-ignored, to prevent the unauthorized release of licensed assets.
+
+Gatsby Inc. employees can download these fonts from [Google Drive](https://drive.google.com/drive/u/1/folders/1DA_iNzLbd1_gvU_FWTzYK6MgLSl85L4v). Put all those folders in `src/assets/futura-pt` and you should be good to go!
 
 ### Chromatic testing
 


### PR DESCRIPTION
Storybook requires a few fonts to run, but they're `.gitignore`d, since they're licensed. I uploaded those fonts to our (private) Google Drive, and added a blurb to the README about where to find them.