### PR TITLE
Adding z-index on modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -47,6 +47,7 @@ const getBackgroundAnimation = (type?: ModalType) => {
 const Overlay = styled(DialogOverlay)<
   DialogOverlayProps & { animation: ReturnType<typeof buildFadeIn> }
 >`
+  z-index: 9999;
   animation: ${props => props.animation} 0.5s ease forwards;
 `
 


### PR DESCRIPTION
Just adding some z-index because the tab title "Organization" in gatsbyjs.com was showing over the modal content 😅 