### PR TITLE
chore: add "files" configuration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.46",
   "description": "Component library for Gatsby projects",
   "source": "src/index.js",
+  "files": [
+    "dist"
+  ],
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",


### PR DESCRIPTION
Fixes #75; note that I've only added `dist` folder since files like `package.json`, `README.md`, `CHANGELOG.md` etc [are always included](https://docs.npmjs.com/files/package.json#files) in the package.