### PR TITLE
Adding ConfirmationModal

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
@@ -1,0 +1,41 @@
+import React, { useRef } from "react"
+import { storiesOf } from "@storybook/react"
+import { ConfirmationModal } from "./ConfirmationModal"
+import { withKnobs, select, boolean } from "@storybook/addon-knobs"
+import { ModalType } from "../Modal/Modal"
+import {
+  ConfirmationModalLabel,
+  ConfirmationModalDescription,
+} from "./ConfirmationModalComponents"
+
+const label = `Type`
+const options = {
+  success: `success`,
+  info: `info`,
+  warn: `warn`,
+  error: `error`,
+}
+
+const ExampleConfirmationModal = () => {
+  const destructiveRef = useRef<HTMLButtonElement>(null)
+  return (
+    <ConfirmationModal
+      initialFocusRef={destructiveRef}
+      type={select(label, options, `info`) as ModalType}
+      isOpen={boolean(`Is opened?`, true)}
+      onDismiss={() => console.log(`Dismissed!`)}
+    >
+      <ConfirmationModalLabel>BE CAREFUL!</ConfirmationModalLabel>
+      <ConfirmationModalDescription>
+        You're about to make something complex!
+      </ConfirmationModalDescription>
+
+      <button>Confirmation</button>
+      <button ref={destructiveRef}>Destructive</button>
+    </ConfirmationModal>
+  )
+}
+
+storiesOf(`ConfirmationModal`, module)
+  .addDecorator(withKnobs)
+  .add(`default`, () => <ExampleConfirmationModal />)

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -1,0 +1,32 @@
+import React, { useRef } from "react"
+import ConfirmationModalContext from "./ConfirmationModalContext"
+import { Modal, ModalCard } from "../Modal"
+import { ModalProps } from "../Modal/Modal"
+
+export interface ConfirmationModalProps extends ModalProps {
+  prefixId?: string
+}
+
+let MODAL_IDS = 0
+export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
+  children,
+  prefixId = `gatsby-modal`,
+  ...props
+}) => {
+  const modalId = useRef<number>(MODAL_IDS++).current
+  const labelId = `${prefixId}-label-${modalId}`
+  const descriptionId = `${prefixId}-description-${modalId}`
+
+  return (
+    <ConfirmationModalContext.Provider value={{ labelId, descriptionId }}>
+      <Modal
+        {...props}
+        role="alertdialog"
+        aria-labelledby={labelId}
+        aria-describedby={descriptionId}
+      >
+        <ModalCard>{children}</ModalCard>
+      </Modal>
+    </ConfirmationModalContext.Provider>
+  )
+}

--- a/src/components/ConfirmationModal/ConfirmationModalComponents.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModalComponents.tsx
@@ -1,0 +1,22 @@
+import React, { useContext } from "react"
+import ConfirmationModalContext from "./ConfirmationModalContext"
+
+export interface ConfirmationModalDetailProps {
+  prefixId?: string
+}
+
+export const ConfirmationModalLabel: React.FC<ConfirmationModalDetailProps> = ({
+  ...props
+}) => {
+  const { labelId } = useContext(ConfirmationModalContext)
+
+  return <div id={labelId} {...props} />
+}
+
+export const ConfirmationModalDescription: React.FC<
+  ConfirmationModalDetailProps
+> = ({ prefixId = `gatsby-modal`, ...props }) => {
+  const { descriptionId } = useContext(ConfirmationModalContext)
+
+  return <div id={descriptionId} {...props} />
+}

--- a/src/components/ConfirmationModal/ConfirmationModalContext.ts
+++ b/src/components/ConfirmationModal/ConfirmationModalContext.ts
@@ -1,0 +1,11 @@
+import React from "react"
+
+export interface ConfirmationModalContext {
+  labelId: string
+  descriptionId: string
+}
+
+export default React.createContext<ConfirmationModalContext>({
+  labelId: "",
+  descriptionId: "",
+})

--- a/src/components/ConfirmationModal/index.ts
+++ b/src/components/ConfirmationModal/index.ts
@@ -1,0 +1,6 @@
+export { ConfirmationModal } from "./ConfirmationModal"
+export {
+  ConfirmationModalLabel,
+  ConfirmationModalDescription,
+  ConfirmationModalDetailProps,
+} from "./ConfirmationModalComponents"


### PR DESCRIPTION
Adding a ConfirmationModal which is basically a modal card with confirmation / cancelation. Widely inspired by the reach-ui one.

```jsx
 <ConfirmationModal
      initialFocusRef={destructiveRef}
      type="info"
      isOpen={true}
      onDismiss={handleDismiss)}
    >
      <ConfirmationModalLabel>BE CAREFUL!</ConfirmationModalLabel>
      <ConfirmationModalDescription>
        You're about to make something complex!
      </ConfirmationModalDescription>

      <button>Confirmation</button>
      <button ref={destructiveRef}>Destructive</button>
    </ConfirmationModal>
```

---

I'm wondering if `ConfirmationModalLabel` and `ConfirmationModalDescription` shouldn't be part of the `Modal` component and thus can be used elsewhere than only in the `ConfirmationModal` 🤔 which would imply that the ConfirmationModal will only be a Modal with a card inside. Do you have an opinion about it?