### PR TITLE
Fixing link instead of button in setting blocks

### DIFF
--- a/src/components/core/SettingsBlock/SettingsBlock.js
+++ b/src/components/core/SettingsBlock/SettingsBlock.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types"
 import { MdHelpOutline } from "react-icons/md"
 
 import { ContentBox } from "../../skeletons/ContentBox"
-import { Button } from "../Button"
+import { LinkButton } from "../LinkButton"
 import { Heading } from "../Heading"
 import { breakpoints, fontFamilies, spaces } from "../../../utils/presets"
 import cardStyles from "../../../theme/styles/card"
@@ -76,7 +76,7 @@ SettingsBlock.Title = ({ children, ...rest }) => (
 )
 
 SettingsBlock.Doclink = ({ ...rest }) => (
-  <Button
+  <LinkButton
     variant={`GHOST`}
     tone={`NEUTRAL`}
     css={{
@@ -85,7 +85,7 @@ SettingsBlock.Doclink = ({ ...rest }) => (
     {...rest}
   >
     <MdHelpOutline />
-  </Button>
+  </LinkButton>
 )
 
 SettingsBlock.Description = ({ children, ...rest }) => (

--- a/src/components/core/SettingsBlock/SettingsBlock.stories.js
+++ b/src/components/core/SettingsBlock/SettingsBlock.stories.js
@@ -17,7 +17,7 @@ storiesOf(`core/SettingsBlock`, module)
           <SettingsBlock.Header>
             <SettingsBlock.Title>
               Automated Integrations
-              <SettingsBlock.Doclink to="/" />
+              <SettingsBlock.Doclink to="/some-where" />
             </SettingsBlock.Title>
           </SettingsBlock.Header>
           <SettingsBlock.Content>


### PR DESCRIPTION
Related to this mansion https://github.com/gatsby-inc/mansion/issues/5565 .

Looks like we're passing a `to` prop to a `Button` instead of a link so that we can't naviguate between pages 😅 