### PR TITLE
Adding Portal

### DIFF
--- a/src/components/Portal/Portal.stories.tsx
+++ b/src/components/Portal/Portal.stories.tsx
@@ -17,7 +17,8 @@ const Toast = styled.div`
 
 storiesOf(`Portal`, module)
   .addDecorator(storyFn => (
-    <>`     `<Global
+    <div>
+      <Global
         styles={css`
           toast-container {
             position: fixed;
@@ -25,7 +26,9 @@ storiesOf(`Portal`, module)
             bottom: 0;
           }
         `}
-      />`     `{storyFn()}`   `</>
+      />
+      {storyFn()}
+    </div>
   ))
   .addParameters({
     options: {

--- a/src/components/Portal/Portal.stories.tsx
+++ b/src/components/Portal/Portal.stories.tsx
@@ -3,8 +3,30 @@ import { storiesOf } from "@storybook/react"
 import Portal from "./"
 import README from "./README.md"
 import { text } from "@storybook/addon-knobs"
+import styled from "@emotion/styled"
+import { Global, css } from "@emotion/core"
+
+const Toast = styled.div`
+  padding: 0.5rem 1rem;
+  border-radius: 3px;
+  border-radius: 3px;
+  color: white;
+  background: #272727;
+  margin: 0.2rem;
+`
 
 storiesOf(`Portal`, module)
+  .addDecorator(storyFn => (
+    <>`     `<Global
+        styles={css`
+          toast-container {
+            position: fixed;
+            right: 0;
+            bottom: 0;
+          }
+        `}
+      />`     `{storyFn()}`   `</>
+  ))
   .addParameters({
     options: {
       showPanel: true,
@@ -23,6 +45,14 @@ storiesOf(`Portal`, module)
       <div>This is the parent portal</div>
       <Portal>
         <div>This is the child portal</div>
+      </Portal>
+    </Portal>
+  ))
+  .add(`Same destination portal`, () => (
+    <Portal tag="toast-node" target="toast-container">
+      <Toast>Parent toast</Toast>
+      <Portal tag="toast-node" target="toast-container">
+        <Toast>Child toast</Toast>
       </Portal>
     </Portal>
   ))

--- a/src/components/Portal/Portal.stories.tsx
+++ b/src/components/Portal/Portal.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { storiesOf } from "@storybook/react"
+import Portal from "./"
+import README from "./README.md"
+import { text } from "@storybook/addon-knobs"
+
+storiesOf(`Portal`, module)
+  .addParameters({
+    options: {
+      showPanel: true,
+    },
+    readme: {
+      sidebar: README,
+    },
+  })
+  .add(`Default`, () => (
+    <Portal>
+      <div>This is portaled somewhere else</div>
+    </Portal>
+  ))
+  .add(`Nesting portal`, () => (
+    <Portal tag={text(`DOM element)`, `other-node`)}>
+      <div>This is the parent portal</div>
+      <Portal>
+        <div>This is the child portal</div>
+      </Portal>
+    </Portal>
+  ))

--- a/src/components/Portal/README.md
+++ b/src/components/Portal/README.md
@@ -1,0 +1,21 @@
+# Portal
+
+A component that allows to render components outside its parent hierarchy.
+
+## Usage
+
+```jsx
+const App = () => (
+    <Portal>
+        <div>Move me somewhere!</di>
+    </Portal>
+)
+```
+
+By default, this will render the children of the portal in a `gatsby-portal` node at the end of the actual body content. To rely on another name, you can rely on the `tag` prop: `<Portal tag="something-else"><div>Hello world</div></Portal>`.
+
+## Notes
+
+It seems that Reachui had some difficulties to be displayed on the DevTools because of the two different `document` used by a React app and React Devtools. Since I was able to display my Portals and there content in my Devtools, I didn't manage this behaviour.
+
+However, I think it could be good to keep it there in case somebody gets in trouble so that we have a workaround solution on this: https://github.com/reach/reach-ui/pull/137

--- a/src/components/Portal/README.md
+++ b/src/components/Portal/README.md
@@ -16,6 +16,6 @@ By default, this will render the children of the portal in a `gatsby-portal` nod
 
 ## Notes
 
-It seems that Reachui had some difficulties to be displayed on the DevTools because of the two different `document` used by a React app and React Devtools. Since I was able to display my Portals and there content in my Devtools, I didn't manage this behaviour.
+It seems that Reach UI had some difficulties to be displayed on the DevTools because of the two different `document` used by a React app and React Devtools. Since I was able to display my Portals and there content in my Devtools, I didn't manage this behaviour.
 
 However, I think it could be good to keep it there in case somebody gets in trouble so that we have a workaround solution on this: https://github.com/reach/reach-ui/pull/137

--- a/src/components/Portal/index.ts
+++ b/src/components/Portal/index.ts
@@ -5,6 +5,7 @@ export interface PortalProps {
   tag?: string
 }
 
+// Relying on a specific type extending HTMLElement allows to create custom HTML elements like <gatsby-portal></<gatsby-portal>
 interface GatsbyElement extends HTMLElement {}
 
 const Portal: React.FC<PortalProps> = ({ children, tag = `gatsby-portal` }) => {
@@ -19,7 +20,7 @@ const Portal: React.FC<PortalProps> = ({ children, tag = `gatsby-portal` }) => {
 
     return () =>
       portalNodeRef.current && document.body.removeChild(portalNodeRef.current)
-  }, [])
+  }, [tag])
 
   return hasInitialized && portalNodeRef.current
     ? createPortal(children, portalNodeRef.current)

--- a/src/components/Portal/index.ts
+++ b/src/components/Portal/index.ts
@@ -1,0 +1,29 @@
+import React, { useRef, useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+
+export interface PortalProps {
+  tag?: string
+}
+
+interface GatsbyElement extends HTMLElement {}
+
+const Portal: React.FC<PortalProps> = ({ children, tag = `gatsby-portal` }) => {
+  const portalNodeRef = useRef<GatsbyElement | undefined>(undefined)
+  const [hasInitialized, setHasInitialized] = useState(false)
+
+  useEffect(() => {
+    portalNodeRef.current = document.createElement(tag)
+    document.body.appendChild(portalNodeRef.current)
+
+    setHasInitialized(true)
+
+    return () =>
+      portalNodeRef.current && document.body.removeChild(portalNodeRef.current)
+  }, [])
+
+  return hasInitialized && portalNodeRef.current
+    ? createPortal(children, portalNodeRef.current)
+    : null
+}
+
+export default Portal


### PR DESCRIPTION
A component that allows to render components outside its parent hierarchy.

This goes directly under the discussion people had yesterday concerning creating opinionated accessible components and is necessary to create the declarative Modal component(s).

```jsx
const App = () => (
    <Portal>
        <div>Move me somewhere!</di>
    </Portal>
)
```

---

A note: It seems that Reachui had some difficulties to be displayed on the DevTools because of the two different `document` used by a React app and React Devtools. Since I was able to display my Portals and there content in my Devtools, I didn't manage this behaviour.

However, I think it could be good to keep it there in case somebody gets in trouble so that we have a workaround solution on this: https://github.com/reach/reach-ui/pull/137