### PR TITLE
fix: replace async/await with promises for CopyButton

### DIFF
--- a/src/components/CopyButton/CopyButton.tsx
+++ b/src/components/CopyButton/CopyButton.tsx
@@ -41,17 +41,18 @@ function CopyButton({
   const timeoutRef = React.useRef<number | undefined>(undefined)
   const [copied, setCopied] = React.useState<boolean>(false)
 
-  const copyOnClick: React.MouseEventHandler<HTMLButtonElement> = async e => {
+  const copyOnClick: React.MouseEventHandler<HTMLButtonElement> = e => {
     if (onClick) {
       onClick(e)
     }
-    await copyToClipboard(content)
 
-    setCopied(true)
+    copyToClipboard(content).then(() => {
+      setCopied(true)
 
-    timeoutRef.current = window.setTimeout(() => {
-      setCopied(false)
-    }, delay)
+      timeoutRef.current = window.setTimeout(() => {
+        setCopied(false)
+      }, delay)
+    })
   }
 
   React.useEffect(

--- a/src/utils/helpers/copyToClipboard.ts
+++ b/src/utils/helpers/copyToClipboard.ts
@@ -1,6 +1,6 @@
-export default function copyToClipboard(content: string) {
+export default function copyToClipboard(content: string): Promise<void> {
   if (!window || !window.navigator) {
-    return Promise.resolve(false)
+    return Promise.resolve()
   }
   const clipboard = window.navigator.clipboard
   /*
@@ -8,29 +8,36 @@ export default function copyToClipboard(content: string) {
    * if clipboard API not supported
    */
   if (!clipboard || typeof clipboard.writeText !== `function`) {
-    const textarea = document.createElement(`textarea`)
-    textarea.value = content
-    textarea.setAttribute(`readonly`, `true`)
-    textarea.setAttribute(`contenteditable`, `true`)
-    textarea.style.position = `absolute`
-    textarea.style.left = `-9999px`
-    document.body.appendChild(textarea)
-    textarea.select()
-    const range = document.createRange()
-    const sel = window.getSelection()
+    clipboardWriteTextFallback(content)
 
-    if (!sel) {
-      return Promise.resolve(false)
-    }
-
-    sel.removeAllRanges()
-    sel.addRange(range)
-    textarea.setSelectionRange(0, textarea.value.length)
-    document.execCommand(`copy`)
-    document.body.removeChild(textarea)
-
-    return Promise.resolve(true)
+    return Promise.resolve()
   }
 
   return clipboard.writeText(content)
+}
+
+function clipboardWriteTextFallback(content: string): void {
+  const textarea = document.createElement(`textarea`)
+  textarea.value = content
+  textarea.setAttribute(`readonly`, `true`)
+  textarea.setAttribute(`contenteditable`, `true`)
+  textarea.style.position = `absolute`
+  textarea.style.left = `-9999px`
+
+  document.body.appendChild(textarea)
+  textarea.select()
+
+  const range = document.createRange()
+  const sel = window.getSelection()
+
+  if (!sel) {
+    return
+  }
+
+  sel.removeAllRanges()
+  sel.addRange(range)
+  textarea.setSelectionRange(0, textarea.value.length)
+  document.execCommand(`copy`)
+
+  document.body.removeChild(textarea)
 }


### PR DESCRIPTION
Based on [this great suggestion](https://github.com/gatsby-inc/gatsby-interface/pull/80#pullrequestreview-305508964) from @joshwcomeau, replace `async/await` in `CopyButton` with promises. 

I've also extracted "copy" fallback functionality to its own function in `copyToClipboard` to make the main function cleaner.