### PR TITLE
Open IntegrationRow links in a new tab

### DIFF
--- a/src/components/core/IntegrationRow/IntegrationRow.js
+++ b/src/components/core/IntegrationRow/IntegrationRow.js
@@ -190,7 +190,7 @@ function renderData(data = [], primaryStyling) {
           }}
         >
           {item.url ? (
-            <Link href={item.url}>
+            <Link href={item.url} target="_blank">
               {item.value}
               <MdLaunch />
             </Link>


### PR DESCRIPTION
Links in `IntegrationRow` should open in a new tab. Quick fix to make it so!

Relates to #4865 in `mansion`