### PR TITLE
chore: fix snapshot testing

### DIFF
--- a/__tests__/Button.js
+++ b/__tests__/Button.js
@@ -1,13 +1,11 @@
 import React from "react"
-import { render, fireEvent } from "react-testing-library"
+import { render } from "@testing-library/react"
 
 import { PrimaryButton } from "../src/components/core/Button"
 
 describe(`<PrimaryButton>`, () => {
   test(`renders unchanged`, async () => {
-    const { container, debug } = render(
-      <PrimaryButton>Click me!</PrimaryButton>
-    )
+    const { container } = render(<PrimaryButton>Click me!</PrimaryButton>)
 
     expect(container).toMatchSnapshot()
   })

--- a/__tests__/Storyshots.test.js
+++ b/__tests__/Storyshots.test.js
@@ -1,5 +1,15 @@
 import initStoryshots from "@storybook/addon-storyshots"
+import { render } from "@testing-library/react"
 
 initStoryshots({
   configPath: `.storybook`,
+  renderer: (storyElement, rendererOptions) => {
+    const { container } = render(storyElement, rendererOptions)
+    return container
+  },
+  /**
+   * We have to exclude DecorativeDots from snapshots since they are always rendered in a differnet way,
+   * which makes snapshot testing useless
+   */
+  storyKindRegex: /^((?!.*?DecorativeDots).)*$/,
 })

--- a/__tests__/Toast.js
+++ b/__tests__/Toast.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, fireEvent, act } from "react-testing-library"
+import { render, fireEvent, act } from "@testing-library/react"
 
 import {
   ToastProvider,
@@ -246,7 +246,7 @@ describe(`useShowErrorAlert hook`, () => {
       )
     }
 
-    const { getByText, debug } = render(
+    const { getByText } = render(
       <ToastProvider>
         <TestComponent />
       </ToastProvider>

--- a/__tests__/__snapshots__/Button.js.snap
+++ b/__tests__/__snapshots__/Button.js.snap
@@ -62,14 +62,6 @@ exports[`<PrimaryButton> renders unchanged 1`] = `
   transform: scale(1);
 }
 
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-0:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -85,9 +77,7 @@ exports[`<PrimaryButton> renders unchanged 1`] = `
     class="emotion-0"
     type="button"
   >
-    <span>
-      Click me!
-    </span>
+    Click me!
   </button>
 </div>
 `;

--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -93,60 +93,182 @@ exports[`Storyshots Breadcrumb default 1`] = `
   vertical-align: middle;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-4"
-      >
-        <nav
-          aria-label="breadcrumb"
-          className="emotion-3"
+      <div>
+        <div
+          class="emotion-4"
         >
-          <div
-            className="emotion-1"
+          <nav
+            aria-label="breadcrumb"
+            class="emotion-3"
           >
-            <a
-              className="emotion-0"
-              href="/"
-              onClick={undefined}
+            <div
+              class="emotion-1"
             >
-              Breadcrumb 1
-            </a>
-            <svg
-              fill="none"
-              height="9"
-              viewBox="0 0 6 9"
-              width="6"
+              <a
+                aria-current="page"
+                class="emotion-0"
+                href="/"
+              >
+                Breadcrumb 1
+              </a>
+              <svg
+                fill="none"
+                height="9"
+                viewBox="0 0 6 9"
+                width="6"
+              >
+                <path
+                  d="M6 4.5L1.5 8.39711L1.5 0.602886L6 4.5Z"
+                  fill="#7F7C82"
+                />
+              </svg>
+            </div>
+            <div
+              class="emotion-2"
             >
-              <path
-                d="M6 4.5L1.5 8.39711L1.5 0.602886L6 4.5Z"
-                fill="#7F7C82"
-              />
-            </svg>
-          </div>
-          <div
-            className="emotion-2"
+              Breadcrumb 2
+               
+              <svg
+                fill="none"
+                height="9"
+                viewBox="0 0 6 9"
+                width="6"
+              >
+                <path
+                  d="M6 4.5L1.5 8.39711L1.5 0.602886L6 4.5Z"
+                  fill="#7F7C82"
+                />
+              </svg>
+            </div>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots CopyButton Default 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f1defa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 0.875rem;
+  min-height: 1.6rem;
+  padding: 0.3rem 0.5rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  border-color: #663399;
+  color: #663399;
+}
+
+html:not([dir="rtl"]) .emotion-0 {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+html[dir="rtl"] .emotion-0 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-1"
+        >
+          <button
+            class="emotion-0"
+            title="Copy content"
+            type="button"
           >
-            Breadcrumb 2
-             
-            <svg
-              fill="none"
-              height="9"
-              viewBox="0 0 6 9"
-              width="6"
-            >
-              <path
-                d="M6 4.5L1.5 8.39711L1.5 0.602886L6 4.5Z"
-                fill="#7F7C82"
-              />
-            </svg>
-          </div>
-        </nav>
+            Copy
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -172,19 +294,19 @@ exports[`Storyshots File Upload File Upload with Custom Components 1`] = `
   padding: 20px;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-0"
-      >
-        <p>
-          Using the FileUpload component without setting the GATSBY_FILESTACK_API_KEY will fail
-        </p>
+      <div>
+        <div
+          class="emotion-0"
+        >
+          <p>
+            Using the FileUpload component without setting the GATSBY_FILESTACK_API_KEY will fail
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -210,19 +332,19 @@ exports[`Storyshots File Upload Multi File Upload 1`] = `
   padding: 20px;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-0"
-      >
-        <p>
-          Using the FileUpload component without setting the GATSBY_FILESTACK_API_KEY will fail
-        </p>
+      <div>
+        <div
+          class="emotion-0"
+        >
+          <p>
+            Using the FileUpload component without setting the GATSBY_FILESTACK_API_KEY will fail
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -248,19 +370,19 @@ exports[`Storyshots File Upload Single File Upload 1`] = `
   padding: 20px;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-0"
-      >
-        <p>
-          Using the FileUpload component without setting the GATSBY_FILESTACK_API_KEY will fail
-        </p>
+      <div>
+        <div
+          class="emotion-0"
+        >
+          <p>
+            Using the FileUpload component without setting the GATSBY_FILESTACK_API_KEY will fail
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -268,24 +390,84 @@ exports[`Storyshots File Upload Single File Upload 1`] = `
 `;
 
 exports[`Storyshots Introduction/ Welcome to Gatsby Inteface 1`] = `
-<div
-  className="storybook-readme-story"
->
-  <div>
-    <div
-      className="markdown-body"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<p>test-file-stub</p>
-",
-        }
-      }
-    />
-  </div>
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
-    <div />
+    <div>
+      <div
+        class="markdown-body"
+      >
+        <p>
+          test-file-stub
+        </p>
+        
+
+      </div>
+    </div>
+    <div>
+      <div />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Modal Card 1`] = `
+<div
+  aria-hidden="true"
+>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Modal Fullscreen 1`] = `
+<div
+  aria-hidden="true"
+>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Modal Nesting modal 1`] = `
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div>
+          <button>
+            Show parent
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Modal Panel 1`] = `
+<div
+  aria-hidden="true"
+>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div />
+    </div>
   </div>
 </div>
 `;
@@ -305,7 +487,21 @@ exports[`Storyshots Notification default 1`] = `
   }
 }
 
-.emotion-9 {
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -323,7 +519,7 @@ exports[`Storyshots Notification default 1`] = `
   padding: 20px;
 }
 
-.emotion-8 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -338,11 +534,11 @@ exports[`Storyshots Notification default 1`] = `
   width: 500px;
 }
 
-.emotion-8 > button {
+.emotion-7 > button {
   margin: 20px;
 }
 
-.emotion-2 {
+.emotion-1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -367,7 +563,7 @@ exports[`Storyshots Notification default 1`] = `
 }
 
 @media (min-width:1000px) {
-  .emotion-2 {
+  .emotion-1 {
     padding: 1rem 1.5rem 1rem 1rem;
   }
 }
@@ -388,28 +584,7 @@ exports[`Storyshots Notification default 1`] = `
   margin-right: 0.5rem;
 }
 
-.emotion-1 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #663399;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-1:focus,
-.emotion-1:hover {
-  color: #663399;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-5 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -435,12 +610,12 @@ exports[`Storyshots Notification default 1`] = `
 }
 
 @media (min-width:1000px) {
-  .emotion-5 {
+  .emotion-4 {
     padding: 1rem 1.5rem 1rem 1rem;
   }
 }
 
-.emotion-4 {
+.emotion-3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -473,13 +648,13 @@ exports[`Storyshots Notification default 1`] = `
   width: 1rem;
 }
 
-.emotion-4[disabled],
-.emotion-4[disabled]:hover {
+.emotion-3[disabled],
+.emotion-3[disabled]:hover {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-.emotion-4 svg {
+.emotion-3 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -489,29 +664,21 @@ exports[`Storyshots Notification default 1`] = `
   transform: scale(1);
 }
 
-.emotion-4 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-4 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-4:hover:not([disabled]) svg {
+.emotion-3:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
 }
 
-.emotion-4:hover {
+.emotion-3:hover {
   background: #fcfaff;
   color: #663399;
 }
 
-.emotion-4 svg {
+.emotion-3 svg {
   fill: #b7b5bd;
 }
 
-.emotion-7 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -530,104 +697,133 @@ exports[`Storyshots Notification default 1`] = `
 }
 
 @media (min-width:1000px) {
-  .emotion-7 {
+  .emotion-6 {
     padding: 1.5rem 2.5rem;
   }
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-9"
-      >
+      <div>
         <div
-          className="emotion-8"
+          class="emotion-8"
         >
           <div
-            className="emotion-2"
+            class="emotion-7"
           >
-            <span
-              className="emotion-0"
+            <div
+              class="emotion-1"
             >
-              Notification variant 'PRIMARY'
-            </span>
-            <a
-              className="emotion-1"
-              href="/"
-            >
-              Link
-               
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                class="emotion-0"
               >
-                <path
-                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-                />
-              </svg>
-            </a>
-          </div>
-          <div
-            className="emotion-5"
-          >
-            <span
-              className="emotion-0"
-            >
-              Notification variant 'PRIMARY' with close
-            </span>
-            <button
-              className="emotion-4"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+                Notification variant 'PRIMARY'
+              </span>
+              <a
+                aria-current="page"
+                class=""
+                href="/"
               >
-                <path
-                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                />
-              </svg>
-            </button>
-          </div>
-          <section
-            className="emotion-7"
-          >
-            <span
-              className="emotion-0"
+                Link
+                 
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                  />
+                </svg>
+              </a>
+            </div>
+            <div
+              class="emotion-4"
             >
-              Notification variant 'SECONDARY'
-            </span>
-          </section>
+              <span
+                class="emotion-0"
+              >
+                Notification variant 'PRIMARY' with close
+              </span>
+              <button
+                class="emotion-3"
+                type="button"
+              >
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <section
+              class="emotion-6"
+            >
+              <span
+                class="emotion-0"
+              >
+                Notification variant 'SECONDARY'
+              </span>
+            </section>
+          </div>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Portal Default 1`] = `
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Portal Nesting portal 1`] = `
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Portal Same destination portal 1`] = `
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div />
       </div>
     </div>
   </div>
@@ -667,7 +863,6 @@ exports[`Storyshots Radio Default 1`] = `
   opacity: 0;
   position: absolute;
   width: 22px;
-  z-index: 2;
 }
 
 .emotion-0:checked + label::before {
@@ -760,74 +955,68 @@ exports[`Storyshots Radio Default 1`] = `
   left: calc(1rem + 7px);
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-18"
-      >
-        <div>
+      <div>
+        <div
+          class="emotion-18"
+        >
           <div>
-            <div
-              className=" undefined emotion-4 emotion-5"
-            >
-              <input
-                checked={false}
-                className="emotion-0 emotion-1"
-                id="option-1"
-                name="radioExample"
-                onChange={[Function]}
-                type="radio"
-                value="1"
-              />
-              <label
-                className="standard emotion-2 emotion-3"
-                htmlFor="option-1"
+            <div>
+              <div
+                class=" undefined emotion-4 emotion-5"
               >
-                Option 1
-              </label>
-            </div>
-            <div
-              className=" undefined emotion-4 emotion-5"
-            >
-              <input
-                checked={false}
-                className="emotion-0 emotion-1"
-                id="option-2"
-                name="radioExample"
-                onChange={[Function]}
-                type="radio"
-                value="2"
-              />
-              <label
-                className="standard emotion-2 emotion-3"
-                htmlFor="option-2"
+                <input
+                  class="emotion-0 emotion-1"
+                  id="option-1"
+                  name="radioExample"
+                  type="radio"
+                  value="1"
+                />
+                <label
+                  class="standard emotion-2 emotion-3"
+                  for="option-1"
+                >
+                  Option 1
+                </label>
+              </div>
+              <div
+                class=" undefined emotion-4 emotion-5"
               >
-                Option 2
-              </label>
-            </div>
-            <div
-              className=" undefined emotion-4 emotion-5"
-            >
-              <input
-                checked={false}
-                className="emotion-0 emotion-1"
-                id="option-3"
-                name="radioExample"
-                onChange={[Function]}
-                type="radio"
-                value="3"
-              />
-              <label
-                className="standard emotion-2 emotion-3"
-                htmlFor="option-3"
+                <input
+                  class="emotion-0 emotion-1"
+                  id="option-2"
+                  name="radioExample"
+                  type="radio"
+                  value="2"
+                />
+                <label
+                  class="standard emotion-2 emotion-3"
+                  for="option-2"
+                >
+                  Option 2
+                </label>
+              </div>
+              <div
+                class=" undefined emotion-4 emotion-5"
               >
-                Option 3
-              </label>
+                <input
+                  class="emotion-0 emotion-1"
+                  id="option-3"
+                  name="radioExample"
+                  type="radio"
+                  value="3"
+                />
+                <label
+                  class="standard emotion-2 emotion-3"
+                  for="option-3"
+                >
+                  Option 3
+                </label>
+              </div>
             </div>
           </div>
         </div>
@@ -870,7 +1059,6 @@ exports[`Storyshots Radio ReactNode as label 1`] = `
   opacity: 0;
   position: absolute;
   width: 22px;
-  z-index: 2;
 }
 
 .emotion-0:checked + label::before {
@@ -963,69 +1151,65 @@ exports[`Storyshots Radio ReactNode as label 1`] = `
   left: calc(1rem + 7px);
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-12"
-      >
-        <div>
+      <div>
+        <div
+          class="emotion-12"
+        >
           <div>
-            <div
-              className=" undefined emotion-4 emotion-5"
-            >
-              <input
-                checked={false}
-                className="emotion-0 emotion-1"
-                id="option-1"
-                name="radioExample"
-                onChange={[Function]}
-                type="radio"
-                value="1"
-              />
-              <label
-                className="standard emotion-2 emotion-3"
-                htmlFor="option-1"
+            <div>
+              <div
+                class=" undefined emotion-4 emotion-5"
               >
-                <div>
-                  <strong>
-                    English
-                  </strong>
-                  <p>
-                    Warszaw is the capital of Poland
-                  </p>
-                </div>
-              </label>
-            </div>
-            <div
-              className=" undefined emotion-4 emotion-5"
-            >
-              <input
-                checked={false}
-                className="emotion-0 emotion-1"
-                id="option-2"
-                name="radioExample"
-                onChange={[Function]}
-                type="radio"
-                value="2"
-              />
-              <label
-                className="standard emotion-2 emotion-3"
-                htmlFor="option-2"
+                <input
+                  class="emotion-0 emotion-1"
+                  id="option-1"
+                  name="radioExample"
+                  type="radio"
+                  value="1"
+                />
+                <label
+                  class="standard emotion-2 emotion-3"
+                  for="option-1"
+                >
+                  <div>
+                    <strong>
+                      English
+                    </strong>
+                    <p>
+                      Warszaw is the capital of Poland
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                class=" undefined emotion-4 emotion-5"
               >
-                <div>
-                  <strong>
-                    Polish
-                  </strong>
-                  <p>
-                    Warszawa to stolica Polski
-                  </p>
-                </div>
-              </label>
+                <input
+                  class="emotion-0 emotion-1"
+                  id="option-2"
+                  name="radioExample"
+                  type="radio"
+                  value="2"
+                />
+                <label
+                  class="standard emotion-2 emotion-3"
+                  for="option-2"
+                >
+                  <div>
+                    <strong>
+                      Polish
+                    </strong>
+                    <p>
+                      Warszawa to stolica Polski
+                    </p>
+                  </div>
+                </label>
+              </div>
             </div>
           </div>
         </div>
@@ -1068,7 +1252,6 @@ exports[`Storyshots Radio dangerouslySetInnerHtml as label 1`] = `
   opacity: 0;
   position: absolute;
   width: 22px;
-  z-index: 2;
 }
 
 .emotion-0:checked + label::before {
@@ -1161,67 +1344,65 @@ exports[`Storyshots Radio dangerouslySetInnerHtml as label 1`] = `
   left: calc(1rem + 7px);
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-12"
-      >
-        <div>
+      <div>
+        <div
+          class="emotion-12"
+        >
           <div>
-            <div
-              className=" undefined emotion-4 emotion-5"
-            >
-              <input
-                checked={false}
-                className="emotion-0 emotion-1"
-                id="option-1"
-                name="radioExample"
-                onChange={[Function]}
-                type="radio"
-                value="1"
-              />
-              <label
-                className="standard emotion-2 emotion-3"
-                htmlFor="option-1"
+            <div>
+              <div
+                class=" undefined emotion-4 emotion-5"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<strong>English</strong><p>Warszaw is the capital of Poland</p>",
-                    }
-                  }
+                <input
+                  class="emotion-0 emotion-1"
+                  id="option-1"
+                  name="radioExample"
+                  type="radio"
+                  value="1"
                 />
-              </label>
-            </div>
-            <div
-              className=" undefined emotion-4 emotion-5"
-            >
-              <input
-                checked={false}
-                className="emotion-0 emotion-1"
-                id="option-2"
-                name="radioExample"
-                onChange={[Function]}
-                type="radio"
-                value="2"
-              />
-              <label
-                className="standard emotion-2 emotion-3"
-                htmlFor="option-2"
+                <label
+                  class="standard emotion-2 emotion-3"
+                  for="option-1"
+                >
+                  <div>
+                    <strong>
+                      English
+                    </strong>
+                    <p>
+                      Warszaw is the capital of Poland
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                class=" undefined emotion-4 emotion-5"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<strong>Polish</strong><p>Warszawa to stolica Polski</p>",
-                    }
-                  }
+                <input
+                  class="emotion-0 emotion-1"
+                  id="option-2"
+                  name="radioExample"
+                  type="radio"
+                  value="2"
                 />
-              </label>
+                <label
+                  class="standard emotion-2 emotion-3"
+                  for="option-2"
+                >
+                  <div>
+                    <strong>
+                      Polish
+                    </strong>
+                    <p>
+                      Warszawa to stolica Polski
+                    </p>
+                  </div>
+                </label>
+              </div>
             </div>
           </div>
         </div>
@@ -1357,154 +1538,152 @@ exports[`Storyshots SidebarNav usage example 1`] = `
   left: -2rem;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-17"
-      >
-        <nav
-          aria-label="sidebar-nav"
-          className="emotion-16"
+      <div>
+        <div
+          class="emotion-17"
         >
-          <ul
-            className="emotion-15"
+          <nav
+            aria-label="sidebar-nav"
+            class="emotion-16"
+            style="display: flex; justify-content: center; align-items: center; padding-left: 2rem;"
           >
-            <li
-              className="emotion-1"
-            >
-              <a
-                className="emotion-0"
-                href="/"
-                onClick={[Function]}
-              >
-                <svg
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="12"
-                    cy="4"
-                    fill="#B17ACC"
-                    r="1"
-                    transform="rotate(90 12 4)"
-                  />
-                  <circle
-                    cx="12"
-                    cy="12"
-                    fill="#8954A8"
-                    r="4"
-                    transform="rotate(45 12 12)"
-                  />
-                  <circle
-                    cx="4"
-                    cy="12"
-                    fill="#232129"
-                    r="1"
-                    transform="rotate(90 4 12)"
-                  />
-                  <circle
-                    cx="6.34302"
-                    cy="6.34317"
-                    fill="#232129"
-                    r="1"
-                    transform="rotate(45 6.34302 6.34317)"
-                  />
-                  <circle
-                    cx="6.34302"
-                    cy="17.6568"
-                    fill="#B17ACC"
-                    r="1"
-                    transform="rotate(45 6.34302 17.6568)"
-                  />
-                  <path
-                    d="M12 3.99994C16.4183 3.99994 20 7.58166 20 11.9999C20 16.4182 16.4183 19.9999 12 19.9999C9.86958 19.9999 7.93366 19.1672 6.5 17.8094"
-                    stroke="#B17ACC"
-                  />
-                </svg>
-                General
-              </a>
-            </li>
             <ul
-              className="emotion-8"
+              class="emotion-15"
             >
               <li
-                className="emotion-3"
+                class="emotion-1"
               >
                 <a
-                  className="emotion-0"
-                  href="#"
-                  onClick={[Function]}
+                  aria-current="page"
+                  class="emotion-0"
+                  href="/"
                 >
-                  Site Details
+                  <svg
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      cx="12"
+                      cy="4"
+                      fill="#B17ACC"
+                      r="1"
+                      transform="rotate(90 12 4)"
+                    />
+                    <circle
+                      cx="12"
+                      cy="12"
+                      fill="#8954A8"
+                      r="4"
+                      transform="rotate(45 12 12)"
+                    />
+                    <circle
+                      cx="4"
+                      cy="12"
+                      fill="#232129"
+                      r="1"
+                      transform="rotate(90 4 12)"
+                    />
+                    <circle
+                      cx="6.34302"
+                      cy="6.34317"
+                      fill="#232129"
+                      r="1"
+                      transform="rotate(45 6.34302 6.34317)"
+                    />
+                    <circle
+                      cx="6.34302"
+                      cy="17.6568"
+                      fill="#B17ACC"
+                      r="1"
+                      transform="rotate(45 6.34302 17.6568)"
+                    />
+                    <path
+                      d="M12 3.99994C16.4183 3.99994 20 7.58166 20 11.9999C20 16.4182 16.4183 19.9999 12 19.9999C9.86958 19.9999 7.93366 19.1672 6.5 17.8094"
+                      stroke="#B17ACC"
+                    />
+                  </svg>
+                  General
+                </a>
+              </li>
+              <ul
+                class="emotion-8"
+              >
+                <li
+                  class="emotion-3"
+                >
+                  <a
+                    class="emotion-0"
+                    href="/#"
+                  >
+                    Site Details
+                  </a>
+                </li>
+                <li
+                  class="emotion-5"
+                >
+                  <a
+                    class="emotion-0"
+                    href="/#"
+                  >
+                    Contributors
+                  </a>
+                </li>
+                <li
+                  class="emotion-5"
+                >
+                  <a
+                    class="emotion-0"
+                    href="/#"
+                  >
+                    Environment Variables
+                  </a>
+                </li>
+              </ul>
+              <li
+                class="emotion-10"
+              >
+                <a
+                  aria-current="page"
+                  class="emotion-0"
+                  href="/"
+                >
+                  Integrations
                 </a>
               </li>
               <li
-                className="emotion-5"
+                class="emotion-10"
               >
                 <a
-                  className="emotion-0"
-                  href="#"
-                  onClick={[Function]}
+                  aria-current="page"
+                  class="emotion-0"
+                  href="/"
                 >
-                  Contributors
+                  Preview
                 </a>
               </li>
               <li
-                className="emotion-5"
+                class="emotion-10"
               >
                 <a
-                  className="emotion-0"
-                  href="#"
-                  onClick={[Function]}
+                  aria-current="page"
+                  class="emotion-0"
+                  href="/"
                 >
-                  Environment Variables
+                  Danger Zone
                 </a>
               </li>
             </ul>
-            <li
-              className="emotion-10"
-            >
-              <a
-                className="emotion-0"
-                href="/"
-                onClick={[Function]}
-              >
-                Integrations
-              </a>
-            </li>
-            <li
-              className="emotion-10"
-            >
-              <a
-                className="emotion-0"
-                href="/"
-                onClick={[Function]}
-              >
-                Preview
-              </a>
-            </li>
-            <li
-              className="emotion-10"
-            >
-              <a
-                className="emotion-0"
-                href="/"
-                onClick={[Function]}
-              >
-                Danger Zone
-              </a>
-            </li>
-          </ul>
-          <div />
-        </nav>
+            <div />
+          </nav>
+        </div>
       </div>
     </div>
   </div>
@@ -1548,26 +1727,22 @@ exports[`Storyshots TextInput Default 1`] = `
   transition: box-shadow 0.15s ease-in-out;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-1"
-      >
-        <input
-          className="emotion-0"
-          defaultValue={undefined}
-          disabled={false}
-          id={undefined}
-          onChange={undefined}
-          placeholder="Placeholder text"
-          type="text"
-          value={undefined}
-        />
+      <div>
+        <div
+          class="emotion-1"
+        >
+          <input
+            class="emotion-0"
+            placeholder="Placeholder text"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1603,6 +1778,20 @@ exports[`Storyshots Toast Default 1`] = `
   }
 }
 
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 .emotion-6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1672,14 +1861,6 @@ exports[`Storyshots Toast Default 1`] = `
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
-}
-
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
 }
 
 .emotion-0:hover:not([disabled]) svg {
@@ -1711,377 +1892,48 @@ exports[`Storyshots Toast Default 1`] = `
   -ms-transform: translate(-50%,0);
   transform: translate(-50%,0);
   width: 100%;
-  z-index: 1;
+  z-index: 100;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-6"
-      >
+      <div>
         <div
-          className="emotion-5"
+          class="emotion-6"
         >
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
+          <div
+            class="emotion-5"
           >
-            <span>
+            <button
+              class="emotion-0"
+              type="button"
+            >
               Show toast
-            </span>
-          </button>
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
+            </button>
+            <button
+              class="emotion-0"
+              type="button"
+            >
               Show toast without auto hide
-            </span>
-          </button>
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
+            </button>
+            <button
+              class="emotion-0"
+              type="button"
+            >
               Show error toast
-            </span>
-          </button>
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
+            </button>
+            <button
+              class="emotion-0"
+              type="button"
+            >
               Show error alert
-            </span>
-          </button>
-          <div
-            className="emotion-4"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots core/Announcement default usage 1`] = `
-.emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 100vh;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 100%;
-  padding: 20px;
-}
-
-.emotion-1 {
-  display: grid;
-  justify-items: start;
-  grid-gap: 2rem;
-}
-
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #f7ffff;
-  color: #008577;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 0.875rem;
-  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  padding: 1rem 2.5rem;
-  background-image: url(test-file-stub);
-  background-position: right center;
-  background-repeat: no-repeat;
-}
-
-.emotion-0:not(:first-child) {
-  border-top: 1px solid #dcfffd;
-}
-
-<div
-  className="storybook-readme-story"
->
-  <div
-    style={Object {}}
-  >
-    <div>
-      <div
-        className="emotion-2"
-      >
-        <div
-          className="emotion-1"
-        >
-          <div
-            className="emotion-0"
-          >
-            We are working on adding more integrations all the time—watch your inbox!
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots core/Badge shortcut usage 1`] = `
-.emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 100vh;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 100%;
-  padding: 20px;
-}
-
-.emotion-1 {
-  display: grid;
-  justify-items: start;
-  grid-gap: 2rem;
-}
-
-.emotion-0 {
-  border-radius: 4px;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  font-weight: bold;
-  line-height: 1;
-  background: #37b635;
-  color: #ffffff;
-  font-size: 13px;
-  -webkit-letter-spacing: 0.05em;
-  -moz-letter-spacing: 0.05em;
-  -ms-letter-spacing: 0.05em;
-  letter-spacing: 0.05em;
-  padding: 4px 5px 2px;
-  text-transform: uppercase;
-}
-
-<div
-  className="storybook-readme-story"
->
-  <div
-    style={Object {}}
-  >
-    <div>
-      <div
-        className="emotion-2"
-      >
-        <div
-          className="emotion-1"
-        >
-          <span
-            className="emotion-0"
-          >
-            New
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots core/Badge variants 1`] = `
-.emotion-5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 100vh;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 100%;
-  padding: 20px;
-}
-
-.emotion-4 {
-  display: grid;
-  justify-items: start;
-  grid-gap: 2rem;
-}
-
-.emotion-0 {
-  border-radius: 4px;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  font-weight: bold;
-  line-height: 1;
-  background: #37b635;
-  color: #ffffff;
-  font-size: 13px;
-  -webkit-letter-spacing: 0.05em;
-  -moz-letter-spacing: 0.05em;
-  -ms-letter-spacing: 0.05em;
-  letter-spacing: 0.05em;
-  padding: 4px 5px 2px;
-  text-transform: uppercase;
-}
-
-.emotion-3 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-1 {
-  border-radius: 4px;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  font-weight: bold;
-  line-height: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #f7fdf7;
-  color: #37b635;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: 1rem;
-  padding: 0.5rem 0.75rem;
-}
-
-.emotion-1 svg:last-child {
-  margin-left: 0.25rem;
-}
-
-.emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #eee;
-  color: green;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: .9rem;
-  font-weight: normal;
-  margin-left: 2em;
-  padding: .3em .6em;
-  vertical-align: text-bottom;
-}
-
-.emotion-2 svg {
-  margin-right: 0.2em;
-}
-
-<div
-  className="storybook-readme-story"
->
-  <div
-    style={Object {}}
-  >
-    <div>
-      <div
-        className="emotion-5"
-      >
-        <div
-          className="emotion-4"
-        >
-          <span
-            className="emotion-0"
-          >
-            New
-          </span>
-          <div
-            className="emotion-3"
-          >
-            <span
-              className="emotion-1"
-            >
-              Connected 
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7 2v11h3v9l7-12h-4l4-8z"
-                />
-              </svg>
-            </span>
+            </button>
             <div
-              className="emotion-2"
-            >
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
-                />
-              </svg>
-               default
-            </div>
+              class="emotion-4"
+            />
           </div>
         </div>
       </div>
@@ -2090,188 +1942,7 @@ exports[`Storyshots core/Badge variants 1`] = `
 </div>
 `;
 
-exports[`Storyshots core/Button in 'loading' state 1`] = `
-@keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0);
-    -ms-transform: rotate(0);
-    transform: rotate(0);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.emotion-3 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 100vh;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 100%;
-  padding: 20px;
-}
-
-.emotion-2 {
-  display: grid;
-  justify-items: start;
-  grid-gap: 2rem;
-}
-
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #663399;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: #663399;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.9;
-}
-
-.emotion-0 svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-0:hover {
-  background: #542c85;
-  border: 1px solid #542c85;
-}
-
-<div
-  className="storybook-readme-story"
->
-  <div
-    style={Object {}}
-  >
-    <div>
-      <div
-        className="emotion-3"
-      >
-        <div
-          className="emotion-2"
-        >
-          <button
-            className="emotion-0"
-            disabled={true}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Loading
-            </span>
-             
-            <svg
-              className={undefined}
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              strokeWidth="0"
-              style={
-                Object {
-                  "color": undefined,
-                }
-              }
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-              />
-            </svg>
-          </button>
-          <button
-            className="emotion-0"
-            disabled={true}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Custom loading label
-            </span>
-             
-            <svg
-              className={undefined}
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              strokeWidth="0"
-              style={
-                Object {
-                  "color": undefined,
-                }
-              }
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-              />
-            </svg>
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots core/Button legacy Buttons 1`] = `
+exports[`Storyshots core/AnchorButton override/extend styles 1`] = `
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -2286,1030 +1957,6 @@ exports[`Storyshots core/Button legacy Buttons 1`] = `
   }
 }
 
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-.emotion-8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 100vh;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 100%;
-  padding: 20px;
-}
-
-.emotion-7 {
-  display: grid;
-  justify-items: start;
-  grid-gap: 2rem;
-}
-
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #663399;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: #663399;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-0:hover {
-  background: #542c85;
-  border: 1px solid #542c85;
-}
-
-.emotion-1 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #f1defa;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: transparent;
-  color: #663399;
-}
-
-.emotion-1[disabled],
-.emotion-1[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-1 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-1:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-1:hover {
-  border-color: #663399;
-  color: #663399;
-}
-
-.emotion-4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: transparent;
-  color: #663399;
-}
-
-.emotion-4[disabled],
-.emotion-4[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-4 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-4 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-4 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-4:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-4:hover {
-  background: #fcfaff;
-  color: #663399;
-}
-
-.emotion-3 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #2ca72c;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: #2ca72c;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-3[disabled],
-.emotion-3[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-3 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-3 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-3 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-3:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-3:hover {
-  background: #1d9520;
-  border: 1px solid #1d9520;
-}
-
-.emotion-5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #da0013;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: #da0013;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-5[disabled],
-.emotion-5[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-5 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-5 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-5 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-5:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-5:hover {
-  background: #ce0009;
-  border: 1px solid #ce0009;
-}
-
-.emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #f0f0f2;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: transparent;
-  color: #78757a;
-}
-
-.emotion-2[disabled],
-.emotion-2[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-2 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-2 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-2 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-2:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-2:hover {
-  border-color: #78757a;
-  color: #78757a;
-}
-
-.emotion-6 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #ffbab8;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: transparent;
-  color: #da0013;
-}
-
-.emotion-6[disabled],
-.emotion-6[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-6 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-6 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-6 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-6:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-6:hover {
-  border-color: #da0013;
-  color: #da0013;
-}
-
-<div
-  className="storybook-readme-story"
->
-  <div
-    style={Object {}}
-  >
-    <div>
-      <div
-        className="emotion-8"
-      >
-        <div
-          className="emotion-7"
-        >
-          <button
-            className="emotion-0"
-            disabled={false}
-            type="button"
-          >
-            <span>
-              PrimaryButton
-            </span>
-          </button>
-          <button
-            className="emotion-1"
-            disabled={false}
-            type="button"
-          >
-            <span>
-              SecondaryButton
-            </span>
-          </button>
-          <button
-            className="emotion-2"
-            disabled={false}
-            type="button"
-          >
-            <span>
-              CancelButton
-            </span>
-          </button>
-          <button
-            className="emotion-3"
-            disabled={false}
-            type="button"
-          >
-            <span>
-              SuccessButton
-            </span>
-          </button>
-          <button
-            className="emotion-4"
-            disabled={false}
-            type="button"
-          >
-            <span>
-              TextButton
-            </span>
-          </button>
-          <button
-            className="emotion-5"
-            disabled={false}
-            type="button"
-          >
-            <span>
-              PrimaryDeleteButton
-            </span>
-          </button>
-          <button
-            className="emotion-6"
-            disabled={false}
-            type="button"
-          >
-            <span>
-              SecondaryDeleteButton
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots core/Button manually applied styles 1`] = `
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-@keyframes animation-0 {
-  33% {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-
-  66% {
-    -webkit-transform: scale(0.8);
-    -ms-transform: scale(0.8);
-    transform: scale(0.8);
-  }
-}
-
-.emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 100vh;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 100%;
-  padding: 20px;
-}
-
-.emotion-1 {
-  display: grid;
-  justify-items: start;
-  grid-gap: 2rem;
-}
-
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #663399;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: #663399;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-0[disabled],
-.emotion-0[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-0:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-0:hover {
-  background: #542c85;
-  border: 1px solid #542c85;
-}
-
-<div
-  className="storybook-readme-story"
->
-  <div
-    style={Object {}}
-  >
-    <div>
-      <div
-        className="emotion-2"
-      >
-        <div
-          className="emotion-1"
-        >
-          <button
-            className="emotion-0"
-          >
-            I'm a &lt;button&gt; but I look like the &lt;Button&gt;
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots core/Button override/extend styles 1`] = `
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -3538,14 +2185,6 @@ exports[`Storyshots core/Button override/extend styles 1`] = `
   transform: scale(1);
 }
 
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-0:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -3560,49 +2199,26 @@ exports[`Storyshots core/Button override/extend styles 1`] = `
   color: #ffffff;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-2"
-      >
+      <div>
         <div
-          className="emotion-1"
+          class="emotion-2"
         >
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
+          <div
+            class="emotion-1"
           >
-            <span>
-              Button with custom style
-            </span>
-             
-            <svg
-              className={undefined}
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              strokeWidth="0"
-              style={
-                Object {
-                  "color": undefined,
-                }
-              }
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              class="emotion-0"
+              rel=" noopener noreferrer"
+              target="_blank"
             >
-              <path
-                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-              />
-            </svg>
-          </button>
+              Button with custom style
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -3610,7 +2226,21 @@ exports[`Storyshots core/Button override/extend styles 1`] = `
 </div>
 `;
 
-exports[`Storyshots core/Button sizes 1`] = `
+exports[`Storyshots core/AnchorButton sizes 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -3733,6 +2363,1354 @@ exports[`Storyshots core/Button sizes 1`] = `
   grid-gap: 2rem;
 }
 
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 0.875rem;
+  min-height: 1.6rem;
+  padding: 0.3rem 0.5rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  min-height: 2rem;
+  padding: 0.45rem 0.75rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.5rem;
+  min-height: 3.25rem;
+  padding: 0.65rem 1.25rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-3[disabled],
+.emotion-3[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-3 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-3:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-3:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-5"
+        >
+          <div
+            class="emotion-4"
+          >
+            <a
+              class="emotion-0"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              class="emotion-1"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              class="emotion-2"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              class="emotion-3"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/AnchorButton tones 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #78757a;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #78757a;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #635e69;
+  border: 1px solid #635e69;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #2ca72c;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #2ca72c;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #1d9520;
+  border: 1px solid #1d9520;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #da0013;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #da0013;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-3[disabled],
+.emotion-3[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-3 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-3:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-3:hover {
+  background: #ce0009;
+  border: 1px solid #ce0009;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-5"
+        >
+          <div
+            class="emotion-4"
+          >
+            <a
+              class="emotion-0"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              class="emotion-1"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              class="emotion-2"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              class="emotion-3"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/AnchorButton variants 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-3 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f1defa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  border-color: #663399;
+  color: #663399;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-4"
+        >
+          <div
+            class="emotion-3"
+          >
+            <a
+              class="emotion-0"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              class="emotion-1"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              SECONDARY
+              '
+            </a>
+            <a
+              class="emotion-2"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              variant 
+              '
+              GHOST
+              '
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/AnchorButton with icons 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-2 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  margin-right: -0.25em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
 .emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3778,13 +3756,6 @@ exports[`Storyshots core/Button sizes 1`] = `
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
-}
-
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
   margin-left: -0.30em;
 }
 
@@ -3796,6 +3767,406 @@ exports[`Storyshots core/Button sizes 1`] = `
 .emotion-1:hover {
   background: #542c85;
   border: 1px solid #542c85;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-3"
+        >
+          <div
+            class="emotion-2"
+          >
+            <a
+              class="emotion-0"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              On the right
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </a>
+            <a
+              class="emotion-1"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+              On the left
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Announcement default usage 1`] = `
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-1 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #f7ffff;
+  color: #008577;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  padding: 1rem 2.5rem;
+  background-image: url(test-file-stub);
+  background-position: right center;
+  background-repeat: no-repeat;
+}
+
+.emotion-0:not(:first-child) {
+  border-top: 1px solid #dcfffd;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-2"
+        >
+          <div
+            class="emotion-1"
+          >
+            <div
+              class="emotion-0"
+            >
+              We are working on adding more integrations all the time—watch your inbox!
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Badge shortcut usage 1`] = `
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-1 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  border-radius: 4px;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-weight: bold;
+  line-height: 1;
+  background: #37b635;
+  color: #ffffff;
+  font-size: 13px;
+  -webkit-letter-spacing: 0.05em;
+  -moz-letter-spacing: 0.05em;
+  -ms-letter-spacing: 0.05em;
+  letter-spacing: 0.05em;
+  padding: 4px 5px 2px;
+  text-transform: uppercase;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-2"
+        >
+          <div
+            class="emotion-1"
+          >
+            <span
+              class="emotion-0"
+            >
+              New
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Badge variants 1`] = `
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  border-radius: 4px;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-weight: bold;
+  line-height: 1;
+  background: #37b635;
+  color: #ffffff;
+  font-size: 13px;
+  -webkit-letter-spacing: 0.05em;
+  -moz-letter-spacing: 0.05em;
+  -ms-letter-spacing: 0.05em;
+  letter-spacing: 0.05em;
+  padding: 4px 5px 2px;
+  text-transform: uppercase;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  border-radius: 4px;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  font-weight: bold;
+  line-height: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #f7fdf7;
+  color: #37b635;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 1rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.emotion-1 svg:last-child {
+  margin-left: 0.25rem;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #eee;
+  color: green;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: .9rem;
+  font-weight: normal;
+  margin-left: 2em;
+  padding: .3em .6em;
+  vertical-align: text-bottom;
+}
+
+.emotion-2 svg {
+  margin-right: 0.2em;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-5"
+        >
+          <div
+            class="emotion-4"
+          >
+            <span
+              class="emotion-0"
+            >
+              New
+            </span>
+            <div
+              class="emotion-3"
+            >
+              <span
+                class="emotion-1"
+              >
+                Connected 
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7 2v11h3v9l7-12h-4l4-8z"
+                  />
+                </svg>
+              </span>
+              <div
+                class="emotion-2"
+              >
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                  />
+                </svg>
+                 default
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button in 'loading' state 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0);
+    -ms-transform: rotate(0);
+    transform: rotate(0);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-2 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
 }
 
 .emotion-0 {
@@ -3821,9 +4192,379 @@ exports[`Storyshots core/Button sizes 1`] = `
   line-height: 1;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 1.5rem;
-  min-height: 3.25rem;
-  padding: 0.65rem 1.25rem;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.9;
+}
+
+.emotion-0 svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  margin-right: -0.25em;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-3"
+        >
+          <div
+            class="emotion-2"
+          >
+            <button
+              class="emotion-0"
+              disabled=""
+              type="button"
+            >
+              <span>
+                Loading
+              </span>
+               
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+            </button>
+            <button
+              class="emotion-0"
+              disabled=""
+              type="button"
+            >
+              <span>
+                Custom loading label
+              </span>
+               
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button legacy Buttons 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-7 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
   background: #663399;
   color: #ffffff;
   font-weight: bold;
@@ -3845,12 +4586,682 @@ exports[`Storyshots core/Button sizes 1`] = `
   transform: scale(1);
 }
 
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
 }
 
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f1defa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  border-color: #663399;
+  color: #663399;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-4[disabled],
+.emotion-4[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-4 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-4:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-4:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #2ca72c;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #2ca72c;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-3[disabled],
+.emotion-3[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-3 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-3:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-3:hover {
+  background: #1d9520;
+  border: 1px solid #1d9520;
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #da0013;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #da0013;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-5[disabled],
+.emotion-5[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-5 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-5:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-5:hover {
+  background: #ce0009;
+  border: 1px solid #ce0009;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f0f0f2;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #78757a;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  border-color: #78757a;
+  color: #78757a;
+}
+
+.emotion-6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #ffbab8;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #da0013;
+}
+
+.emotion-6[disabled],
+.emotion-6[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-6 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-6:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-6:hover {
+  border-color: #da0013;
+  color: #da0013;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-8"
+        >
+          <div
+            class="emotion-7"
+          >
+            <button
+              class="emotion-0"
+              type="button"
+            >
+              PrimaryButton
+            </button>
+            <button
+              class="emotion-1"
+              type="button"
+            >
+              SecondaryButton
+            </button>
+            <button
+              class="emotion-2"
+              type="button"
+            >
+              CancelButton
+            </button>
+            <button
+              class="emotion-3"
+              type="button"
+            >
+              SuccessButton
+            </button>
+            <button
+              class="emotion-4"
+              type="button"
+            >
+              TextButton
+            </button>
+            <button
+              class="emotion-5"
+              type="button"
+            >
+              PrimaryDeleteButton
+            </button>
+            <button
+              class="emotion-6"
+              type="button"
+            >
+              SecondaryDeleteButton
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button manually applied styles 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-1 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
 }
 
 .emotion-0:hover:not([disabled]) svg {
@@ -3861,6 +5272,563 @@ exports[`Storyshots core/Button sizes 1`] = `
 .emotion-0:hover {
   background: #542c85;
   border: 1px solid #542c85;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-2"
+        >
+          <div
+            class="emotion-1"
+          >
+            <button
+              class="emotion-0"
+            >
+              I'm a &lt;button&gt; but I look like the &lt;Button&gt;
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button override/extend styles 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-1 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+  color: #663399;
+  background: #fec21e;
+  border-color: #fec21e;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-0:hover:not([disabled]) {
+  color: #ffffff;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-2"
+        >
+          <div
+            class="emotion-1"
+          >
+            <button
+              class="emotion-0"
+              type="button"
+            >
+              Button with custom style
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/Button sizes 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
 }
 
 .emotion-2 {
@@ -3886,9 +5854,9 @@ exports[`Storyshots core/Button sizes 1`] = `
   line-height: 1;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 1rem;
-  min-height: 2rem;
-  padding: 0.45rem 0.75rem;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
   background: #663399;
   color: #ffffff;
   font-weight: bold;
@@ -3910,14 +5878,6 @@ exports[`Storyshots core/Button sizes 1`] = `
   transform: scale(1);
 }
 
-.emotion-2 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-2 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-2:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -3928,7 +5888,7 @@ exports[`Storyshots core/Button sizes 1`] = `
   border: 1px solid #542c85;
 }
 
-.emotion-3 {
+.emotion-0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3959,6 +5919,120 @@ exports[`Storyshots core/Button sizes 1`] = `
   font-weight: bold;
 }
 
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  min-height: 2rem;
+  padding: 0.45rem 0.75rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.5rem;
+  min-height: 3.25rem;
+  padding: 0.65rem 1.25rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
 .emotion-3[disabled],
 .emotion-3[disabled]:hover {
   cursor: not-allowed;
@@ -3975,14 +6049,6 @@ exports[`Storyshots core/Button sizes 1`] = `
   transform: scale(1);
 }
 
-.emotion-3 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-3 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-3:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -3993,59 +6059,55 @@ exports[`Storyshots core/Button sizes 1`] = `
   border: 1px solid #542c85;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-5"
-      >
+      <div>
         <div
-          className="emotion-4"
+          class="emotion-5"
         >
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
+          <div
+            class="emotion-4"
           >
-            <span>
-              Button size 'XL'
-            </span>
-          </button>
-          <button
-            className="emotion-1"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Button size 'L'
-            </span>
-          </button>
-          <button
-            className="emotion-2"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Button size 'M'
-            </span>
-          </button>
-          <button
-            className="emotion-3"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Button size 'S'
-            </span>
-          </button>
+            <button
+              class="emotion-0"
+              type="button"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </button>
+            <button
+              class="emotion-1"
+              type="button"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </button>
+            <button
+              class="emotion-2"
+              type="button"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </button>
+            <button
+              class="emotion-3"
+              type="button"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -4194,6 +6256,62 @@ exports[`Storyshots core/Button tones 1`] = `
   }
 }
 
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 .emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4265,14 +6383,6 @@ exports[`Storyshots core/Button tones 1`] = `
   transform: scale(1);
 }
 
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-0:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -4284,136 +6394,6 @@ exports[`Storyshots core/Button tones 1`] = `
 }
 
 .emotion-1 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #2ca72c;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: #2ca72c;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-1[disabled],
-.emotion-1[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-1 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-1:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-1:hover {
-  background: #1d9520;
-  border: 1px solid #1d9520;
-}
-
-.emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #da0013;
-  border-radius: 4px;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
-  transition: background 0.5s,border 0.5s,color 0.5s;
-  line-height: 1;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 1.125rem;
-  min-height: 2.4rem;
-  padding: 0.55rem 1rem;
-  background: #da0013;
-  color: #ffffff;
-  font-weight: bold;
-}
-
-.emotion-2[disabled],
-.emotion-2[disabled]:hover {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.emotion-2 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin: 0 0.25rem;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-2 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-2 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-2:hover:not([disabled]) svg {
-  -webkit-animation: animation-0 1s linear infinite;
-  animation: animation-0 1s linear infinite;
-}
-
-.emotion-2:hover {
-  background: #ce0009;
-  border: 1px solid #ce0009;
-}
-
-.emotion-3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4444,6 +6424,120 @@ exports[`Storyshots core/Button tones 1`] = `
   font-weight: bold;
 }
 
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #635e69;
+  border: 1px solid #635e69;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #2ca72c;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #2ca72c;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #1d9520;
+  border: 1px solid #1d9520;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #da0013;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #da0013;
+  color: #ffffff;
+  font-weight: bold;
+}
+
 .emotion-3[disabled],
 .emotion-3[disabled]:hover {
   cursor: not-allowed;
@@ -4460,77 +6554,65 @@ exports[`Storyshots core/Button tones 1`] = `
   transform: scale(1);
 }
 
-.emotion-3 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-3 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-3:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
 }
 
 .emotion-3:hover {
-  background: #635e69;
-  border: 1px solid #635e69;
+  background: #ce0009;
+  border: 1px solid #ce0009;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-5"
-      >
+      <div>
         <div
-          className="emotion-4"
+          class="emotion-5"
         >
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
+          <div
+            class="emotion-4"
           >
-            <span>
-              Button tone 'BRAND'
-            </span>
-          </button>
-          <button
-            className="emotion-1"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Button tone 'SUCCESS'
-            </span>
-          </button>
-          <button
-            className="emotion-2"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Button tone 'DANGER'
-            </span>
-          </button>
-          <button
-            className="emotion-3"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Button tone 'NEUTRAL'
-            </span>
-          </button>
+            <button
+              class="emotion-0"
+              type="button"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </button>
+            <button
+              class="emotion-1"
+              type="button"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </button>
+            <button
+              class="emotion-2"
+              type="button"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </button>
+            <button
+              class="emotion-3"
+              type="button"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -4539,6 +6621,146 @@ exports[`Storyshots core/Button tones 1`] = `
 `;
 
 exports[`Storyshots core/Button variants 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -4666,14 +6888,6 @@ exports[`Storyshots core/Button variants 1`] = `
   transform: scale(1);
 }
 
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-0:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -4728,14 +6942,6 @@ exports[`Storyshots core/Button variants 1`] = `
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
-}
-
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
 }
 
 .emotion-1:hover:not([disabled]) svg {
@@ -4794,14 +7000,6 @@ exports[`Storyshots core/Button variants 1`] = `
   transform: scale(1);
 }
 
-.emotion-2 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-2 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-2:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -4812,49 +7010,46 @@ exports[`Storyshots core/Button variants 1`] = `
   color: #663399;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-4"
-      >
+      <div>
         <div
-          className="emotion-3"
+          class="emotion-4"
         >
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
+          <div
+            class="emotion-3"
           >
-            <span>
-              Button variant 'PRIMARY'
-            </span>
-          </button>
-          <button
-            className="emotion-1"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Button variant 'SECONDARY'
-            </span>
-          </button>
-          <button
-            className="emotion-2"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Button variant 'GHOST'
-            </span>
-          </button>
+            <button
+              class="emotion-0"
+              type="button"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </button>
+            <button
+              class="emotion-1"
+              type="button"
+            >
+              variant 
+              '
+              SECONDARY
+              '
+            </button>
+            <button
+              class="emotion-2"
+              type="button"
+            >
+              variant 
+              '
+              GHOST
+              '
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -5003,7 +7198,63 @@ exports[`Storyshots core/Button with icons 1`] = `
   }
 }
 
-.emotion-4 {
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5021,7 +7272,7 @@ exports[`Storyshots core/Button with icons 1`] = `
   padding: 20px;
 }
 
-.emotion-3 {
+.emotion-2 {
   display: grid;
   justify-items: start;
   grid-gap: 2rem;
@@ -5072,14 +7323,7 @@ exports[`Storyshots core/Button with icons 1`] = `
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
-}
-
-.emotion-0 svg:last-child {
   margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
 }
 
 .emotion-0:hover:not([disabled]) svg {
@@ -5092,107 +7336,115 @@ exports[`Storyshots core/Button with icons 1`] = `
   border: 1px solid #542c85;
 }
 
-<div
-  className="storybook-readme-story"
->
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-4"
-      >
+      <div>
         <div
-          className="emotion-3"
+          class="emotion-3"
         >
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
+          <div
+            class="emotion-2"
           >
-            <span>
+            <button
+              class="emotion-0"
+              type="button"
+            >
               On the right
-            </span>
-            <svg
-              className={undefined}
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              strokeWidth="0"
-              style={
-                Object {
-                  "color": undefined,
-                }
-              }
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </button>
+            <button
+              class="emotion-1"
+              type="button"
             >
-              <path
-                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-              />
-            </svg>
-          </button>
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <svg
-              className={undefined}
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              strokeWidth="0"
-              style={
-                Object {
-                  "color": undefined,
-                }
-              }
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-              />
-            </svg>
-            <span>
-               On the left
-            </span>
-          </button>
-          <button
-            className="emotion-0"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              With default icon
-            </span>
-             
-            <svg
-              className={undefined}
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              strokeWidth="0"
-              style={
-                Object {
-                  "color": undefined,
-                }
-              }
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-              />
-            </svg>
-          </button>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+              On the left
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -5255,73 +7507,67 @@ exports[`Storyshots core/Heading redered 'as' 1`] = `
   font-weight: bold;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-8"
-      >
+      <div>
         <div
-          className="emotion-7"
+          class="emotion-8"
         >
-          <h1
-            className="emotion-0"
+          <div
+            class="emotion-7"
           >
-            Heading rendered as &lt;h1&gt; tag
-          </h1>
-          <h2
-            className="emotion-0"
-          >
-            Heading rendered as &lt;h2&gt; tag 
-            <div
-              className="emotion-1"
+            <h1
+              class="emotion-0"
             >
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              Heading rendered as &lt;h1&gt; tag
+            </h1>
+            <h2
+              class="emotion-0"
+            >
+              Heading rendered as &lt;h2&gt; tag 
+              <div
+                class="emotion-1"
               >
-                <path
-                  d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
-                />
-              </svg>
-               default
-            </div>
-          </h2>
-          <h3
-            className="emotion-0"
-          >
-            Heading rendered as &lt;h3&gt; tag
-          </h3>
-          <h4
-            className="emotion-0"
-          >
-            Heading rendered as &lt;h4&gt; tag
-          </h4>
-          <h5
-            className="emotion-0"
-          >
-            Heading rendered as &lt;h5&gt; tag
-          </h5>
-          <span
-            className="emotion-0"
-          >
-            Heading rendered as &lt;span&gt; tag
-          </span>
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                  />
+                </svg>
+                 default
+              </div>
+            </h2>
+            <h3
+              class="emotion-0"
+            >
+              Heading rendered as &lt;h3&gt; tag
+            </h3>
+            <h4
+              class="emotion-0"
+            >
+              Heading rendered as &lt;h4&gt; tag
+            </h4>
+            <h5
+              class="emotion-0"
+            >
+              Heading rendered as &lt;h5&gt; tag
+            </h5>
+            <span
+              class="emotion-0"
+            >
+              Heading rendered as &lt;span&gt; tag
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -5408,63 +7654,57 @@ exports[`Storyshots core/Heading tones 1`] = `
   font-weight: bold;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-6"
-      >
+      <div>
         <div
-          className="emotion-5"
+          class="emotion-6"
         >
-          <h2
-            className="emotion-1"
+          <div
+            class="emotion-5"
           >
-            Heading tone - NEUTRAL 
-            <div
-              className="emotion-0"
+            <h2
+              class="emotion-1"
             >
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              Heading tone - NEUTRAL 
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
-                />
-              </svg>
-               default
-            </div>
-          </h2>
-          <h2
-            className="emotion-2"
-          >
-            Heading tone - BRAND
-          </h2>
-          <h2
-            className="emotion-3"
-          >
-            Heading tone - DANGER
-          </h2>
-          <h2
-            className="emotion-4"
-          >
-            Heading tone - SUCCESS
-          </h2>
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                  />
+                </svg>
+                 default
+              </div>
+            </h2>
+            <h2
+              class="emotion-2"
+            >
+              Heading tone - BRAND
+            </h2>
+            <h2
+              class="emotion-3"
+            >
+              Heading tone - DANGER
+            </h2>
+            <h2
+              class="emotion-4"
+            >
+              Heading tone - SUCCESS
+            </h2>
+          </div>
         </div>
       </div>
     </div>
@@ -5544,58 +7784,52 @@ exports[`Storyshots core/Heading variants 1`] = `
   text-transform: uppercase;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-5"
-      >
+      <div>
         <div
-          className="emotion-4"
+          class="emotion-5"
         >
-          <h2
-            className="emotion-1"
+          <div
+            class="emotion-4"
           >
-            Heading variant - PRIMARY 
-            <div
-              className="emotion-0"
+            <h2
+              class="emotion-1"
             >
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              Heading variant - PRIMARY 
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
-                />
-              </svg>
-               default
-            </div>
-          </h2>
-          <h2
-            className="emotion-2"
-          >
-            Heading variant - EMPHASIZED
-          </h2>
-          <h2
-            className="emotion-3"
-          >
-            Heading variant - LIGHT
-          </h2>
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                  />
+                </svg>
+                 default
+              </div>
+            </h2>
+            <h2
+              class="emotion-2"
+            >
+              Heading variant - EMPHASIZED
+            </h2>
+            <h2
+              class="emotion-3"
+            >
+              Heading variant - LIGHT
+            </h2>
+          </div>
         </div>
       </div>
     </div>
@@ -5814,25 +8048,32 @@ exports[`Storyshots core/IntegrationRow default usage 1`] = `
   }
 }
 
-.emotion-7 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #663399;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
 }
 
-.emotion-7:focus,
-.emotion-7:hover {
-  color: #663399;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
 }
 
 .emotion-15 {
@@ -5943,14 +8184,6 @@ exports[`Storyshots core/IntegrationRow default usage 1`] = `
   transform: scale(1);
 }
 
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-1:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -6043,179 +8276,170 @@ exports[`Storyshots core/IntegrationRow default usage 1`] = `
   color: #232129;
 }
 
-<div
-  className="storybook-readme-story"
->
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #663399;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-7:focus,
+.emotion-7:hover {
+  color: #663399;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-16"
-      >
+      <div>
         <div
-          className="emotion-15"
-          width="35em"
+          class="emotion-16"
         >
           <div
-            className="emotion-2"
+            class="emotion-15"
+            width="35em"
           >
-            <span
-              className="emotion-0"
-            >
-              <img
-                alt=""
-                src="test-file-stub"
-              />
-            </span>
-            <button
-              className="emotion-1"
-              disabled={false}
-              type="button"
-            >
-              <span>
-                Connect
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            className="emotion-14"
-          >
-            <span
-              className="emotion-3"
-            >
-              Connected 
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7 2v11h3v9l7-12h-4l4-8z"
-                />
-              </svg>
-            </span>
-            <span
-              className="emotion-0"
-            >
-              <img
-                alt=""
-                src="test-file-stub"
-              />
-            </span>
-            <button
-              className="emotion-1"
-              disabled={false}
-              type="button"
-            >
-              <span>
-                Edit
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                />
-              </svg>
-            </button>
             <div
-              className="emotion-13"
+              class="emotion-2"
             >
-              <div
-                className="emotion-9"
+              <span
+                class="emotion-0"
               >
-                <span
-                  className="emotion-6"
+                <img
+                  alt=""
+                  src="test-file-stub"
+                />
+              </span>
+              <button
+                class="emotion-1"
+                type="button"
+              >
+                Connect
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  space name
-                </span>
-                <span
-                  className="emotion-8"
+                  <path
+                    d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              class="emotion-14"
+            >
+              <span
+                class="emotion-3"
+              >
+                Connected 
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <a
-                    className="emotion-7"
-                    href="https://gatsbyjs.com"
-                    rel=""
-                    target={undefined}
+                  <path
+                    d="M7 2v11h3v9l7-12h-4l4-8z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="emotion-0"
+              >
+                <img
+                  alt=""
+                  src="test-file-stub"
+                />
+              </span>
+              <button
+                class="emotion-1"
+                type="button"
+              >
+                Edit
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                  />
+                </svg>
+              </button>
+              <div
+                class="emotion-13"
+              >
+                <div
+                  class="emotion-9"
+                >
+                  <span
+                    class="emotion-6"
                   >
-                    gatsby-provisioned-blog-fba42
-                    <svg
-                      className={undefined}
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      strokeWidth="0"
-                      style={
-                        Object {
-                          "color": undefined,
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
+                    space name
+                  </span>
+                  <span
+                    class="emotion-8"
+                  >
+                    <a
+                      class="emotion-7"
+                      href="https://gatsbyjs.com"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
-                      <path
-                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
-                      />
-                    </svg>
-                  </a>
-                </span>
-              </div>
-              <div
-                className="emotion-9"
-              >
-                <span
-                  className="emotion-6"
+                      gatsby-provisioned-blog-fba42
+                      <svg
+                        fill="currentColor"
+                        height="1em"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                        />
+                      </svg>
+                    </a>
+                  </span>
+                </div>
+                <div
+                  class="emotion-9"
                 >
-                  space id
-                </span>
-                <span
-                  className="emotion-8"
-                >
-                  vkdbses99qqt
-                </span>
+                  <span
+                    class="emotion-6"
+                  >
+                    space id
+                  </span>
+                  <span
+                    class="emotion-8"
+                  >
+                    vkdbses99qqt
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -6437,25 +8661,32 @@ exports[`Storyshots core/IntegrationRow shortcut usage 1`] = `
   }
 }
 
-.emotion-6 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #663399;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
 }
 
-.emotion-6:focus,
-.emotion-6:hover {
-  color: #663399;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
 }
 
 .emotion-18 {
@@ -6566,14 +8797,6 @@ exports[`Storyshots core/IntegrationRow shortcut usage 1`] = `
   transform: scale(1);
 }
 
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-1:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -6666,225 +8889,205 @@ exports[`Storyshots core/IntegrationRow shortcut usage 1`] = `
   color: #232129;
 }
 
-<div
-  className="storybook-readme-story"
->
+.emotion-6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #663399;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-6:focus,
+.emotion-6:hover {
+  color: #663399;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-19"
-      >
+      <div>
         <div
-          className="emotion-18"
-          width="35em"
+          class="emotion-19"
         >
           <div
-            className="emotion-2"
+            class="emotion-18"
+            width="35em"
           >
-            <span
-              className="emotion-0"
-            >
-              <img
-                alt="Netlify"
-                src="test-file-stub"
-              />
-            </span>
-            <button
-              className="emotion-1"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span>
-                Connect
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            className="emotion-14"
-          >
-            <span
-              className="emotion-0"
-            >
-              <img
-                alt="Netlify"
-                src="test-file-stub"
-              />
-            </span>
-            <button
-              className="emotion-1"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span>
-                Edit
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                />
-              </svg>
-            </button>
             <div
-              className="emotion-12"
+              class="emotion-2"
             >
-              <div
-                className="emotion-8"
+              <span
+                class="emotion-0"
               >
-                <span
-                  className="emotion-5"
-                >
-                  site
-                </span>
-                <span
-                  className="emotion-7"
-                >
-                  <a
-                    className="emotion-6"
-                    href="https://gatsbyjs.com"
-                    rel=""
-                    target={undefined}
-                  >
-                    hello-world-01
-                    <svg
-                      className={undefined}
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      strokeWidth="0"
-                      style={
-                        Object {
-                          "color": undefined,
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
-                      />
-                    </svg>
-                  </a>
-                </span>
-              </div>
-              <div
-                className="emotion-8"
-              >
-                <span
-                  className="emotion-5"
-                >
-                  team
-                </span>
-                <span
-                  className="emotion-7"
-                >
-                  shannonb_ux
-                </span>
-              </div>
-            </div>
-            <span
-              className="emotion-13"
-            >
-              Connected 
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7 2v11h3v9l7-12h-4l4-8z"
+                <img
+                  alt="Netlify"
+                  src="test-file-stub"
                 />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <span
-              className="emotion-0"
-            >
-              <img
-                alt="Netlify"
-                src="test-file-stub"
-              />
-            </span>
-            <a
-              className="emotion-1"
-              href="/"
-              rel=" noopener noreferrer"
-              role="button"
-              target="_blank"
-            >
-              <span>
-                Setup instructions
               </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                class="emotion-1"
+                type="button"
               >
-                <path
-                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                Connect
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              class="emotion-14"
+            >
+              <span
+                class="emotion-0"
+              >
+                <img
+                  alt="Netlify"
+                  src="test-file-stub"
                 />
-              </svg>
-            </a>
+              </span>
+              <button
+                class="emotion-1"
+                type="button"
+              >
+                Edit
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                  />
+                </svg>
+              </button>
+              <div
+                class="emotion-12"
+              >
+                <div
+                  class="emotion-8"
+                >
+                  <span
+                    class="emotion-5"
+                  >
+                    site
+                  </span>
+                  <span
+                    class="emotion-7"
+                  >
+                    <a
+                      class="emotion-6"
+                      href="https://gatsbyjs.com"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      hello-world-01
+                      <svg
+                        fill="currentColor"
+                        height="1em"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                        />
+                      </svg>
+                    </a>
+                  </span>
+                </div>
+                <div
+                  class="emotion-8"
+                >
+                  <span
+                    class="emotion-5"
+                  >
+                    team
+                  </span>
+                  <span
+                    class="emotion-7"
+                  >
+                    shannonb_ux
+                  </span>
+                </div>
+              </div>
+              <span
+                class="emotion-13"
+              >
+                Connected 
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7 2v11h3v9l7-12h-4l4-8z"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <span
+                class="emotion-0"
+              >
+                <img
+                  alt="Netlify"
+                  src="test-file-stub"
+                />
+              </span>
+              <a
+                class="emotion-1"
+                href="/"
+                rel=" noopener noreferrer"
+                target="_blank"
+              >
+                Setup instructions
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                  />
+                </svg>
+              </a>
+            </div>
           </div>
         </div>
       </div>
@@ -6894,6 +9097,34 @@ exports[`Storyshots core/IntegrationRow shortcut usage 1`] = `
 `;
 
 exports[`Storyshots core/IntegrationRow with inline SVG as logo 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -7212,14 +9443,6 @@ exports[`Storyshots core/IntegrationRow with inline SVG as logo 1`] = `
   transform: scale(1);
 }
 
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-1:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -7230,84 +9453,2992 @@ exports[`Storyshots core/IntegrationRow with inline SVG as logo 1`] = `
   color: #663399;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-4"
-      >
+      <div>
         <div
-          className="emotion-3"
-          width="35em"
+          class="emotion-4"
         >
           <div
-            className="emotion-2"
+            class="emotion-3"
+            width="35em"
           >
-            <span
-              className="emotion-0"
+            <div
+              class="emotion-2"
             >
-              <svg
-                fill="none"
-                height={28}
-                viewBox="0 0 147 40"
-                width={102}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                class="emotion-0"
               >
-                <radialGradient
-                  cy="0%"
-                  gradientTransform="matrix(0 .9989 -1.152 0 .5 -.5)"
-                  id="a"
-                  r="100.11%"
-                >
-                  <stop
-                    offset="0"
-                    stopColor="#20c6b7"
-                  />
-                  <stop
-                    offset="1"
-                    stopColor="#4d9abf"
-                  />
-                </radialGradient>
-                <g
+                <svg
                   fill="none"
-                  fillRule="evenodd"
+                  height="28"
+                  viewBox="0 0 147 40"
+                  width="102"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <radialgradient
+                    cy="0%"
+                    gradientTransform="matrix(0 .9989 -1.152 0 .5 -.5)"
+                    id="a"
+                    r="100.11%"
+                  >
+                    <stop
+                      offset="0"
+                      stop-color="#20c6b7"
+                    />
+                    <stop
+                      offset="1"
+                      stop-color="#4d9abf"
+                    />
+                  </radialgradient>
+                  <g
+                    fill="none"
+                    fill-rule="evenodd"
+                  >
+                    <path
+                      d="m53.37 12.978.123 2.198c1.403-1.7 3.245-2.55 5.525-2.55 3.951 0 5.962 2.268 6.032 6.804v12.568h-4.26v-12.322c0-1.207-.26-2.1-.78-2.681-.52-.58-1.371-.87-2.552-.87-1.719 0-3 .78-3.84 2.338v13.535h-4.262v-19.02h4.016zm24.378 19.372c-2.7 0-4.89-.852-6.567-2.557-1.678-1.705-2.517-3.976-2.517-6.812v-.527c0-1.898.365-3.595 1.096-5.089.73-1.494 1.757-2.657 3.078-3.49 1.321-.831 2.794-1.247 4.42-1.247 2.583 0 4.58.826 5.988 2.478 1.41 1.653 2.114 3.99 2.114 7.014v1.723h-12.4c.13 1.57.652 2.812 1.57 3.726s2.073 1.371 3.464 1.371c1.952 0 3.542-.79 4.77-2.373l2.297 2.198c-.76 1.136-1.774 2.018-3.042 2.645-1.269.627-2.692.94-4.27.94zm-.508-16.294c-1.17 0-2.113.41-2.832 1.23-.72.82-1.178 1.963-1.377 3.428h8.12v-.317c-.094-1.43-.474-2.51-1.14-3.243-.667-.732-1.59-1.098-2.771-1.098zm16.765-7.7v4.623h3.35v3.164h-3.35v10.617c0 .726.144 1.25.43 1.573.286.322.798.483 1.535.483a6.55 6.55 0 0 0 1.49-.176v3.305c-.97.27-1.905.404-2.806.404-3.273 0-4.91-1.81-4.91-5.431v-10.776h-3.124v-3.164h3.122v-4.623h4.261zm11.137 23.643h-4.262v-27h4.262zm9.172 0h-4.262v-19.02h4.262zm-4.525-23.96c0-.655.207-1.2.622-1.634.416-.433 1.009-.65 1.78-.65.772 0 1.368.217 1.79.65.42.434.63.979.63 1.635 0 .644-.21 1.18-.63 1.608-.422.428-1.018.642-1.79.642-.771 0-1.364-.214-1.78-.642-.415-.427-.622-.964-.622-1.608zm10.663 23.96v-15.857h-2.894v-3.164h2.894v-1.74c0-2.11.584-3.738 1.753-4.887 1.17-1.148 2.806-1.722 4.91-1.722.749 0 1.544.105 2.386.316l-.105 3.34a8.375 8.375 0 0 0 -1.631-.14c-2.035 0-3.052 1.048-3.052 3.146v1.687h3.858v3.164h-3.858v15.856h-4.261zm17.87-6.117 3.858-12.903h4.542l-7.54 21.903c-1.158 3.199-3.122 4.799-5.893 4.799-.62 0-1.304-.106-2.052-.317v-3.305l.807.053c1.075 0 1.885-.196 2.429-.589.543-.392.973-1.051 1.289-1.977l.613-1.635-6.664-18.932h4.595z"
+                      fill="#0e1e25"
+                    />
+                    <path
+                      d="m28.589 14.135-.014-.006c-.008-.003-.016-.006-.023-.013a.11.11 0 0 1 -.028-.093l.773-4.726 3.625 3.626-3.77 1.604a.083.083 0 0 1 -.033.006h-.015c-.005-.003-.01-.007-.02-.017a1.716 1.716 0 0 0 -.495-.381zm5.258-.288 3.876 3.876c.805.806 1.208 1.208 1.355 1.674.022.069.04.138.054.209l-9.263-3.923a.728.728 0 0 0 -.015-.006c-.037-.015-.08-.032-.08-.07s.044-.056.081-.071l.012-.005zm5.127 7.003c-.2.376-.59.766-1.25 1.427l-4.37 4.369-5.652-1.177-.03-.006c-.05-.008-.103-.017-.103-.062a1.706 1.706 0 0 0 -.655-1.193c-.023-.023-.017-.059-.01-.092 0-.005 0-.01.002-.014l1.063-6.526.004-.022c.006-.05.015-.108.06-.108a1.73 1.73 0 0 0 1.16-.665c.009-.01.015-.021.027-.027.032-.015.07 0 .103.014l9.65 4.082zm-6.625 6.801-7.186 7.186 1.23-7.56.002-.01c.001-.01.003-.02.006-.029.01-.024.036-.034.061-.044l.012-.005a1.85 1.85 0 0 0 .695-.517c.024-.028.053-.055.09-.06a.09.09 0 0 1 .029 0l5.06 1.04zm-8.707 8.707-.81.81-8.955-12.942a.424.424 0 0 0 -.01-.014c-.014-.019-.029-.038-.026-.06 0-.016.011-.03.022-.042l.01-.013c.027-.04.05-.08.075-.123l.02-.035.003-.003c.014-.024.027-.047.051-.06.021-.01.05-.006.073-.001l9.921 2.046a.164.164 0 0 1 .076.033c.013.013.016.027.019.043a1.757 1.757 0 0 0 1.028 1.175c.028.014.016.045.003.078a.238.238 0 0 0 -.015.045c-.125.76-1.197 7.298-1.485 9.063zm-1.692 1.691c-.597.591-.949.904-1.347 1.03a2 2 0 0 1 -1.206 0c-.466-.148-.869-.55-1.674-1.356l-8.993-8.993 2.349-3.643c.011-.018.022-.034.04-.047.025-.018.061-.01.091 0a2.434 2.434 0 0 0 1.638-.083c.027-.01.054-.017.075.002a.19.19 0 0 1 .028.032l8.999 13.059zm-14.087-10.186-2.063-2.063 4.074-1.738a.084.084 0 0 1 .033-.007c.034 0 .054.034.072.065a2.91 2.91 0 0 0 .13.184l.013.016c.012.017.004.034-.008.05l-2.25 3.493zm-2.976-2.976-2.61-2.61c-.444-.444-.766-.766-.99-1.043l7.936 1.646a.84.84 0 0 0 .03.005c.049.008.103.017.103.063 0 .05-.059.073-.109.092l-.023.01zm-4.056-4.995a2 2 0 0 1 .09-.495c.148-.466.55-.868 1.356-1.674l3.34-3.34a2175.525 2175.525 0 0 0 4.626 6.687c.027.036.057.076.026.106-.146.161-.292.337-.395.528a.16.16 0 0 1 -.05.062c-.013.008-.027.005-.042.002h-.002l-8.949-1.877zm5.68-6.403 4.489-4.491c.423.185 1.96.834 3.333 1.414 1.04.44 1.988.84 2.286.97.03.012.057.024.07.054.008.018.004.041 0 .06a2.003 2.003 0 0 0 .523 1.828c.03.03 0 .073-.026.11l-.014.021-4.56 7.063c-.012.02-.023.037-.043.05-.024.015-.058.008-.086.001a2.274 2.274 0 0 0 -.543-.074c-.164 0-.342.03-.522.063h-.001c-.02.003-.038.007-.054-.005a.21.21 0 0 1 -.045-.051l-4.808-7.013zm5.398-5.398 5.814-5.814c.805-.805 1.208-1.208 1.674-1.355a2 2 0 0 1 1.206 0c.466.147.869.55 1.674 1.355l1.26 1.26-4.135 6.404a.155.155 0 0 1 -.041.048c-.025.017-.06.01-.09 0a2.097 2.097 0 0 0 -1.92.37c-.027.028-.067.012-.101-.003-.54-.235-4.74-2.01-5.341-2.265zm12.506-3.676 3.818 3.818-.92 5.698v.015a.135.135 0 0 1 -.008.038c-.01.02-.03.024-.05.03a1.83 1.83 0 0 0 -.548.273.154.154 0 0 0 -.02.017c-.011.012-.022.023-.04.025a.114.114 0 0 1 -.043-.007l-5.818-2.472-.011-.005c-.037-.015-.081-.033-.081-.071a2.198 2.198 0 0 0 -.31-.915c-.028-.046-.059-.094-.035-.141zm-3.932 8.606 5.454 2.31c.03.014.063.027.076.058a.106.106 0 0 1 0 .057c-.016.08-.03.171-.03.263v.153c0 .038-.039.054-.075.069l-.011.004c-.864.369-12.13 5.173-12.147 5.173s-.035 0-.052-.017c-.03-.03 0-.072.027-.11a.76.76 0 0 0 .014-.02l4.482-6.94.008-.012c.026-.042.056-.089.104-.089l.045.007c.102.014.192.027.283.027.68 0 1.31-.331 1.69-.897a.16.16 0 0 1 .034-.04c.027-.02.067-.01.098.004zm-6.246 9.185 12.28-5.237s.018 0 .035.017c.067.067.124.112.179.154l.027.017c.025.014.05.03.052.056 0 .01 0 .016-.002.025l-1.052 6.462-.004.026c-.007.05-.014.107-.061.107a1.729 1.729 0 0 0 -1.373.847l-.005.008c-.014.023-.027.045-.05.057-.021.01-.048.006-.07.001l-9.793-2.02c-.01-.002-.152-.519-.163-.52z"
+                      fill="url(#a)"
+                      fill-rule="nonzero"
+                      transform="translate(-.702)"
+                    />
+                  </g>
+                </svg>
+              </span>
+              <button
+                class="emotion-1"
+                type="button"
+              >
+                Connect
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="m53.37 12.978.123 2.198c1.403-1.7 3.245-2.55 5.525-2.55 3.951 0 5.962 2.268 6.032 6.804v12.568h-4.26v-12.322c0-1.207-.26-2.1-.78-2.681-.52-.58-1.371-.87-2.552-.87-1.719 0-3 .78-3.84 2.338v13.535h-4.262v-19.02h4.016zm24.378 19.372c-2.7 0-4.89-.852-6.567-2.557-1.678-1.705-2.517-3.976-2.517-6.812v-.527c0-1.898.365-3.595 1.096-5.089.73-1.494 1.757-2.657 3.078-3.49 1.321-.831 2.794-1.247 4.42-1.247 2.583 0 4.58.826 5.988 2.478 1.41 1.653 2.114 3.99 2.114 7.014v1.723h-12.4c.13 1.57.652 2.812 1.57 3.726s2.073 1.371 3.464 1.371c1.952 0 3.542-.79 4.77-2.373l2.297 2.198c-.76 1.136-1.774 2.018-3.042 2.645-1.269.627-2.692.94-4.27.94zm-.508-16.294c-1.17 0-2.113.41-2.832 1.23-.72.82-1.178 1.963-1.377 3.428h8.12v-.317c-.094-1.43-.474-2.51-1.14-3.243-.667-.732-1.59-1.098-2.771-1.098zm16.765-7.7v4.623h3.35v3.164h-3.35v10.617c0 .726.144 1.25.43 1.573.286.322.798.483 1.535.483a6.55 6.55 0 0 0 1.49-.176v3.305c-.97.27-1.905.404-2.806.404-3.273 0-4.91-1.81-4.91-5.431v-10.776h-3.124v-3.164h3.122v-4.623h4.261zm11.137 23.643h-4.262v-27h4.262zm9.172 0h-4.262v-19.02h4.262zm-4.525-23.96c0-.655.207-1.2.622-1.634.416-.433 1.009-.65 1.78-.65.772 0 1.368.217 1.79.65.42.434.63.979.63 1.635 0 .644-.21 1.18-.63 1.608-.422.428-1.018.642-1.79.642-.771 0-1.364-.214-1.78-.642-.415-.427-.622-.964-.622-1.608zm10.663 23.96v-15.857h-2.894v-3.164h2.894v-1.74c0-2.11.584-3.738 1.753-4.887 1.17-1.148 2.806-1.722 4.91-1.722.749 0 1.544.105 2.386.316l-.105 3.34a8.375 8.375 0 0 0 -1.631-.14c-2.035 0-3.052 1.048-3.052 3.146v1.687h3.858v3.164h-3.858v15.856h-4.261zm17.87-6.117 3.858-12.903h4.542l-7.54 21.903c-1.158 3.199-3.122 4.799-5.893 4.799-.62 0-1.304-.106-2.052-.317v-3.305l.807.053c1.075 0 1.885-.196 2.429-.589.543-.392.973-1.051 1.289-1.977l.613-1.635-6.664-18.932h4.595z"
-                    fill="#0e1e25"
+                    d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
                   />
-                  <path
-                    d="m28.589 14.135-.014-.006c-.008-.003-.016-.006-.023-.013a.11.11 0 0 1 -.028-.093l.773-4.726 3.625 3.626-3.77 1.604a.083.083 0 0 1 -.033.006h-.015c-.005-.003-.01-.007-.02-.017a1.716 1.716 0 0 0 -.495-.381zm5.258-.288 3.876 3.876c.805.806 1.208 1.208 1.355 1.674.022.069.04.138.054.209l-9.263-3.923a.728.728 0 0 0 -.015-.006c-.037-.015-.08-.032-.08-.07s.044-.056.081-.071l.012-.005zm5.127 7.003c-.2.376-.59.766-1.25 1.427l-4.37 4.369-5.652-1.177-.03-.006c-.05-.008-.103-.017-.103-.062a1.706 1.706 0 0 0 -.655-1.193c-.023-.023-.017-.059-.01-.092 0-.005 0-.01.002-.014l1.063-6.526.004-.022c.006-.05.015-.108.06-.108a1.73 1.73 0 0 0 1.16-.665c.009-.01.015-.021.027-.027.032-.015.07 0 .103.014l9.65 4.082zm-6.625 6.801-7.186 7.186 1.23-7.56.002-.01c.001-.01.003-.02.006-.029.01-.024.036-.034.061-.044l.012-.005a1.85 1.85 0 0 0 .695-.517c.024-.028.053-.055.09-.06a.09.09 0 0 1 .029 0l5.06 1.04zm-8.707 8.707-.81.81-8.955-12.942a.424.424 0 0 0 -.01-.014c-.014-.019-.029-.038-.026-.06 0-.016.011-.03.022-.042l.01-.013c.027-.04.05-.08.075-.123l.02-.035.003-.003c.014-.024.027-.047.051-.06.021-.01.05-.006.073-.001l9.921 2.046a.164.164 0 0 1 .076.033c.013.013.016.027.019.043a1.757 1.757 0 0 0 1.028 1.175c.028.014.016.045.003.078a.238.238 0 0 0 -.015.045c-.125.76-1.197 7.298-1.485 9.063zm-1.692 1.691c-.597.591-.949.904-1.347 1.03a2 2 0 0 1 -1.206 0c-.466-.148-.869-.55-1.674-1.356l-8.993-8.993 2.349-3.643c.011-.018.022-.034.04-.047.025-.018.061-.01.091 0a2.434 2.434 0 0 0 1.638-.083c.027-.01.054-.017.075.002a.19.19 0 0 1 .028.032l8.999 13.059zm-14.087-10.186-2.063-2.063 4.074-1.738a.084.084 0 0 1 .033-.007c.034 0 .054.034.072.065a2.91 2.91 0 0 0 .13.184l.013.016c.012.017.004.034-.008.05l-2.25 3.493zm-2.976-2.976-2.61-2.61c-.444-.444-.766-.766-.99-1.043l7.936 1.646a.84.84 0 0 0 .03.005c.049.008.103.017.103.063 0 .05-.059.073-.109.092l-.023.01zm-4.056-4.995a2 2 0 0 1 .09-.495c.148-.466.55-.868 1.356-1.674l3.34-3.34a2175.525 2175.525 0 0 0 4.626 6.687c.027.036.057.076.026.106-.146.161-.292.337-.395.528a.16.16 0 0 1 -.05.062c-.013.008-.027.005-.042.002h-.002l-8.949-1.877zm5.68-6.403 4.489-4.491c.423.185 1.96.834 3.333 1.414 1.04.44 1.988.84 2.286.97.03.012.057.024.07.054.008.018.004.041 0 .06a2.003 2.003 0 0 0 .523 1.828c.03.03 0 .073-.026.11l-.014.021-4.56 7.063c-.012.02-.023.037-.043.05-.024.015-.058.008-.086.001a2.274 2.274 0 0 0 -.543-.074c-.164 0-.342.03-.522.063h-.001c-.02.003-.038.007-.054-.005a.21.21 0 0 1 -.045-.051l-4.808-7.013zm5.398-5.398 5.814-5.814c.805-.805 1.208-1.208 1.674-1.355a2 2 0 0 1 1.206 0c.466.147.869.55 1.674 1.355l1.26 1.26-4.135 6.404a.155.155 0 0 1 -.041.048c-.025.017-.06.01-.09 0a2.097 2.097 0 0 0 -1.92.37c-.027.028-.067.012-.101-.003-.54-.235-4.74-2.01-5.341-2.265zm12.506-3.676 3.818 3.818-.92 5.698v.015a.135.135 0 0 1 -.008.038c-.01.02-.03.024-.05.03a1.83 1.83 0 0 0 -.548.273.154.154 0 0 0 -.02.017c-.011.012-.022.023-.04.025a.114.114 0 0 1 -.043-.007l-5.818-2.472-.011-.005c-.037-.015-.081-.033-.081-.071a2.198 2.198 0 0 0 -.31-.915c-.028-.046-.059-.094-.035-.141zm-3.932 8.606 5.454 2.31c.03.014.063.027.076.058a.106.106 0 0 1 0 .057c-.016.08-.03.171-.03.263v.153c0 .038-.039.054-.075.069l-.011.004c-.864.369-12.13 5.173-12.147 5.173s-.035 0-.052-.017c-.03-.03 0-.072.027-.11a.76.76 0 0 0 .014-.02l4.482-6.94.008-.012c.026-.042.056-.089.104-.089l.045.007c.102.014.192.027.283.027.68 0 1.31-.331 1.69-.897a.16.16 0 0 1 .034-.04c.027-.02.067-.01.098.004zm-6.246 9.185 12.28-5.237s.018 0 .035.017c.067.067.124.112.179.154l.027.017c.025.014.05.03.052.056 0 .01 0 .016-.002.025l-1.052 6.462-.004.026c-.007.05-.014.107-.061.107a1.729 1.729 0 0 0 -1.373.847l-.005.008c-.014.023-.027.045-.05.057-.021.01-.048.006-.07.001l-9.793-2.02c-.01-.002-.152-.519-.163-.52z"
-                    fill="url(#a)"
-                    fillRule="nonzero"
-                    transform="translate(-.702)"
-                  />
-                </g>
-              </svg>
-            </span>
-            <button
-              className="emotion-1"
-              disabled={false}
-              type="button"
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/LinkButton override/extend styles 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-1 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+  color: #663399;
+  background: #fec21e;
+  border-color: #fec21e;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-0:hover:not([disabled]) {
+  color: #ffffff;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-2"
+        >
+          <div
+            class="emotion-1"
+          >
+            <a
+              aria-current="page"
+              class="emotion-0"
+              href="/"
             >
-              <span>
-                Connect
-              </span>
+              Button with custom style
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/LinkButton sizes 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 0.875rem;
+  min-height: 1.6rem;
+  padding: 0.3rem 0.5rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  min-height: 2rem;
+  padding: 0.45rem 0.75rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.5rem;
+  min-height: 3.25rem;
+  padding: 0.65rem 1.25rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-3[disabled],
+.emotion-3[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-3 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-3:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-3:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-5"
+        >
+          <div
+            class="emotion-4"
+          >
+            <a
+              aria-current="page"
+              class="emotion-0"
+              href="/"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              aria-current="page"
+              class="emotion-1"
+              href="/"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              aria-current="page"
+              class="emotion-2"
+              href="/"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              aria-current="page"
+              class="emotion-3"
+              href="/"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/LinkButton tones 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-4 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #78757a;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #78757a;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #635e69;
+  border: 1px solid #635e69;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #2ca72c;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #2ca72c;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #1d9520;
+  border: 1px solid #1d9520;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #da0013;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #da0013;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-3[disabled],
+.emotion-3[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-3 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-3:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-3:hover {
+  background: #ce0009;
+  border: 1px solid #ce0009;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-5"
+        >
+          <div
+            class="emotion-4"
+          >
+            <a
+              aria-current="page"
+              class="emotion-0"
+              href="/"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              aria-current="page"
+              class="emotion-1"
+              href="/"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              aria-current="page"
+              class="emotion-2"
+              href="/"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              aria-current="page"
+              class="emotion-3"
+              href="/"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/LinkButton variants 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-3 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f1defa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  border-color: #663399;
+  color: #663399;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+}
+
+.emotion-2[disabled],
+.emotion-2[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-2:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-2:hover {
+  background: #fcfaff;
+  color: #663399;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-4"
+        >
+          <div
+            class="emotion-3"
+          >
+            <a
+              aria-current="page"
+              class="emotion-0"
+              href="/"
+            >
+              variant 
+              '
+              PRIMARY
+              '
+            </a>
+            <a
+              aria-current="page"
+              class="emotion-1"
+              href="/"
+            >
+              variant 
+              '
+              SECONDARY
+              '
+            </a>
+            <a
+              aria-current="page"
+              class="emotion-2"
+              href="/"
+            >
+              variant 
+              '
+              GHOST
+              '
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots core/LinkButton with icons 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-2 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-0[disabled],
+.emotion-0[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  margin-right: -0.25em;
+}
+
+.emotion-0:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.emotion-1[disabled],
+.emotion-1[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-1 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  margin-left: -0.30em;
+}
+
+.emotion-1:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-3"
+        >
+          <div
+            class="emotion-2"
+          >
+            <a
+              aria-current="page"
+              class="emotion-0"
+              href="/"
+            >
+              On the right
               <svg
-                className={undefined}
                 fill="currentColor"
                 height="1em"
                 stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
+                stroke-width="0"
                 viewBox="0 0 24 24"
                 width="1em"
                 xmlns="http://www.w3.org/2000/svg"
@@ -7316,7 +12447,27 @@ exports[`Storyshots core/IntegrationRow with inline SVG as logo 1`] = `
                   d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
                 />
               </svg>
-            </button>
+            </a>
+            <a
+              aria-current="page"
+              class="emotion-1"
+              href="/"
+            >
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+              On the left
+            </a>
           </div>
         </div>
       </div>
@@ -7578,7 +12729,245 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   }
 }
 
-.emotion-54 {
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-53 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7596,8 +12985,8 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   padding: 20px;
 }
 
-.emotion-53 {
-  box-shadow: 0px 2px 4px rgba(46,41,51,0.08),0px 4px 8px rgba(71,63,79,0.16);
+.emotion-52 {
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7611,7 +13000,7 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   border-radius: 8px;
 }
 
-.emotion-52 {
+.emotion-51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7747,7 +13136,11 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   display: inline;
 }
 
-.emotion-50 {
+.emotion-25 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7768,7 +13161,64 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   padding-bottom: 4rem;
 }
 
-.emotion-55 {
+.emotion-24 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f1defa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+  font-weight: 400;
+}
+
+.emotion-24[disabled],
+.emotion-24[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-24 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-24:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-24:hover {
+  border-color: #663399;
+  color: #663399;
+}
+
+.emotion-54 {
   width: 880px;
   max-width: 94%;
   margin: 0 auto;
@@ -7878,7 +13328,7 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   width: 100%;
 }
 
-.emotion-30 {
+.emotion-29 {
   font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
   margin: 0;
   color: #232129;
@@ -7888,12 +13338,15 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   font-size: 1.25rem;
 }
 
-.emotion-27 {
+.emotion-26 {
+  border: 2px solid #ffffff;
+  border-radius: 8px;
   padding: 1.5rem 1.5rem 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  position: relative;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -7905,14 +13358,15 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   width: 100%;
+  z-index: 0;
 }
 
-.emotion-27:not(:first-child) {
+.emotion-26:not(:first-child) {
   border-left: 1px solid #f0f0f2;
 }
 
 @media (min-width:750px) {
-  .emotion-27 {
+  .emotion-26 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -7926,56 +13380,12 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   }
 }
 
-.emotion-26 {
-  width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-top: 2.5rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  padding-bottom: 4rem;
-}
-
-.emotion-25 {
-  width: 3rem;
-  height: 3rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: #37b635;
-  border-radius: 50%;
-}
-
-.emotion-24 {
-  fill: #ffffff;
-  width: 70%;
-  height: 70%;
-}
-
-.emotion-51 {
+.emotion-50 {
+  border: 2px solid #047bd3;
+  border-radius: 8px;
   padding: 1.5rem 1.5rem 0;
   display: none;
+  position: relative;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -7987,14 +13397,11 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   width: 100%;
-}
-
-.emotion-51:not(:first-child) {
-  border-left: 1px solid #f0f0f2;
+  z-index: 1;
 }
 
 @media (min-width:750px) {
-  .emotion-51 {
+  .emotion-50 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -8008,12 +13415,12 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   }
 }
 
-.emotion-49 {
+.emotion-48 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border: 1px solid #663399;
+  border: 1px solid #f1defa;
   border-radius: 4px;
   box-sizing: border-box;
   cursor: pointer;
@@ -8034,22 +13441,22 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   font-size: 1.125rem;
   min-height: 2.4rem;
   padding: 0.55rem 1rem;
-  background: #663399;
-  color: #ffffff;
-  font-weight: bold;
-  width: 100%;
-  background: #ffffff;
-  color: #047bd3;
+  background: transparent;
+  color: #663399;
+  font-weight: 800;
+  cursor: default;
+  background: #047bd3;
   border-color: #047bd3;
+  color: #ffffff;
 }
 
-.emotion-49[disabled],
-.emotion-49[disabled]:hover {
+.emotion-48[disabled],
+.emotion-48[disabled]:hover {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-.emotion-49 svg {
+.emotion-48 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -8057,541 +13464,443 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
-}
-
-.emotion-49 svg:last-child {
   margin-right: -0.25em;
 }
 
-.emotion-49 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-49:hover:not([disabled]) svg {
+.emotion-48:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
 }
 
-.emotion-49:hover {
-  background: #542c85;
-  border: 1px solid #542c85;
+.emotion-48:hover {
+  border-color: #663399;
+  color: #663399;
 }
 
-.emotion-49:hover {
+.emotion-48:hover {
   color: #ffffff;
   background: #047bd3;
   border-color: #047bd3;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-55"
-      >
+      <div>
         <div
-          className="emotion-54"
+          class="emotion-54"
         >
           <div
-            className="emotion-53"
+            class="emotion-53"
           >
-            <nav
-              className="emotion-2"
-            >
-              <button
-                className="emotion-0"
-                onClick={[Function]}
-              >
-                Free
-              </button>
-              <button
-                className="emotion-1"
-                onClick={[Function]}
-              >
-                Professional
-              </button>
-            </nav>
             <div
-              className="emotion-52"
+              class="emotion-52"
             >
-              <div
-                className="emotion-27"
+              <nav
+                class="emotion-2"
               >
-                <div
-                  className="emotion-4"
-                >
-                  <img
-                    alt="Free"
-                    className="emotion-3"
-                    src="test-file-stub"
-                  />
-                </div>
-                <h2
-                  className="emotion-5"
+                <button
+                  class="emotion-0"
                 >
                   Free
-                </h2>
-                <div
-                  className="emotion-6"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "For personal projects and single-purpose sites",
-                    }
-                  }
-                />
-                <div
-                  className="emotion-10"
-                >
-                  <span
-                    className="emotion-7"
-                  >
-                    $
-                  </span>
-                  <strong
-                    className="emotion-8"
-                  >
-                    0
-                  </strong>
-                  <span
-                    className="emotion-9"
-                  >
-                    / month
-                  </span>
-                </div>
-                <div
-                  className="emotion-23"
-                >
-                  <ul
-                    className="emotion-22"
-                  >
-                    <li
-                      className="emotion-13"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-11"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-12"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Builds and Preview",
-                          }
-                        }
-                      />
-                    </li>
-                    <li
-                      className="emotion-13"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-11"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-12"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "10 real-time edits/day",
-                          }
-                        }
-                      />
-                      <span
-                        className="emotion-17"
-                      >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup="true"
-                          aria-label="more info"
-                          className="emotion-16"
-                          onClick={[Function]}
-                        >
-                          <svg
-                            className={undefined}
-                            fill="currentColor"
-                            height="1em"
-                            stroke="currentColor"
-                            strokeWidth="0"
-                            style={
-                              Object {
-                                "color": undefined,
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                            />
-                          </svg>
-                        </button>
-                        <span
-                          css={null}
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": null,
-                            }
-                          }
-                          role="status"
-                        />
-                      </span>
-                    </li>
-                    <li
-                      className="emotion-13"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-11"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-12"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Online documentation",
-                          }
-                        }
-                      />
-                    </li>
-                  </ul>
-                </div>
-                <div
-                  className="emotion-26"
-                >
-                  <div
-                    className="emotion-25"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="emotion-24"
-                      data-testid="icon-check"
-                      fill="currentColor"
-                      fillRule="evenodd"
-                      height="24px"
-                      preserveAspectRatio="xMidYMid meet"
-                      stroke="none"
-                      strokeWidth="1"
-                      style={
-                        Object {
-                          "verticalAlign": "middle",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      width="24px"
-                    >
-                      <path
-                        d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                      />
-                      <path
-                        d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                      />
-                      <path
-                        d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="emotion-51"
-              >
-                <div
-                  className="emotion-4"
-                >
-                  <img
-                    alt="Professional"
-                    className="emotion-3"
-                    src="test-file-stub"
-                  />
-                </div>
-                <h2
-                  className="emotion-30"
+                </button>
+                <button
+                  class="emotion-1"
                 >
                   Professional
-                </h2>
+                </button>
+              </nav>
+              <div
+                class="emotion-51"
+              >
                 <div
-                  className="emotion-6"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "For personal projects and single-purpose sites",
-                    }
-                  }
-                />
-                <div
-                  className="emotion-10"
+                  class="emotion-26"
                 >
-                  <span
-                    className="emotion-7"
+                  <div
+                    class="emotion-4"
                   >
-                    $
-                  </span>
-                  <strong
-                    className="emotion-8"
+                    <img
+                      alt="Free"
+                      class="emotion-3"
+                      src="test-file-stub"
+                    />
+                  </div>
+                  <h2
+                    class="emotion-5"
                   >
-                    42
-                  </strong>
-                  <span
-                    className="emotion-9"
+                    Free
+                  </h2>
+                  <div
+                    class="emotion-6"
                   >
-                    / month
-                  </span>
-                </div>
-                <div
-                  className="emotion-23"
-                >
-                  <ul
-                    className="emotion-22"
+                    For personal projects and single-purpose sites
+                  </div>
+                  <div
+                    class="emotion-10"
                   >
-                    <li
-                      className="emotion-13"
+                    <span
+                      class="emotion-7"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-11"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-12"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Builds and Preview",
-                          }
-                        }
-                      />
-                    </li>
-                    <li
-                      className="emotion-13"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-11"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-12"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "100 real-time edits/day",
-                          }
-                        }
-                      />
-                      <span
-                        className="emotion-17"
-                      >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup="true"
-                          aria-label="more info"
-                          className="emotion-16"
-                          onClick={[Function]}
-                        >
-                          <svg
-                            className={undefined}
-                            fill="currentColor"
-                            height="1em"
-                            stroke="currentColor"
-                            strokeWidth="0"
-                            style={
-                              Object {
-                                "color": undefined,
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                            />
-                          </svg>
-                        </button>
-                        <span
-                          css={null}
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": null,
-                            }
-                          }
-                          role="status"
-                        />
-                      </span>
-                    </li>
-                    <li
-                      className="emotion-13"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-11"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-12"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Online documentation",
-                          }
-                        }
-                      />
-                    </li>
-                  </ul>
-                </div>
-                <div
-                  className="emotion-50"
-                >
-                  <a
-                    className="emotion-49"
-                    href="/"
-                    onClick={[Function]}
-                    role="button"
-                  >
-                    <span>
-                      Pick
+                      $
                     </span>
-                  </a>
+                    <strong
+                      class="emotion-8"
+                    >
+                      0
+                    </strong>
+                    <span
+                      class="emotion-9"
+                    >
+                      / month
+                    </span>
+                  </div>
+                  <div
+                    class="emotion-23"
+                  >
+                    <ul
+                      class="emotion-22"
+                    >
+                      <li
+                        class="emotion-13"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-11"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-12"
+                        >
+                          Builds and Preview
+                        </div>
+                      </li>
+                      <li
+                        class="emotion-13"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-11"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-12"
+                        >
+                          10 real-time edits/day
+                        </div>
+                        <span
+                          class="emotion-17"
+                        >
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            aria-label="more info"
+                            class="emotion-16"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="1em"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              viewBox="0 0 24 24"
+                              width="1em"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                              />
+                            </svg>
+                          </button>
+                          <span
+                            role="status"
+                          />
+                        </span>
+                      </li>
+                      <li
+                        class="emotion-13"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-11"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-12"
+                        >
+                          Online documentation
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    class="emotion-25"
+                  >
+                    <a
+                      aria-current="page"
+                      class="emotion-24"
+                      href="/"
+                    >
+                      Pick
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="emotion-50"
+                >
+                  <div
+                    class="emotion-4"
+                  >
+                    <img
+                      alt="Professional"
+                      class="emotion-3"
+                      src="test-file-stub"
+                    />
+                  </div>
+                  <h2
+                    class="emotion-29"
+                  >
+                    Professional
+                  </h2>
+                  <div
+                    class="emotion-6"
+                  >
+                    For personal projects and single-purpose sites
+                  </div>
+                  <div
+                    class="emotion-10"
+                  >
+                    <span
+                      class="emotion-7"
+                    >
+                      $
+                    </span>
+                    <strong
+                      class="emotion-8"
+                    >
+                      42
+                    </strong>
+                    <span
+                      class="emotion-9"
+                    >
+                      / month
+                    </span>
+                  </div>
+                  <div
+                    class="emotion-23"
+                  >
+                    <ul
+                      class="emotion-22"
+                    >
+                      <li
+                        class="emotion-13"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-11"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-12"
+                        >
+                          Builds and Preview
+                        </div>
+                      </li>
+                      <li
+                        class="emotion-13"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-11"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-12"
+                        >
+                          100 real-time edits/day
+                        </div>
+                        <span
+                          class="emotion-17"
+                        >
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            aria-label="more info"
+                            class="emotion-16"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="1em"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              viewBox="0 0 24 24"
+                              width="1em"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                              />
+                            </svg>
+                          </button>
+                          <span
+                            role="status"
+                          />
+                        </span>
+                      </li>
+                      <li
+                        class="emotion-13"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-11"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-12"
+                        >
+                          Online documentation
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    class="emotion-25"
+                  >
+                    <a
+                      aria-current="page"
+                      class="emotion-48"
+                      href="/"
+                    >
+                      Pick
+                      <svg
+                        fill="currentColor"
+                        height="1em"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        />
+                      </svg>
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>
@@ -8604,6 +13913,244 @@ exports[`Storyshots core/PricingCard individual multiplan card 1`] = `
 `;
 
 exports[`Storyshots core/PricingCard multiplan card 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -8861,7 +14408,7 @@ exports[`Storyshots core/PricingCard multiplan card 1`] = `
 }
 
 .emotion-74 {
-  box-shadow: 0px 2px 4px rgba(46,41,51,0.08),0px 4px 8px rgba(71,63,79,0.16);
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -9103,11 +14650,14 @@ exports[`Storyshots core/PricingCard multiplan card 1`] = `
 }
 
 .emotion-25 {
+  border: 2px solid #ffffff;
+  border-radius: 8px;
   padding: 1.5rem 1.5rem 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  position: relative;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -9119,6 +14669,7 @@ exports[`Storyshots core/PricingCard multiplan card 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   width: 100%;
+  z-index: 0;
 }
 
 .emotion-25:not(:first-child) {
@@ -9182,8 +14733,11 @@ exports[`Storyshots core/PricingCard multiplan card 1`] = `
 }
 
 .emotion-47 {
+  border: 2px solid #ffffff;
+  border-radius: 8px;
   padding: 1.5rem 1.5rem 0;
   display: none;
+  position: relative;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -9195,6 +14749,7 @@ exports[`Storyshots core/PricingCard multiplan card 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   width: 100%;
+  z-index: 0;
 }
 
 .emotion-47:not(:first-child) {
@@ -9303,14 +14858,6 @@ exports[`Storyshots core/PricingCard multiplan card 1`] = `
   transform: scale(1);
 }
 
-.emotion-71 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-71 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-71:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -9330,707 +14877,590 @@ exports[`Storyshots core/PricingCard multiplan card 1`] = `
   text-align: center;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-76"
-      >
+      <div>
         <div
-          className="emotion-75"
+          class="emotion-76"
         >
           <div
-            className="emotion-74"
+            class="emotion-75"
           >
-            <nav
-              className="emotion-3"
-            >
-              <button
-                className="emotion-0"
-                onClick={[Function]}
-              >
-                Free
-              </button>
-              <button
-                className="emotion-1"
-                onClick={[Function]}
-              >
-                Professional
-              </button>
-              <button
-                className="emotion-2"
-                onClick={[Function]}
-              >
-                Bussines
-              </button>
-            </nav>
             <div
-              className="emotion-70"
+              class="emotion-74"
             >
-              <div
-                className="emotion-25"
+              <nav
+                class="emotion-3"
               >
-                <div
-                  className="emotion-5"
-                >
-                  <img
-                    alt="Free"
-                    className="emotion-4"
-                    src="test-file-stub"
-                  />
-                </div>
-                <h2
-                  className="emotion-6"
+                <button
+                  class="emotion-0"
                 >
                   Free
-                </h2>
-                <div
-                  className="emotion-7"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "For personal projects and single-purpose sites",
-                    }
-                  }
-                />
-                <div
-                  className="emotion-11"
-                >
-                  <span
-                    className="emotion-8"
-                  >
-                    $
-                  </span>
-                  <strong
-                    className="emotion-9"
-                  >
-                    0
-                  </strong>
-                  <span
-                    className="emotion-10"
-                  >
-                    / month
-                  </span>
-                </div>
-                <div
-                  className="emotion-24"
-                >
-                  <ul
-                    className="emotion-23"
-                  >
-                    <li
-                      className="emotion-14"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-12"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-13"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Builds and Preview",
-                          }
-                        }
-                      />
-                    </li>
-                    <li
-                      className="emotion-14"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-12"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-13"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "10 real-time edits/day",
-                          }
-                        }
-                      />
-                      <span
-                        className="emotion-18"
-                      >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup="true"
-                          aria-label="more info"
-                          className="emotion-17"
-                          onClick={[Function]}
-                        >
-                          <svg
-                            className={undefined}
-                            fill="currentColor"
-                            height="1em"
-                            stroke="currentColor"
-                            strokeWidth="0"
-                            style={
-                              Object {
-                                "color": undefined,
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                            />
-                          </svg>
-                        </button>
-                        <span
-                          css={null}
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": null,
-                            }
-                          }
-                          role="status"
-                        />
-                      </span>
-                    </li>
-                    <li
-                      className="emotion-14"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-12"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-13"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Online documentation",
-                          }
-                        }
-                      />
-                    </li>
-                  </ul>
-                </div>
-              </div>
-              <div
-                className="emotion-47"
-              >
-                <div
-                  className="emotion-5"
-                >
-                  <img
-                    alt="Professional"
-                    className="emotion-4"
-                    src="test-file-stub"
-                  />
-                </div>
-                <h2
-                  className="emotion-28"
+                </button>
+                <button
+                  class="emotion-1"
                 >
                   Professional
-                </h2>
-                <div
-                  className="emotion-7"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "For personal projects and single-purpose sites",
-                    }
-                  }
-                />
-                <div
-                  className="emotion-11"
+                </button>
+                <button
+                  class="emotion-2"
                 >
-                  <span
-                    className="emotion-8"
+                  Bussines
+                </button>
+              </nav>
+              <div
+                class="emotion-70"
+              >
+                <div
+                  class="emotion-25"
+                >
+                  <div
+                    class="emotion-5"
                   >
-                    $
-                  </span>
-                  <strong
-                    className="emotion-9"
+                    <img
+                      alt="Free"
+                      class="emotion-4"
+                      src="test-file-stub"
+                    />
+                  </div>
+                  <h2
+                    class="emotion-6"
                   >
-                    42
-                  </strong>
-                  <span
-                    className="emotion-10"
+                    Free
+                  </h2>
+                  <div
+                    class="emotion-7"
                   >
-                    / month
-                  </span>
+                    For personal projects and single-purpose sites
+                  </div>
+                  <div
+                    class="emotion-11"
+                  >
+                    <span
+                      class="emotion-8"
+                    >
+                      $
+                    </span>
+                    <strong
+                      class="emotion-9"
+                    >
+                      0
+                    </strong>
+                    <span
+                      class="emotion-10"
+                    >
+                      / month
+                    </span>
+                  </div>
+                  <div
+                    class="emotion-24"
+                  >
+                    <ul
+                      class="emotion-23"
+                    >
+                      <li
+                        class="emotion-14"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-12"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-13"
+                        >
+                          Builds and Preview
+                        </div>
+                      </li>
+                      <li
+                        class="emotion-14"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-12"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-13"
+                        >
+                          10 real-time edits/day
+                        </div>
+                        <span
+                          class="emotion-18"
+                        >
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            aria-label="more info"
+                            class="emotion-17"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="1em"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              viewBox="0 0 24 24"
+                              width="1em"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                              />
+                            </svg>
+                          </button>
+                          <span
+                            role="status"
+                          />
+                        </span>
+                      </li>
+                      <li
+                        class="emotion-14"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-12"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-13"
+                        >
+                          Online documentation
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
                 </div>
                 <div
-                  className="emotion-24"
+                  class="emotion-47"
                 >
-                  <ul
-                    className="emotion-23"
+                  <div
+                    class="emotion-5"
                   >
-                    <li
-                      className="emotion-14"
+                    <img
+                      alt="Professional"
+                      class="emotion-4"
+                      src="test-file-stub"
+                    />
+                  </div>
+                  <h2
+                    class="emotion-28"
+                  >
+                    Professional
+                  </h2>
+                  <div
+                    class="emotion-7"
+                  >
+                    For personal projects and single-purpose sites
+                  </div>
+                  <div
+                    class="emotion-11"
+                  >
+                    <span
+                      class="emotion-8"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-12"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-13"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Builds and Preview",
-                          }
-                        }
-                      />
-                    </li>
-                    <li
-                      className="emotion-14"
+                      $
+                    </span>
+                    <strong
+                      class="emotion-9"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-12"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
+                      42
+                    </strong>
+                    <span
+                      class="emotion-10"
+                    >
+                      / month
+                    </span>
+                  </div>
+                  <div
+                    class="emotion-24"
+                  >
+                    <ul
+                      class="emotion-23"
+                    >
+                      <li
+                        class="emotion-14"
                       >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-13"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "100 real-time edits/day",
-                          }
-                        }
-                      />
-                      <span
-                        className="emotion-18"
-                      >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup="true"
-                          aria-label="more info"
-                          className="emotion-17"
-                          onClick={[Function]}
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-12"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
                         >
-                          <svg
-                            className={undefined}
-                            fill="currentColor"
-                            height="1em"
-                            stroke="currentColor"
-                            strokeWidth="0"
-                            style={
-                              Object {
-                                "color": undefined,
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                            />
-                          </svg>
-                        </button>
-                        <span
-                          css={null}
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": null,
-                            }
-                          }
-                          role="status"
-                        />
-                      </span>
-                    </li>
-                    <li
-                      className="emotion-14"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-12"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-13"
+                        >
+                          Builds and Preview
+                        </div>
+                      </li>
+                      <li
+                        class="emotion-14"
                       >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-13"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Online documentation",
-                          }
-                        }
-                      />
-                    </li>
-                  </ul>
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-12"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-13"
+                        >
+                          100 real-time edits/day
+                        </div>
+                        <span
+                          class="emotion-18"
+                        >
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            aria-label="more info"
+                            class="emotion-17"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="1em"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              viewBox="0 0 24 24"
+                              width="1em"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                              />
+                            </svg>
+                          </button>
+                          <span
+                            role="status"
+                          />
+                        </span>
+                      </li>
+                      <li
+                        class="emotion-14"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-12"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-13"
+                        >
+                          Online documentation
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  class="emotion-47"
+                >
+                  <div
+                    class="emotion-5"
+                  >
+                    <img
+                      alt="Bussines"
+                      class="emotion-4"
+                      src="test-file-stub"
+                    />
+                  </div>
+                  <h2
+                    class="emotion-50"
+                  >
+                    Bussines
+                  </h2>
+                  <div
+                    class="emotion-7"
+                  >
+                    For personal projects and single-purpose sites
+                  </div>
+                  <div
+                    class="emotion-11"
+                  >
+                    <span
+                      class="emotion-8"
+                    >
+                      $
+                    </span>
+                    <strong
+                      class="emotion-9"
+                    >
+                      722
+                    </strong>
+                    <span
+                      class="emotion-10"
+                    >
+                      / month
+                    </span>
+                  </div>
+                  <div
+                    class="emotion-24"
+                  >
+                    <ul
+                      class="emotion-23"
+                    >
+                      <li
+                        class="emotion-14"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-12"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-13"
+                        >
+                          Builds and Preview
+                        </div>
+                      </li>
+                      <li
+                        class="emotion-14"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-12"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-13"
+                        >
+                          <p>
+                            1000 real-time edits/day
+                          </p>
+                        </div>
+                        <span
+                          class="emotion-18"
+                        >
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            aria-label="more info"
+                            class="emotion-17"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="1em"
+                              stroke="currentColor"
+                              stroke-width="0"
+                              viewBox="0 0 24 24"
+                              width="1em"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                              />
+                            </svg>
+                          </button>
+                          <span
+                            role="status"
+                          />
+                        </span>
+                      </li>
+                      <li
+                        class="emotion-14"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-12"
+                          data-testid="icon-check"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          height="24px"
+                          preserveAspectRatio="xMidYMid meet"
+                          stroke="none"
+                          stroke-width="1"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 24 24"
+                          width="24px"
+                        >
+                          <path
+                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                          />
+                          <path
+                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                          />
+                          <path
+                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                          />
+                        </svg>
+                        <div
+                          class="emotion-13"
+                        >
+                          Online documentation
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
                 </div>
               </div>
               <div
-                className="emotion-47"
+                class="emotion-73"
               >
-                <div
-                  className="emotion-5"
+                <a
+                  aria-current="page"
+                  class="emotion-71"
+                  href="/"
                 >
-                  <img
-                    alt="Bussines"
-                    className="emotion-4"
-                    src="test-file-stub"
-                  />
-                </div>
-                <h2
-                  className="emotion-50"
-                >
-                  Bussines
-                </h2>
-                <div
-                  className="emotion-7"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "For personal projects and single-purpose sites",
-                    }
-                  }
-                />
-                <div
-                  className="emotion-11"
-                >
-                  <span
-                    className="emotion-8"
-                  >
-                    $
-                  </span>
-                  <strong
-                    className="emotion-9"
-                  >
-                    722
-                  </strong>
-                  <span
-                    className="emotion-10"
-                  >
-                    / month
-                  </span>
-                </div>
-                <div
-                  className="emotion-24"
-                >
-                  <ul
-                    className="emotion-23"
-                  >
-                    <li
-                      className="emotion-14"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-12"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-13"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Builds and Preview",
-                          }
-                        }
-                      />
-                    </li>
-                    <li
-                      className="emotion-14"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-12"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-13"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "<p>1000 real-time edits/day</p>",
-                          }
-                        }
-                      />
-                      <span
-                        className="emotion-18"
-                      >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup="true"
-                          aria-label="more info"
-                          className="emotion-17"
-                          onClick={[Function]}
-                        >
-                          <svg
-                            className={undefined}
-                            fill="currentColor"
-                            height="1em"
-                            stroke="currentColor"
-                            strokeWidth="0"
-                            style={
-                              Object {
-                                "color": undefined,
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                            />
-                          </svg>
-                        </button>
-                        <span
-                          css={null}
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": null,
-                            }
-                          }
-                          role="status"
-                        />
-                      </span>
-                    </li>
-                    <li
-                      className="emotion-14"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-12"
-                        data-testid="icon-check"
-                        fill="currentColor"
-                        fillRule="evenodd"
-                        height="24px"
-                        preserveAspectRatio="xMidYMid meet"
-                        stroke="none"
-                        strokeWidth="1"
-                        style={
-                          Object {
-                            "verticalAlign": "middle",
-                          }
-                        }
-                        viewBox="0 0 24 24"
-                        width="24px"
-                      >
-                        <path
-                          d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                        />
-                        <path
-                          d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                        />
-                        <path
-                          d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                        />
-                      </svg>
-                      <div
-                        className="emotion-13"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Online documentation",
-                          }
-                        }
-                      />
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-            <div
-              className="emotion-73"
-            >
-              <a
-                className="emotion-71"
-                href="/"
-                role="button"
-              >
-                <span>
                   Get started for free
+                </a>
+                <span
+                  class="emotion-72"
+                >
+                  No commitment, no credit card required. All you need is a Github account.
                 </span>
-              </a>
-              <span
-                className="emotion-72"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "No commitment, no credit card required. All you need is a Github account.",
-                  }
-                }
-              />
+              </div>
             </div>
           </div>
         </div>
@@ -10265,7 +15695,245 @@ exports[`Storyshots core/PricingCard variants 1`] = `
   }
 }
 
-.emotion-48 {
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+.emotion-95 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -10283,20 +15951,20 @@ exports[`Storyshots core/PricingCard variants 1`] = `
   padding: 20px;
 }
 
-.emotion-49 {
+.emotion-96 {
   width: 660px;
   max-width: 94%;
   margin: 0 auto;
 }
 
-.emotion-47 {
+.emotion-94 {
   display: grid;
   grid-gap: 2rem;
   grid-template-columns: 1fr 1fr;
 }
 
 .emotion-23 {
-  box-shadow: 0px 2px 4px rgba(46,41,51,0.08),0px 4px 8px rgba(71,63,79,0.16);
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -10322,11 +15990,14 @@ exports[`Storyshots core/PricingCard variants 1`] = `
 }
 
 .emotion-21 {
+  border: 2px solid #ffffff;
+  border-radius: 8px;
   padding: 1.5rem 1.5rem 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  position: relative;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -10338,6 +16009,7 @@ exports[`Storyshots core/PricingCard variants 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   width: 100%;
+  z-index: 0;
 }
 
 .emotion-21:not(:first-child) {
@@ -10387,7 +16059,7 @@ exports[`Storyshots core/PricingCard variants 1`] = `
   color: #232129;
   line-height: 1.125;
   font-weight: bold;
-  color: #b17acc;
+  color: #37b635;
   font-size: 1.25rem;
 }
 
@@ -10495,6 +16167,10 @@ exports[`Storyshots core/PricingCard variants 1`] = `
 }
 
 .emotion-20 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -10516,6 +16192,284 @@ exports[`Storyshots core/PricingCard variants 1`] = `
 }
 
 .emotion-19 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f1defa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+  font-weight: 400;
+}
+
+.emotion-19[disabled],
+.emotion-19[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-19 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-19:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-19:hover {
+  border-color: #663399;
+  color: #663399;
+}
+
+.emotion-45 {
+  border: 2px solid #37b635;
+  border-radius: 8px;
+  padding: 1.5rem 1.5rem 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 100%;
+  z-index: 1;
+}
+
+@media (min-width:750px) {
+  .emotion-45 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-shrink: 1;
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+    -webkit-flex-basis: calc(100% / 1);
+    -ms-flex-preferred-size: calc(100% / 1);
+    flex-basis: calc(100% / 1);
+  }
+}
+
+.emotion-43 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #f1defa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  color: #663399;
+  font-weight: 800;
+  cursor: default;
+  background: #37b635;
+  border-color: #37b635;
+  color: #ffffff;
+}
+
+.emotion-43[disabled],
+.emotion-43[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-43 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  margin-right: -0.25em;
+}
+
+.emotion-43:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-43:hover {
+  border-color: #663399;
+  color: #663399;
+}
+
+.emotion-43:hover {
+  color: #ffffff;
+  background: #37b635;
+  border-color: #37b635;
+}
+
+.emotion-70 {
+  box-shadow: 0px 1px 2px rgba(46,41,51,0.08),0px 2px 4px rgba(71,63,79,0.08);
+  background-color: #362066;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 8px;
+}
+
+.emotion-68 {
+  border: 2px solid #362066;
+  border-radius: 8px;
+  padding: 1.5rem 1.5rem 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 100%;
+  z-index: 0;
+}
+
+.emotion-68:not(:first-child) {
+  border-left: 1px solid #f0f0f2;
+}
+
+@media (min-width:750px) {
+  .emotion-68 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-shrink: 1;
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+    -webkit-flex-basis: calc(100% / 1);
+    -ms-flex-preferred-size: calc(100% / 1);
+    flex-basis: calc(100% / 1);
+  }
+}
+
+.emotion-50 {
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin: 0;
+  color: #232129;
+  line-height: 1.125;
+  font-weight: bold;
+  color: #ffffff;
+  font-size: 1.25rem;
+}
+
+.emotion-51 {
+  text-align: center;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #d9bae8;
+  line-height: 1.4;
+}
+
+.emotion-51 p {
+  margin: 0;
+}
+
+.emotion-65 {
+  font-size: 0.875rem;
+  color: #d9bae8;
+  width: 100%;
+  margin-top: 1.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-52 {
+  width: 1.5em;
+  height: 1.5em;
+  fill: #8a4baf;
+  margin-right: 0.5rem;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-transform: translateY(-.2em);
+  -ms-transform: translateY(-.2em);
+  transform: translateY(-.2em);
+}
+
+.emotion-66 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -10544,19 +16498,16 @@ exports[`Storyshots core/PricingCard variants 1`] = `
   background: #663399;
   color: #ffffff;
   font-weight: bold;
-  width: 100%;
-  background: #8a4baf;
-  color: #ffffff;
-  border-color: #8a4baf;
+  font-weight: 400;
 }
 
-.emotion-19[disabled],
-.emotion-19[disabled]:hover {
+.emotion-66[disabled],
+.emotion-66[disabled]:hover {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-.emotion-19 svg {
+.emotion-66 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -10566,77 +16517,25 @@ exports[`Storyshots core/PricingCard variants 1`] = `
   transform: scale(1);
 }
 
-.emotion-19 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-19 svg:first-child {
-  margin-left: -0.30em;
-}
-
-.emotion-19:hover:not([disabled]) svg {
+.emotion-66:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
 }
 
-.emotion-19:hover {
+.emotion-66:hover {
   background: #542c85;
   border: 1px solid #542c85;
 }
 
-.emotion-19:hover {
-  color: #ffffff;
-  background: #8a4baf;
-  border-color: #8a4baf;
-}
-
-.emotion-46 {
-  box-shadow: 0px 2px 4px rgba(46,41,51,0.08),0px 4px 8px rgba(71,63,79,0.16);
-  background-color: #362066;
+.emotion-91 {
+  border: 2px solid #8a4baf;
+  border-radius: 8px;
+  padding: 1.5rem 1.5rem 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   position: relative;
-  width: 100%;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  border-radius: 8px;
-}
-
-.emotion-26 {
-  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  margin: 0;
-  color: #232129;
-  line-height: 1.125;
-  font-weight: bold;
-  color: #ffffff;
-  font-size: 1.25rem;
-}
-
-.emotion-27 {
-  text-align: center;
-  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  margin-top: 1rem;
-  font-size: 0.875rem;
-  color: #d9bae8;
-  line-height: 1.4;
-}
-
-.emotion-27 p {
-  margin: 0;
-}
-
-.emotion-41 {
-  font-size: 0.875rem;
-  color: #d9bae8;
-  width: 100%;
-  margin-top: 1.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -10644,448 +16543,835 @@ exports[`Storyshots core/PricingCard variants 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.emotion-28 {
-  width: 1.5em;
-  height: 1.5em;
-  fill: #8a4baf;
-  margin-right: 0.5rem;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-transform: translateY(-.2em);
-  -ms-transform: translateY(-.2em);
-  transform: translateY(-.2em);
+  width: 100%;
+  z-index: 1;
 }
 
-<div
-  className="storybook-readme-story"
->
+@media (min-width:750px) {
+  .emotion-91 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-shrink: 1;
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+    -webkit-flex-basis: calc(100% / 1);
+    -ms-flex-preferred-size: calc(100% / 1);
+    flex-basis: calc(100% / 1);
+  }
+}
+
+.emotion-89 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #663399;
+  border-radius: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background 0.5s,border 0.5s,color 0.5s;
+  transition: background 0.5s,border 0.5s,color 0.5s;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1.125rem;
+  min-height: 2.4rem;
+  padding: 0.55rem 1rem;
+  background: #663399;
+  color: #ffffff;
+  font-weight: bold;
+  font-weight: 800;
+  cursor: default;
+  background: #8a4baf;
+  border-color: #8a4baf;
+  color: #ffffff;
+}
+
+.emotion-89[disabled],
+.emotion-89[disabled]:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emotion-89 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 0.25rem;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  margin-right: -0.25em;
+}
+
+.emotion-89:hover:not([disabled]) svg {
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-89:hover {
+  background: #542c85;
+  border: 1px solid #542c85;
+}
+
+.emotion-89:hover {
+  color: #ffffff;
+  background: #8a4baf;
+  border-color: #8a4baf;
+}
+
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-49"
-      >
+      <div>
         <div
-          className="emotion-48"
+          class="emotion-96"
         >
           <div
-            className="emotion-47"
+            class="emotion-95"
           >
             <div
-              className="emotion-23"
+              class="emotion-94"
             >
               <div
-                className="emotion-22"
+                class="emotion-23"
               >
                 <div
-                  className="emotion-21"
+                  class="emotion-22"
                 >
                   <div
-                    className="emotion-1"
+                    class="emotion-21"
                   >
-                    <img
-                      alt="Free"
-                      className="emotion-0"
-                      src="test-file-stub"
-                    />
-                  </div>
-                  <h2
-                    className="emotion-2"
-                  >
-                    Free
-                  </h2>
-                  <div
-                    className="emotion-3"
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "For personal projects and single-purpose sites",
-                      }
-                    }
-                  />
-                  <div
-                    className="emotion-7"
-                  >
-                    <span
-                      className="emotion-4"
+                    <div
+                      class="emotion-1"
                     >
-                      $
-                    </span>
-                    <strong
-                      className="emotion-5"
+                      <img
+                        alt="Free"
+                        class="emotion-0"
+                        src="test-file-stub"
+                      />
+                    </div>
+                    <h2
+                      class="emotion-2"
                     >
-                      0
-                    </strong>
-                    <span
-                      className="emotion-6"
+                      Free
+                    </h2>
+                    <div
+                      class="emotion-3"
                     >
-                      / month
-                    </span>
-                  </div>
-                  <div
-                    className="emotion-18"
-                  >
-                    <ul
-                      className="emotion-17"
+                      For personal projects and single-purpose sites
+                    </div>
+                    <div
+                      class="emotion-7"
                     >
-                      <li
-                        className="emotion-10"
+                      <span
+                        class="emotion-4"
                       >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-8"
-                          data-testid="icon-check"
-                          fill="currentColor"
-                          fillRule="evenodd"
-                          height="24px"
-                          preserveAspectRatio="xMidYMid meet"
-                          stroke="none"
-                          strokeWidth="1"
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                          viewBox="0 0 24 24"
-                          width="24px"
-                        >
-                          <path
-                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                          />
-                          <path
-                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                          />
-                          <path
-                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                          />
-                        </svg>
-                        <div
-                          className="emotion-9"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Builds and Preview",
-                            }
-                          }
-                        />
-                      </li>
-                      <li
-                        className="emotion-10"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-8"
-                          data-testid="icon-check"
-                          fill="currentColor"
-                          fillRule="evenodd"
-                          height="24px"
-                          preserveAspectRatio="xMidYMid meet"
-                          stroke="none"
-                          strokeWidth="1"
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                          viewBox="0 0 24 24"
-                          width="24px"
-                        >
-                          <path
-                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                          />
-                          <path
-                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                          />
-                          <path
-                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                          />
-                        </svg>
-                        <div
-                          className="emotion-9"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "10 real-time edits/day",
-                            }
-                          }
-                        />
-                      </li>
-                      <li
-                        className="emotion-10"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-8"
-                          data-testid="icon-check"
-                          fill="currentColor"
-                          fillRule="evenodd"
-                          height="24px"
-                          preserveAspectRatio="xMidYMid meet"
-                          stroke="none"
-                          strokeWidth="1"
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                          viewBox="0 0 24 24"
-                          width="24px"
-                        >
-                          <path
-                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                          />
-                          <path
-                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                          />
-                          <path
-                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                          />
-                        </svg>
-                        <div
-                          className="emotion-9"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "nline documentation",
-                            }
-                          }
-                        />
-                      </li>
-                    </ul>
-                  </div>
-                  <div
-                    className="emotion-20"
-                  >
-                    <a
-                      className="emotion-19"
-                      href="/"
-                      onClick={[Function]}
-                      role="button"
-                    >
-                      <span>
-                        Subscribe
+                        $
                       </span>
-                    </a>
+                      <strong
+                        class="emotion-5"
+                      >
+                        0
+                      </strong>
+                      <span
+                        class="emotion-6"
+                      >
+                        / month
+                      </span>
+                    </div>
+                    <div
+                      class="emotion-18"
+                    >
+                      <ul
+                        class="emotion-17"
+                      >
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-8"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            Builds and Preview
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-8"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            10 real-time edits/day
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-8"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            nline documentation
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                    <div
+                      class="emotion-20"
+                    >
+                      <a
+                        aria-current="page"
+                        class="emotion-19"
+                        href="/"
+                      >
+                        Subscribe
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              className="emotion-46"
-            >
               <div
-                className="emotion-22"
+                class="emotion-23"
               >
                 <div
-                  className="emotion-21"
+                  class="emotion-22"
                 >
                   <div
-                    className="emotion-1"
+                    class="emotion-45"
                   >
-                    <img
-                      alt="Enterprise"
-                      className="emotion-0"
-                      src="test-file-stub"
-                    />
-                  </div>
-                  <h2
-                    className="emotion-26"
-                  >
-                    Enterprise
-                  </h2>
-                  <div
-                    className="emotion-27"
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "Custom packages designed for your company",
-                      }
-                    }
-                  />
-                  <div
-                    className="emotion-41"
-                  >
-                    <ul
-                      className="emotion-17"
+                    <div
+                      class="emotion-1"
                     >
-                      <li
-                        className="emotion-10"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-28"
-                          data-testid="icon-check"
-                          fill="currentColor"
-                          fillRule="evenodd"
-                          height="24px"
-                          preserveAspectRatio="xMidYMid meet"
-                          stroke="none"
-                          strokeWidth="1"
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                          viewBox="0 0 24 24"
-                          width="24px"
-                        >
-                          <path
-                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                          />
-                          <path
-                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                          />
-                          <path
-                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                          />
-                        </svg>
-                        <div
-                          className="emotion-9"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Builds and Preview",
-                            }
-                          }
-                        />
-                      </li>
-                      <li
-                        className="emotion-10"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-28"
-                          data-testid="icon-check"
-                          fill="currentColor"
-                          fillRule="evenodd"
-                          height="24px"
-                          preserveAspectRatio="xMidYMid meet"
-                          stroke="none"
-                          strokeWidth="1"
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                          viewBox="0 0 24 24"
-                          width="24px"
-                        >
-                          <path
-                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                          />
-                          <path
-                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                          />
-                          <path
-                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                          />
-                        </svg>
-                        <div
-                          className="emotion-9"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "1000 real-time edits/day",
-                            }
-                          }
-                        />
-                      </li>
-                      <li
-                        className="emotion-10"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-28"
-                          data-testid="icon-check"
-                          fill="currentColor"
-                          fillRule="evenodd"
-                          height="24px"
-                          preserveAspectRatio="xMidYMid meet"
-                          stroke="none"
-                          strokeWidth="1"
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                          viewBox="0 0 24 24"
-                          width="24px"
-                        >
-                          <path
-                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                          />
-                          <path
-                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                          />
-                          <path
-                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                          />
-                        </svg>
-                        <div
-                          className="emotion-9"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Online documentation",
-                            }
-                          }
-                        />
-                      </li>
-                      <li
-                        className="emotion-10"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-28"
-                          data-testid="icon-check"
-                          fill="currentColor"
-                          fillRule="evenodd"
-                          height="24px"
-                          preserveAspectRatio="xMidYMid meet"
-                          stroke="none"
-                          strokeWidth="1"
-                          style={
-                            Object {
-                              "verticalAlign": "middle",
-                            }
-                          }
-                          viewBox="0 0 24 24"
-                          width="24px"
-                        >
-                          <path
-                            d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                          />
-                          <path
-                            d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                          />
-                          <path
-                            d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                          />
-                        </svg>
-                        <div
-                          className="emotion-9"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Dedicated account manager",
-                            }
-                          }
-                        />
-                      </li>
-                    </ul>
-                  </div>
-                  <div
-                    className="emotion-20"
-                  >
-                    <a
-                      className="emotion-19"
-                      href="/"
-                      onClick={[Function]}
-                      role="button"
+                      <img
+                        alt="Free"
+                        class="emotion-0"
+                        src="test-file-stub"
+                      />
+                    </div>
+                    <h2
+                      class="emotion-2"
                     >
-                      <span>
-                        Contact sales
+                      Free
+                    </h2>
+                    <div
+                      class="emotion-3"
+                    >
+                      For personal projects and single-purpose sites
+                    </div>
+                    <div
+                      class="emotion-7"
+                    >
+                      <span
+                        class="emotion-4"
+                      >
+                        $
                       </span>
-                    </a>
+                      <strong
+                        class="emotion-5"
+                      >
+                        0
+                      </strong>
+                      <span
+                        class="emotion-6"
+                      >
+                        / month
+                      </span>
+                    </div>
+                    <div
+                      class="emotion-18"
+                    >
+                      <ul
+                        class="emotion-17"
+                      >
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-8"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            Builds and Preview
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-8"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            10 real-time edits/day
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-8"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            nline documentation
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                    <div
+                      class="emotion-20"
+                    >
+                      <a
+                        aria-current="page"
+                        class="emotion-43"
+                        href="/"
+                      >
+                        Subscribe
+                        <svg
+                          fill="currentColor"
+                          height="1em"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                          />
+                        </svg>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-70"
+              >
+                <div
+                  class="emotion-22"
+                >
+                  <div
+                    class="emotion-68"
+                  >
+                    <div
+                      class="emotion-1"
+                    >
+                      <img
+                        alt="Enterprise"
+                        class="emotion-0"
+                        src="test-file-stub"
+                      />
+                    </div>
+                    <h2
+                      class="emotion-50"
+                    >
+                      Enterprise
+                    </h2>
+                    <div
+                      class="emotion-51"
+                    >
+                      Custom packages designed for your company
+                    </div>
+                    <div
+                      class="emotion-65"
+                    >
+                      <ul
+                        class="emotion-17"
+                      >
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-52"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            Builds and Preview
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-52"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            1000 real-time edits/day
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-52"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            Online documentation
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-52"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            Dedicated account manager
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                    <div
+                      class="emotion-20"
+                    >
+                      <a
+                        aria-current="page"
+                        class="emotion-66"
+                        href="/"
+                      >
+                        Contact sales
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-70"
+              >
+                <div
+                  class="emotion-22"
+                >
+                  <div
+                    class="emotion-91"
+                  >
+                    <div
+                      class="emotion-1"
+                    >
+                      <img
+                        alt="Enterprise"
+                        class="emotion-0"
+                        src="test-file-stub"
+                      />
+                    </div>
+                    <h2
+                      class="emotion-50"
+                    >
+                      Enterprise
+                    </h2>
+                    <div
+                      class="emotion-51"
+                    >
+                      Custom packages designed for your company
+                    </div>
+                    <div
+                      class="emotion-65"
+                    >
+                      <ul
+                        class="emotion-17"
+                      >
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-52"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            Builds and Preview
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-52"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            1000 real-time edits/day
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-52"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            Online documentation
+                          </div>
+                        </li>
+                        <li
+                          class="emotion-10"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="emotion-52"
+                            data-testid="icon-check"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            height="24px"
+                            preserveAspectRatio="xMidYMid meet"
+                            stroke="none"
+                            stroke-width="1"
+                            style="vertical-align: middle;"
+                            viewBox="0 0 24 24"
+                            width="24px"
+                          >
+                            <path
+                              d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                            />
+                            <path
+                              d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                            />
+                            <path
+                              d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                            />
+                          </svg>
+                          <div
+                            class="emotion-9"
+                          >
+                            Dedicated account manager
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                    <div
+                      class="emotion-20"
+                    >
+                      <a
+                        aria-current="page"
+                        class="emotion-89"
+                        href="/"
+                      >
+                        Contact sales
+                        <svg
+                          fill="currentColor"
+                          height="1em"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                          />
+                        </svg>
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -11099,6 +17385,244 @@ exports[`Storyshots core/PricingCard variants 1`] = `
 `;
 
 exports[`Storyshots core/SettingsBlock default usage 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -11472,14 +17996,6 @@ exports[`Storyshots core/SettingsBlock default usage 1`] = `
   transform: scale(1);
 }
 
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-0:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -11541,173 +18057,155 @@ exports[`Storyshots core/SettingsBlock default usage 1`] = `
   }
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-22"
-      >
+      <div>
         <div
-          className="emotion-21"
-          width="35em"
+          class="emotion-22"
         >
           <div
-            className="emotion-5"
+            class="emotion-21"
+            width="35em"
           >
-            <header
-              className="emotion-2"
-            >
-              <h3
-                className="emotion-1"
-              >
-                Automated Integrations
-                <a
-                  className="emotion-0"
-                  href="/"
-                  role="button"
-                >
-                  <svg
-                    className={undefined}
-                    fill="currentColor"
-                    height="1em"
-                    stroke="currentColor"
-                    strokeWidth="0"
-                    style={
-                      Object {
-                        "color": undefined,
-                      }
-                    }
-                    viewBox="0 0 24 24"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
-                    />
-                  </svg>
-                </a>
-              </h3>
-            </header>
             <div
-              className="emotion-4"
+              class="emotion-5"
             >
-              <div
-                className="emotion-3"
+              <header
+                class="emotion-2"
               >
-                This is the Block's content section
+                <h3
+                  class="emotion-1"
+                >
+                  Automated Integrations
+                  <button
+                    class="emotion-0"
+                    to="/"
+                    type="button"
+                  >
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
+                      />
+                    </svg>
+                  </button>
+                </h3>
+              </header>
+              <div
+                class="emotion-4"
+              >
+                <div
+                  class="emotion-3"
+                >
+                  This is the Block's content section
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            className="emotion-5"
-          >
-            <header
-              className="emotion-2"
-            >
-              <h3
-                className="emotion-1"
-              >
-                Automated Integrations 
-                <a
-                  className="emotion-0"
-                  href="/"
-                  role="button"
-                >
-                  <svg
-                    className={undefined}
-                    fill="currentColor"
-                    height="1em"
-                    stroke="currentColor"
-                    strokeWidth="0"
-                    style={
-                      Object {
-                        "color": undefined,
-                      }
-                    }
-                    viewBox="0 0 24 24"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
-                    />
-                  </svg>
-                </a>
-              </h3>
-              <p
-                className="emotion-8"
-              >
-                Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
-              </p>
-            </header>
             <div
-              className="emotion-4"
+              class="emotion-5"
             >
-              <div
-                className="emotion-3"
+              <header
+                class="emotion-2"
               >
-                This is the Block's content section
+                <h3
+                  class="emotion-1"
+                >
+                  Automated Integrations 
+                  <button
+                    class="emotion-0"
+                    to="/"
+                    type="button"
+                  >
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
+                      />
+                    </svg>
+                  </button>
+                </h3>
+                <p
+                  class="emotion-8"
+                >
+                  Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+                </p>
+              </header>
+              <div
+                class="emotion-4"
+              >
+                <div
+                  class="emotion-3"
+                >
+                  This is the Block's content section
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            className="emotion-5"
-          >
-            <header
-              className="emotion-2"
-            >
-              <h3
-                className="emotion-1"
-              >
-                Automated Integrations 
-                <a
-                  className="emotion-0"
-                  href="/"
-                  role="button"
-                >
-                  <svg
-                    className={undefined}
-                    fill="currentColor"
-                    height="1em"
-                    stroke="currentColor"
-                    strokeWidth="0"
-                    style={
-                      Object {
-                        "color": undefined,
-                      }
-                    }
-                    viewBox="0 0 24 24"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
-                    />
-                  </svg>
-                </a>
-              </h3>
-              <p
-                className="emotion-8"
-              >
-                Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
-              </p>
-              <p
-                className="emotion-8"
-              >
-                CDN hosts of your choice—just connect and you are good to go!
-              </p>
-            </header>
             <div
-              className="emotion-4"
+              class="emotion-5"
             >
-              <div
-                className="emotion-3"
+              <header
+                class="emotion-2"
               >
-                This is the Block's content section
+                <h3
+                  class="emotion-1"
+                >
+                  Automated Integrations 
+                  <button
+                    class="emotion-0"
+                    to="/"
+                    type="button"
+                  >
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
+                      />
+                    </svg>
+                  </button>
+                </h3>
+                <p
+                  class="emotion-8"
+                >
+                  Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+                </p>
+                <p
+                  class="emotion-8"
+                >
+                  CDN hosts of your choice—just connect and you are good to go!
+                </p>
+              </header>
+              <div
+                class="emotion-4"
+              >
+                <div
+                  class="emotion-3"
+                >
+                  This is the Block's content section
+                </div>
               </div>
             </div>
           </div>
@@ -11830,46 +18328,46 @@ exports[`Storyshots core/SettingsBlock shortcut usage 1`] = `
   }
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-7"
-      >
+      <div>
         <div
-          className="emotion-6"
-          width="35em"
+          class="emotion-7"
         >
           <div
-            className="emotion-5"
-            doclink="/"
+            class="emotion-6"
+            width="35em"
           >
-            <header
-              className="emotion-2"
-            >
-              <h3
-                className="emotion-0"
-              >
-                Automated Integrations
-                 
-              </h3>
-              <p
-                className="emotion-1"
-              >
-                 Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
-              </p>
-            </header>
             <div
-              className="emotion-4"
+              class="emotion-5"
+              doclink="/"
             >
-              <div
-                className="emotion-3"
+              <header
+                class="emotion-2"
               >
-                This is the Block's content section
+                <h3
+                  class="emotion-0"
+                >
+                  Automated Integrations
+                   
+                </h3>
+                <p
+                  class="emotion-1"
+                >
+                   Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+                </p>
+              </header>
+              <div
+                class="emotion-4"
+              >
+                <div
+                  class="emotion-3"
+                >
+                  This is the Block's content section
+                </div>
               </div>
             </div>
           </div>
@@ -12030,72 +18528,70 @@ exports[`Storyshots core/SettingsBlock with Announcement 1`] = `
   }
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-11"
-      >
+      <div>
         <div
-          className="emotion-10"
-          width="35em"
+          class="emotion-11"
         >
           <div
-            className="emotion-9"
-            doclink="/"
+            class="emotion-10"
+            width="35em"
           >
-            <header
-              className="emotion-2"
-            >
-              <h3
-                className="emotion-0"
-              >
-                Automated Integrations
-                 
-              </h3>
-              <p
-                className="emotion-1"
-              >
-                 Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
-              </p>
-            </header>
             <div
-              className="emotion-8"
+              class="emotion-9"
+              doclink="/"
             >
-              <div
-                className="emotion-4"
-                onClickEdit={[Function]}
+              <header
+                class="emotion-2"
               >
-                <span
-                  className="emotion-3"
+                <h3
+                  class="emotion-0"
                 >
-                  <img
-                    alt="Contentful"
-                    src="test-file-stub"
-                  />
-                </span>
-              </div>
-              <div
-                className="emotion-4"
-                onClickEdit={[Function]}
-              >
-                <span
-                  className="emotion-3"
+                  Automated Integrations
+                   
+                </h3>
+                <p
+                  class="emotion-1"
                 >
-                  <img
-                    alt="Netlify"
-                    src="test-file-stub"
-                  />
-                </span>
-              </div>
+                   Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+                </p>
+              </header>
               <div
-                className="emotion-7"
+                class="emotion-8"
               >
-                We are working on adding more integrations all the time—watch your inbox!
+                <div
+                  class="emotion-4"
+                >
+                  <span
+                    class="emotion-3"
+                  >
+                    <img
+                      alt="Contentful"
+                      src="test-file-stub"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="emotion-4"
+                >
+                  <span
+                    class="emotion-3"
+                  >
+                    <img
+                      alt="Netlify"
+                      src="test-file-stub"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="emotion-7"
+                >
+                  We are working on adding more integrations all the time—watch your inbox!
+                </div>
               </div>
             </div>
           </div>
@@ -12233,67 +18729,65 @@ exports[`Storyshots core/SettingsBlock with items 1`] = `
   }
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-10"
-      >
+      <div>
         <div
-          className="emotion-9"
-          width="35em"
+          class="emotion-10"
         >
           <div
-            className="emotion-8"
-            doclink="/"
+            class="emotion-9"
+            width="35em"
           >
-            <header
-              className="emotion-2"
-            >
-              <h3
-                className="emotion-0"
-              >
-                Automated Integrations
-                 
-              </h3>
-              <p
-                className="emotion-1"
-              >
-                 Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
-              </p>
-            </header>
             <div
-              className="emotion-7"
+              class="emotion-8"
+              doclink="/"
             >
-              <div
-                className="emotion-4"
-                onClickEdit={[Function]}
+              <header
+                class="emotion-2"
               >
-                <span
-                  className="emotion-3"
+                <h3
+                  class="emotion-0"
                 >
-                  <img
-                    alt="Contentful"
-                    src="test-file-stub"
-                  />
-                </span>
-              </div>
+                  Automated Integrations
+                   
+                </h3>
+                <p
+                  class="emotion-1"
+                >
+                   Gatsby Cloud can automatically deploy each site build to one or more CDN hosts of your choice—just connect and you are good to go!
+                </p>
+              </header>
               <div
-                className="emotion-4"
-                onClickEdit={[Function]}
+                class="emotion-7"
               >
-                <span
-                  className="emotion-3"
+                <div
+                  class="emotion-4"
                 >
-                  <img
-                    alt="Netlify"
-                    src="test-file-stub"
-                  />
-                </span>
+                  <span
+                    class="emotion-3"
+                  >
+                    <img
+                      alt="Contentful"
+                      src="test-file-stub"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="emotion-4"
+                >
+                  <span
+                    class="emotion-3"
+                  >
+                    <img
+                      alt="Netlify"
+                      src="test-file-stub"
+                    />
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -12571,6 +19065,244 @@ exports[`Storyshots core/SettingsCard custom EditButton 1`] = `
   }
 }
 
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 .emotion-10 {
   display: grid;
   justify-items: start;
@@ -12621,14 +19353,6 @@ exports[`Storyshots core/SettingsCard custom EditButton 1`] = `
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
-}
-
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
 }
 
 .emotion-1:hover:not([disabled]) svg {
@@ -12706,116 +19430,96 @@ exports[`Storyshots core/SettingsCard custom EditButton 1`] = `
   margin-bottom: 1rem;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-11"
-      >
+      <div>
         <div
-          className="emotion-10"
-          width="35em"
+          class="emotion-11"
         >
           <div
-            className="emotion-4"
+            class="emotion-10"
+            width="35em"
           >
-            <h3
-              className="emotion-0"
+            <div
+              class="emotion-4"
             >
-              Card's title
-            </h3>
-            <button
-              className="emotion-1"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span>
+              <h3
+                class="emotion-0"
+              >
+                Card's title
+              </h3>
+              <button
+                class="emotion-1"
+                type="button"
+              >
                 Change
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                  />
+                </svg>
+              </button>
+              <div
+                class="emotion-3"
               >
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                />
-              </svg>
-            </button>
-            <div
-              className="emotion-3"
-            >
-              <p
-                className="emotion-2"
-              >
-                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-              </p>
+                <p
+                  class="emotion-2"
+                >
+                  Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                </p>
+              </div>
             </div>
-          </div>
-          <div
-            className="emotion-4"
-          >
-            <h3
-              className="emotion-0"
+            <div
+              class="emotion-4"
             >
-              Card's title
-            </h3>
-            <button
-              className="emotion-1"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span>
+              <h3
+                class="emotion-0"
+              >
+                Card's title
+              </h3>
+              <button
+                class="emotion-1"
+                type="button"
+              >
                 Add 
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                  />
+                </svg>
+              </button>
+              <div
+                class="emotion-3"
               >
-                <path
-                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                />
-              </svg>
-            </button>
-            <div
-              className="emotion-3"
-            >
-              <p
-                className="emotion-2"
-              >
-                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-              </p>
+                <p
+                  class="emotion-2"
+                >
+                  Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                </p>
+              </div>
             </div>
           </div>
+           
         </div>
-         
       </div>
     </div>
   </div>
@@ -12823,6 +19527,244 @@ exports[`Storyshots core/SettingsCard custom EditButton 1`] = `
 `;
 
 exports[`Storyshots core/SettingsCard default usage 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -13141,14 +20083,6 @@ exports[`Storyshots core/SettingsCard default usage 1`] = `
   transform: scale(1);
 }
 
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-1:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -13224,65 +20158,55 @@ exports[`Storyshots core/SettingsCard default usage 1`] = `
   margin-bottom: 1rem;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-6"
-      >
+      <div>
         <div
-          className="emotion-5"
-          width="35em"
+          class="emotion-6"
         >
           <div
-            className="emotion-4"
+            class="emotion-5"
+            width="35em"
           >
-            <h3
-              className="emotion-0"
-            >
-              Card's title
-            </h3>
-            <button
-              className="emotion-1"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span>
-                Edit
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                />
-              </svg>
-            </button>
             <div
-              className="emotion-3"
+              class="emotion-4"
             >
-              <p
-                className="emotion-2"
+              <h3
+                class="emotion-0"
               >
-                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-              </p>
+                Card's title
+              </h3>
+              <button
+                class="emotion-1"
+                type="button"
+              >
+                Edit
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                  />
+                </svg>
+              </button>
+              <div
+                class="emotion-3"
+              >
+                <p
+                  class="emotion-2"
+                >
+                  Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                </p>
+              </div>
             </div>
           </div>
         </div>
@@ -13293,6 +20217,244 @@ exports[`Storyshots core/SettingsCard default usage 1`] = `
 `;
 
 exports[`Storyshots core/SettingsCard no secondary conent 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -13611,14 +20773,6 @@ exports[`Storyshots core/SettingsCard no secondary conent 1`] = `
   transform: scale(1);
 }
 
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-1:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -13713,126 +20867,106 @@ exports[`Storyshots core/SettingsCard no secondary conent 1`] = `
   margin-bottom: 1rem;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-13"
-      >
+      <div>
         <div
-          className="emotion-12"
-          width="35em"
+          class="emotion-13"
         >
           <div
-            className="emotion-4"
+            class="emotion-12"
+            width="35em"
           >
-            <h3
-              className="emotion-0"
-            >
-              Card's title
-            </h3>
-            <button
-              className="emotion-1"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span>
-                Edit
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                />
-              </svg>
-            </button>
             <div
-              className="emotion-3"
+              class="emotion-4"
             >
-              <p
-                className="emotion-2"
+              <h3
+                class="emotion-0"
               >
-                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-              </p>
-            </div>
-          </div>
-          <div
-            className="emotion-4"
-          >
-            <h3
-              className="emotion-0"
-            >
-              Card's title
-            </h3>
-            <button
-              className="emotion-1"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span>
+                Card's title
+              </h3>
+              <button
+                class="emotion-1"
+                type="button"
+              >
                 Edit
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                />
-              </svg>
-            </button>
-            <div
-              className="emotion-3"
-            >
-              <p
-                className="emotion-2"
-              >
-                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-              </p>
-              <p
-                className="emotion-2"
-              >
-                Amaranth tatsoi tomatillo melon azuki bean garlic.
-              </p>
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                  />
+                </svg>
+              </button>
               <div
-                className="emotion-9"
+                class="emotion-3"
               >
-                PRIMARY CONTENT
+                <p
+                  class="emotion-2"
+                >
+                  Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                </p>
+              </div>
+            </div>
+            <div
+              class="emotion-4"
+            >
+              <h3
+                class="emotion-0"
+              >
+                Card's title
+              </h3>
+              <button
+                class="emotion-1"
+                type="button"
+              >
+                Edit
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                  />
+                </svg>
+              </button>
+              <div
+                class="emotion-3"
+              >
+                <p
+                  class="emotion-2"
+                >
+                  Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                </p>
+                <p
+                  class="emotion-2"
+                >
+                  Amaranth tatsoi tomatillo melon azuki bean garlic.
+                </p>
+                <div
+                  class="emotion-9"
+                >
+                  PRIMARY CONTENT
+                </div>
               </div>
             </div>
           </div>
+           
         </div>
-         
       </div>
     </div>
   </div>
@@ -13840,6 +20974,244 @@ exports[`Storyshots core/SettingsCard no secondary conent 1`] = `
 `;
 
 exports[`Storyshots core/SettingsCard with custom tone 1`] = `
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
+@keyframes animation-0 {
+  33% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  66% {
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+  }
+}
+
 @keyframes animation-0 {
   33% {
     -webkit-transform: scale(1);
@@ -14237,14 +21609,6 @@ exports[`Storyshots core/SettingsCard with custom tone 1`] = `
   transform: scale(1);
 }
 
-.emotion-1 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-1 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-1:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -14255,65 +21619,55 @@ exports[`Storyshots core/SettingsCard with custom tone 1`] = `
   color: #da0013;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-6"
-      >
+      <div>
         <div
-          className="emotion-5"
-          width="35em"
+          class="emotion-6"
         >
           <div
-            className="emotion-4"
+            class="emotion-5"
+            width="35em"
           >
-            <h3
-              className="emotion-0"
-            >
-              Delete ite
-            </h3>
-            <button
-              className="emotion-1"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span>
-                Delete site 
-              </span>
-              <svg
-                className={undefined}
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                strokeWidth="0"
-                style={
-                  Object {
-                    "color": undefined,
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                />
-              </svg>
-            </button>
             <div
-              className="emotion-3"
+              class="emotion-4"
             >
-              <p
-                className="emotion-2"
+              <h3
+                class="emotion-0"
               >
-                Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-              </p>
+                Delete ite
+              </h3>
+              <button
+                class="emotion-1"
+                type="button"
+              >
+                Delete site 
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                  />
+                </svg>
+              </button>
+              <div
+                class="emotion-3"
+              >
+                <p
+                  class="emotion-2"
+                >
+                  Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                </p>
+              </div>
             </div>
           </div>
         </div>
@@ -14353,6 +21707,7 @@ exports[`Storyshots core/Switch usage 1`] = `
   display: flex;
   color: #232129;
   cursor: pointer;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
   font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
   -webkit-letter-spacing: 0.03em;
   -moz-letter-spacing: 0.03em;
@@ -14388,7 +21743,6 @@ exports[`Storyshots core/Switch usage 1`] = `
   cursor: pointer;
   display: inline-block;
   height: 24px;
-  margin-right: 0.5rem;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -14401,6 +21755,7 @@ exports[`Storyshots core/Switch usage 1`] = `
   user-select: none;
   width: 48px;
   margin-left: 0;
+  margin-right: 0.5rem;
 }
 
 label:focus-within > .emotion-2 {
@@ -14442,55 +21797,53 @@ label:focus-within > .emotion-2 {
   position: absolute;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-6"
-      >
-        <label
-          className="emotion-5"
-          htmlFor="interval_primary"
+      <div>
+        <div
+          class="emotion-6"
         >
-          <span
-            aria-hidden={true}
-            className="emotion-0"
-          >
-            MONTHLY
-          </span>
-          <input
-            checked={false}
-            className="emotion-1"
-            id="interval_primary"
-            name="interval_primary"
-            onChange={[Function]}
-            type="checkbox"
-            value={true}
-          />
-          <span
-            aria-hidden={true}
-            className="emotion-2"
-          />
-          <span
-            className="emotion-4"
+          <label
+            class="emotion-5"
+            for="interval_primary"
           >
             <span
-              aria-hidden={true}
+              aria-hidden="true"
+              class="emotion-0"
             >
-              YEARLY
+              MONTHLY
             </span>
+            <input
+              class="emotion-1"
+              id="interval_primary"
+              name="interval_primary"
+              type="checkbox"
+              value="true"
+            />
             <span
-              className="emotion-3"
+              aria-hidden="true"
+              class="emotion-2"
+            />
+            <span
+              class="emotion-4"
             >
-               
-              YEARLY PAYMENT
+              <span
+                aria-hidden="true"
+              >
+                YEARLY
+              </span>
+              <span
+                class="emotion-3"
+              >
+                 
+                YEARLY PAYMENT
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
   </div>
@@ -14533,6 +21886,7 @@ exports[`Storyshots core/Switch with Formik 1`] = `
   display: flex;
   color: #232129;
   cursor: pointer;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
   font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
   -webkit-letter-spacing: 0.03em;
   -moz-letter-spacing: 0.03em;
@@ -14568,7 +21922,6 @@ exports[`Storyshots core/Switch with Formik 1`] = `
   cursor: pointer;
   display: inline-block;
   height: 24px;
-  margin-right: 0.5rem;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -14581,6 +21934,7 @@ exports[`Storyshots core/Switch with Formik 1`] = `
   user-select: none;
   width: 48px;
   margin-left: 0;
+  margin-right: 0.5rem;
 }
 
 label:focus-within > .emotion-2 {
@@ -14648,70 +22002,67 @@ label:focus-within > .emotion-2 {
   overflow-x: scroll;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-10"
-      >
-        <form
-          className="emotion-9"
+      <div>
+        <div
+          class="emotion-10"
         >
-          <label
-            className="emotion-5"
-            htmlFor="subInterval_primary"
+          <form
+            class="emotion-9"
           >
-            <span
-              aria-hidden={true}
-              className="emotion-0"
-            >
-              MONTHLY
-            </span>
-            <input
-              checked={false}
-              className="emotion-1"
-              id="subInterval_primary"
-              name="subInterval_primary"
-              onChange={[Function]}
-              type="checkbox"
-              value={true}
-            />
-            <span
-              aria-hidden={true}
-              className="emotion-2"
-            />
-            <span
-              className="emotion-4"
+            <label
+              class="emotion-5"
+              for="subInterval_primary"
             >
               <span
-                aria-hidden={true}
+                aria-hidden="true"
+                class="emotion-0"
               >
-                YEARLY
+                MONTHLY
               </span>
+              <input
+                class="emotion-1"
+                id="subInterval_primary"
+                name="subInterval_primary"
+                type="checkbox"
+                value="true"
+              />
               <span
-                className="emotion-3"
+                aria-hidden="true"
+                class="emotion-2"
+              />
+              <span
+                class="emotion-4"
               >
-                 
-                YEARLY PAYMENT
+                <span
+                  aria-hidden="true"
+                >
+                  YEARLY
+                </span>
+                <span
+                  class="emotion-3"
+                >
+                   
+                  YEARLY PAYMENT
+                </span>
               </span>
-            </span>
-          </label>
-          <div
-            className="emotion-8"
-          >
+            </label>
             <div
-              className="emotion-6"
+              class="emotion-8"
             >
-              Formik State
-            </div>
-            <pre
-              className="emotion-7"
-            >
-              {
+              <div
+                class="emotion-6"
+              >
+                Formik State
+              </div>
+              <pre
+                class="emotion-7"
+              >
+                {
   "values": {
     "subInterval": "MONTHLY"
   },
@@ -14728,9 +22079,10 @@ label:focus-within > .emotion-2 {
   "validateOnChange": true,
   "validateOnBlur": true
 }
-            </pre>
-          </div>
-        </form>
+              </pre>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   </div>
@@ -14738,7 +22090,7 @@ label:focus-within > .emotion-2 {
 `;
 
 exports[`Storyshots core/Toggle before or after label 1`] = `
-.emotion-9 {
+.emotion-7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14756,7 +22108,7 @@ exports[`Storyshots core/Toggle before or after label 1`] = `
   padding: 20px;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: grid;
   justify-items: start;
   grid-gap: 2rem;
@@ -14774,7 +22126,7 @@ exports[`Storyshots core/Toggle before or after label 1`] = `
   position: absolute;
 }
 
-.emotion-3 {
+.emotion-2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14788,7 +22140,7 @@ exports[`Storyshots core/Toggle before or after label 1`] = `
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
 }
 
-.emotion-3 span:last-child {
+.emotion-2 span:last-child {
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
@@ -14800,7 +22152,6 @@ exports[`Storyshots core/Toggle before or after label 1`] = `
   cursor: pointer;
   display: inline-block;
   height: 24px;
-  margin-right: 0.5rem;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -14813,6 +22164,7 @@ exports[`Storyshots core/Toggle before or after label 1`] = `
   user-select: none;
   width: 48px;
   margin-left: 0;
+  margin-right: 0.5rem;
 }
 
 label:focus-within > .emotion-1 {
@@ -14838,7 +22190,7 @@ label:focus-within > .emotion-1 {
   width: 24px;
 }
 
-.emotion-7 {
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14852,19 +22204,18 @@ label:focus-within > .emotion-1 {
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
 }
 
-.emotion-7 span:last-child {
+.emotion-5 span:last-child {
   -webkit-order: 0;
   -ms-flex-order: 0;
   order: 0;
 }
 
-.emotion-5 {
+.emotion-4 {
   background: #8a4baf;
   border-radius: 999px;
   cursor: pointer;
   display: inline-block;
   height: 24px;
-  margin-right: 0;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -14877,14 +22228,15 @@ label:focus-within > .emotion-1 {
   user-select: none;
   width: 48px;
   margin-left: 0.5rem;
+  margin-right: 0;
 }
 
-label:focus-within > .emotion-5 {
+label:focus-within > .emotion-4 {
   box-shadow: 0 0 0 3px #f1defa;
   outline: 0;
 }
 
-.emotion-5:after {
+.emotion-4:after {
   background: #ffffff;
   left: 0;
   position: relative;
@@ -14897,70 +22249,64 @@ label:focus-within > .emotion-5 {
   transition: all 0.1s ease;
 }
 
-.emotion-5:active:after {
+.emotion-4:active:after {
   left: 0;
   width: 24px;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-9"
-      >
+      <div>
         <div
-          className="emotion-8"
+          class="emotion-7"
         >
-          <label
-            className="emotion-3"
-            htmlFor="subInterval"
+          <div
+            class="emotion-6"
           >
-            <input
-              checked={true}
-              className="emotion-0"
-              id="subInterval"
-              name="subInterval"
-              onChange={[Function]}
-              type="checkbox"
-              value={true}
-            />
-            <span
-              aria-hidden={true}
-              className="emotion-1"
-            />
-            <span
-              className="emotion-2"
+            <label
+              class="emotion-2"
+              for="subInterval"
             >
-              Yearly payment
-            </span>
-          </label>
-          <label
-            className="emotion-7"
-            htmlFor="renew"
-          >
-            <input
-              checked={true}
-              className="emotion-0"
-              id="renew"
-              name="renew"
-              onChange={[Function]}
-              type="checkbox"
-              value={true}
-            />
-            <span
-              aria-hidden={true}
-              className="emotion-5"
-            />
-            <span
-              className="emotion-2"
+              <input
+                checked=""
+                class="emotion-0"
+                id="subInterval"
+                name="subInterval"
+                type="checkbox"
+                value="true"
+              />
+              <span
+                aria-hidden="true"
+                class="emotion-1"
+              />
+              <span>
+                Yearly payment
+              </span>
+            </label>
+            <label
+              class="emotion-5"
+              for="renew"
             >
-              Automaticaly renew
-            </span>
-          </label>
+              <input
+                checked=""
+                class="emotion-0"
+                id="renew"
+                name="renew"
+                type="checkbox"
+                value="true"
+              />
+              <span
+                aria-hidden="true"
+                class="emotion-4"
+              />
+              <span>
+                Automaticaly renew
+              </span>
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -14969,7 +22315,7 @@ label:focus-within > .emotion-5 {
 `;
 
 exports[`Storyshots core/Toggle shortcut usage 1`] = `
-.emotion-9 {
+.emotion-7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14987,7 +22333,7 @@ exports[`Storyshots core/Toggle shortcut usage 1`] = `
   padding: 20px;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: grid;
   justify-items: start;
   grid-gap: 2rem;
@@ -15005,13 +22351,12 @@ exports[`Storyshots core/Toggle shortcut usage 1`] = `
   position: absolute;
 }
 
-.emotion-5 {
+.emotion-4 {
   background: #d9d7e0;
   border-radius: 999px;
   cursor: pointer;
   display: inline-block;
   height: 24px;
-  margin-right: 0.5rem;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -15024,14 +22369,15 @@ exports[`Storyshots core/Toggle shortcut usage 1`] = `
   user-select: none;
   width: 48px;
   margin-left: 0;
+  margin-right: 0.5rem;
 }
 
-label:focus-within > .emotion-5 {
+label:focus-within > .emotion-4 {
   box-shadow: 0 0 0 3px #f1defa;
   outline: 0;
 }
 
-.emotion-5:after {
+.emotion-4:after {
   background: #ffffff;
   left: 0;
   position: relative;
@@ -15044,12 +22390,12 @@ label:focus-within > .emotion-5 {
   transition: all 0.1s ease;
 }
 
-.emotion-5:active:after {
+.emotion-4:active:after {
   left: 0;
   width: 24px;
 }
 
-.emotion-3 {
+.emotion-2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -15063,7 +22409,7 @@ label:focus-within > .emotion-5 {
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
 }
 
-.emotion-3 span:last-child {
+.emotion-2 span:last-child {
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
@@ -15075,7 +22421,6 @@ label:focus-within > .emotion-5 {
   cursor: pointer;
   display: inline-block;
   height: 24px;
-  margin-right: 0.5rem;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -15088,6 +22433,7 @@ label:focus-within > .emotion-5 {
   user-select: none;
   width: 48px;
   margin-left: 0;
+  margin-right: 0.5rem;
 }
 
 label:focus-within > .emotion-1 {
@@ -15113,65 +22459,58 @@ label:focus-within > .emotion-1 {
   width: 24px;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-9"
-      >
+      <div>
         <div
-          className="emotion-8"
+          class="emotion-7"
         >
-          <label
-            className="emotion-3"
-            htmlFor="subInterval"
+          <div
+            class="emotion-6"
           >
-            <input
-              checked={true}
-              className="emotion-0"
-              id="subInterval"
-              name="subInterval"
-              onChange={[Function]}
-              type="checkbox"
-              value={true}
-            />
-            <span
-              aria-hidden={true}
-              className="emotion-1"
-            />
-            <span
-              className="emotion-2"
+            <label
+              class="emotion-2"
+              for="subInterval"
             >
-              Yearly payment
-            </span>
-          </label>
-          <label
-            className="emotion-3"
-            htmlFor="renew"
-          >
-            <input
-              checked={false}
-              className="emotion-0"
-              id="renew"
-              name="renew"
-              onChange={[Function]}
-              type="checkbox"
-              value={true}
-            />
-            <span
-              aria-hidden={true}
-              className="emotion-5"
-            />
-            <span
-              className="emotion-2"
+              <input
+                checked=""
+                class="emotion-0"
+                id="subInterval"
+                name="subInterval"
+                type="checkbox"
+                value="true"
+              />
+              <span
+                aria-hidden="true"
+                class="emotion-1"
+              />
+              <span>
+                Yearly payment
+              </span>
+            </label>
+            <label
+              class="emotion-2"
+              for="renew"
             >
-              Automaticaly renew
-            </span>
-          </label>
+              <input
+                class="emotion-0"
+                id="renew"
+                name="renew"
+                type="checkbox"
+                value="true"
+              />
+              <span
+                aria-hidden="true"
+                class="emotion-4"
+              />
+              <span>
+                Automaticaly renew
+              </span>
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -15180,7 +22519,7 @@ label:focus-within > .emotion-1 {
 `;
 
 exports[`Storyshots core/Toggle with Formik 1`] = `
-.emotion-8 {
+.emotion-7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -15198,7 +22537,7 @@ exports[`Storyshots core/Toggle with Formik 1`] = `
   padding: 20px;
 }
 
-.emotion-7 {
+.emotion-6 {
   display: grid;
   justify-items: start;
   grid-gap: 2rem;
@@ -15222,7 +22561,6 @@ exports[`Storyshots core/Toggle with Formik 1`] = `
   cursor: pointer;
   display: inline-block;
   height: 24px;
-  margin-right: 0.5rem;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -15235,6 +22573,7 @@ exports[`Storyshots core/Toggle with Formik 1`] = `
   user-select: none;
   width: 48px;
   margin-left: 0;
+  margin-right: 0.5rem;
 }
 
 label:focus-within > .emotion-1 {
@@ -15260,14 +22599,14 @@ label:focus-within > .emotion-1 {
   width: 24px;
 }
 
-.emotion-6 {
+.emotion-5 {
   margin: 3rem 0;
   border-radius: 4px;
   background: #f6f8fa;
   box-shadow: 0 0 1px #eee inset;
 }
 
-.emotion-4 {
+.emotion-3 {
   text-transform: uppercase;
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
@@ -15281,12 +22620,12 @@ label:focus-within > .emotion-1 {
   letter-spacing: 1px;
 }
 
-.emotion-5 {
+.emotion-4 {
   padding: .25rem .5rem;
   overflow-x: scroll;
 }
 
-.emotion-3 {
+.emotion-2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -15300,60 +22639,55 @@ label:focus-within > .emotion-1 {
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
 }
 
-.emotion-3 span:last-child {
+.emotion-2 span:last-child {
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-8"
-      >
-        <form
-          className="emotion-7"
+      <div>
+        <div
+          class="emotion-7"
         >
-          <label
-            className="emotion-3"
-            htmlFor="subscriptionInterval"
+          <form
+            class="emotion-6"
           >
-            <input
-              checked={false}
-              className="emotion-0"
-              id="subscriptionInterval"
-              name="subscriptionInterval"
-              onChange={[Function]}
-              type="checkbox"
-              value={true}
-            />
-            <span
-              aria-hidden={true}
-              className="emotion-1"
-            />
-            <span
-              className="emotion-2"
+            <label
+              class="emotion-2"
+              for="subscriptionInterval"
             >
-              Yearly payment
-            </span>
-          </label>
-          <div
-            className="emotion-6"
-          >
+              <input
+                class="emotion-0"
+                id="subscriptionInterval"
+                name="subscriptionInterval"
+                type="checkbox"
+                value="true"
+              />
+              <span
+                aria-hidden="true"
+                class="emotion-1"
+              />
+              <span>
+                Yearly payment
+              </span>
+            </label>
             <div
-              className="emotion-4"
+              class="emotion-5"
             >
-              Formik State
-            </div>
-            <pre
-              className="emotion-5"
-            >
-              {
+              <div
+                class="emotion-3"
+              >
+                Formik State
+              </div>
+              <pre
+                class="emotion-4"
+              >
+                {
   "values": {
     "subscriptionInterval": false,
     "automaticalRenew": false
@@ -15372,9 +22706,10 @@ label:focus-within > .emotion-1 {
   "validateOnChange": true,
   "validateOnBlur": true
 }
-            </pre>
-          </div>
-        </form>
+              </pre>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   </div>
@@ -15406,6 +22741,10 @@ exports[`Storyshots core/Toggle with a rich label 1`] = `
   grid-gap: 2rem;
 }
 
+.emotion-4 {
+  margin-left: 0.5rem;
+}
+
 .emotion-0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -15424,7 +22763,6 @@ exports[`Storyshots core/Toggle with a rich label 1`] = `
   cursor: pointer;
   display: inline-block;
   height: 24px;
-  margin-right: 0.5rem;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -15437,6 +22775,7 @@ exports[`Storyshots core/Toggle with a rich label 1`] = `
   user-select: none;
   width: 48px;
   margin-left: 0;
+  margin-right: 0.5rem;
 }
 
 label:focus-within > .emotion-1 {
@@ -15475,16 +22814,16 @@ label:focus-within > .emotion-1 {
   cursor: pointer;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
   margin-left: 0.75rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .emotion-5 span:last-child {
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
-}
-
-.emotion-4 {
-  margin-left: 0.5rem;
 }
 
 .emotion-2 {
@@ -15498,51 +22837,49 @@ label:focus-within > .emotion-1 {
   color: #78757a;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-7"
-      >
+      <div>
         <div
-          className="emotion-6"
+          class="emotion-7"
         >
-          <label
-            className="emotion-5"
-            htmlFor="subInterval"
+          <div
+            class="emotion-6"
           >
-            <input
-              checked={false}
-              className="emotion-0"
-              id="subInterval"
-              name="subInterval"
-              onChange={[Function]}
-              type="checkbox"
-              value={true}
-            />
-            <span
-              aria-hidden={true}
-              className="emotion-1"
-            />
-            <span
-              className="emotion-4"
+            <label
+              class="emotion-5"
+              for="subInterval"
             >
-              <strong
-                className="emotion-2"
+              <input
+                class="emotion-0"
+                id="subInterval"
+                name="subInterval"
+                type="checkbox"
+                value="true"
+              />
+              <span
+                aria-hidden="true"
+                class="emotion-1"
+              />
+              <span
+                class="emotion-4"
               >
-                Yearly payment
-              </strong>
-              <p
-                className="emotion-3"
-              >
-                This is label with HTML
-              </p>
-            </span>
-          </label>
+                <strong
+                  class="emotion-2"
+                >
+                  Yearly payment
+                </strong>
+                <p
+                  class="emotion-3"
+                >
+                  This is label with HTML
+                </p>
+              </span>
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -15605,63 +22942,50 @@ exports[`Storyshots core/ToggleTip shortcut usage 1`] = `
   position: relative;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-3"
-      >
+      <div>
         <div
-          className="emotion-2"
+          class="emotion-3"
         >
-          <p>
-            This is a text with ToggleTip
-             
-            <span
-              className="emotion-1"
-            >
-              <button
-                aria-expanded={false}
-                aria-haspopup="true"
-                aria-label="more info"
-                className="emotion-0"
-                onClick={[Function]}
-              >
-                <svg
-                  className={undefined}
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  strokeWidth="0"
-                  style={
-                    Object {
-                      "color": undefined,
-                    }
-                  }
-                  viewBox="0 0 24 24"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                  />
-                </svg>
-              </button>
+          <div
+            class="emotion-2"
+          >
+            <p>
+              This is a text with ToggleTip
+               
               <span
-                css={null}
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": null,
-                  }
-                }
-                role="status"
-              />
-            </span>
-          </p>
+                class="emotion-1"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="more info"
+                  class="emotion-0"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                    />
+                  </svg>
+                </button>
+                <span
+                  role="status"
+                />
+              </span>
+            </p>
+          </div>
         </div>
       </div>
     </div>
@@ -15744,251 +23068,235 @@ exports[`Storyshots icons All icons 1`] = `
   justify-content: space-around;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-14"
-      >
+      <div>
         <div
-          className="emotion-13"
+          class="emotion-14"
         >
-          <h2>
-            4
-             icon(s):
-          </h2>
           <div
-            className="emotion-12"
+            class="emotion-13"
           >
+            <h2>
+              4
+               icon(s):
+            </h2>
             <div
-              className="emotion-2"
+              class="emotion-12"
             >
               <div
-                className="emotion-0"
+                class="emotion-2"
               >
-                BlogIcon
-              </div>
-              <div
-                className="emotion-1"
-              >
-                <svg
-                  aria-hidden={true}
-                  color="#000"
-                  data-testid="icon-blog"
-                  fill="none"
-                  fillRule="evenodd"
-                  height="24px"
-                  preserveAspectRatio="xMidYMid meet"
-                  stroke="currentColor"
-                  strokeWidth="1"
-                  style={
-                    Object {
-                      "verticalAlign": "middle",
-                    }
-                  }
-                  viewBox="0 0 24 24"
-                  width="24px"
+                <div
+                  class="emotion-0"
                 >
-                  <path
-                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </div>
-            </div>
-            <div
-              className="emotion-2"
-            >
-              <div
-                className="emotion-0"
-              >
-                CheckIcon
-              </div>
-              <div
-                className="emotion-1"
-              >
-                <svg
-                  aria-hidden={true}
-                  color="#000"
-                  data-testid="icon-check"
-                  fill="currentColor"
-                  fillRule="evenodd"
-                  height="24px"
-                  preserveAspectRatio="xMidYMid meet"
-                  stroke="none"
-                  strokeWidth="1"
-                  style={
-                    Object {
-                      "verticalAlign": "middle",
-                    }
-                  }
-                  viewBox="0 0 24 24"
-                  width="24px"
+                  BlogIcon
+                </div>
+                <div
+                  class="emotion-1"
                 >
-                  <path
-                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                  />
-                  <path
-                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                  />
-                  <path
-                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    color="#000"
+                    data-testid="icon-blog"
+                    fill="none"
+                    fill-rule="evenodd"
+                    height="24px"
+                    preserveAspectRatio="xMidYMid meet"
+                    stroke="currentColor"
+                    stroke-width="1"
+                    style="vertical-align: middle;"
+                    viewBox="0 0 24 24"
+                    width="24px"
+                  >
+                    <path
+                      d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
               </div>
-            </div>
-            <div
-              className="emotion-2"
-            >
               <div
-                className="emotion-0"
+                class="emotion-2"
               >
-                EcommerceIcon
-              </div>
-              <div
-                className="emotion-1"
-              >
-                <svg
-                  aria-hidden={true}
-                  color="#000"
-                  data-testid="icon-ecommerce"
-                  fill="none"
-                  fillRule="evenodd"
-                  height="24px"
-                  preserveAspectRatio="xMidYMid meet"
-                  stroke="currentColor"
-                  strokeWidth="1"
-                  style={
-                    Object {
-                      "verticalAlign": "middle",
-                    }
-                  }
-                  viewBox="0 0 24 24"
-                  width="24px"
+                <div
+                  class="emotion-0"
                 >
-                  <path
-                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M16.4999 7.5L15.6709 3.75"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M9 7.5L9.828 3.75"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </div>
-            </div>
-            <div
-              className="emotion-2"
-            >
-              <div
-                className="emotion-0"
-              >
-                PortfolioIcon
-              </div>
-              <div
-                className="emotion-1"
-              >
-                <svg
-                  aria-hidden={true}
-                  color="#000"
-                  data-testid="icon-portfolio"
-                  fill="none"
-                  fillRule="evenodd"
-                  height="24px"
-                  preserveAspectRatio="xMidYMid meet"
-                  stroke="currentColor"
-                  strokeWidth="1"
-                  style={
-                    Object {
-                      "verticalAlign": "middle",
-                    }
-                  }
-                  viewBox="0 0 24 24"
-                  width="24px"
+                  CheckIcon
+                </div>
+                <div
+                  class="emotion-1"
                 >
-                  <path
-                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M6.74609 2.24799V0.747986"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M17.2461 2.24799V0.747986"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    color="#000"
+                    data-testid="icon-check"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    height="24px"
+                    preserveAspectRatio="xMidYMid meet"
+                    stroke="none"
+                    stroke-width="1"
+                    style="vertical-align: middle;"
+                    viewBox="0 0 24 24"
+                    width="24px"
+                  >
+                    <path
+                      d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                    />
+                    <path
+                      d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                    />
+                    <path
+                      d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="emotion-2"
+              >
+                <div
+                  class="emotion-0"
+                >
+                  EcommerceIcon
+                </div>
+                <div
+                  class="emotion-1"
+                >
+                  <svg
+                    aria-hidden="true"
+                    color="#000"
+                    data-testid="icon-ecommerce"
+                    fill="none"
+                    fill-rule="evenodd"
+                    height="24px"
+                    preserveAspectRatio="xMidYMid meet"
+                    stroke="currentColor"
+                    stroke-width="1"
+                    style="vertical-align: middle;"
+                    viewBox="0 0 24 24"
+                    width="24px"
+                  >
+                    <path
+                      d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M16.4999 7.5L15.6709 3.75"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M9 7.5L9.828 3.75"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="emotion-2"
+              >
+                <div
+                  class="emotion-0"
+                >
+                  PortfolioIcon
+                </div>
+                <div
+                  class="emotion-1"
+                >
+                  <svg
+                    aria-hidden="true"
+                    color="#000"
+                    data-testid="icon-portfolio"
+                    fill="none"
+                    fill-rule="evenodd"
+                    height="24px"
+                    preserveAspectRatio="xMidYMid meet"
+                    stroke="currentColor"
+                    stroke-width="1"
+                    style="vertical-align: middle;"
+                    viewBox="0 0 24 24"
+                    width="24px"
+                  >
+                    <path
+                      d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M6.74609 2.24799V0.747986"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M17.2461 2.24799V0.747986"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
               </div>
             </div>
           </div>
@@ -16065,838 +23373,762 @@ exports[`Storyshots icons/Single icons BlogIcon 1`] = `
   justify-content: space-around;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-43"
-      >
+      <div>
         <div
-          className="emotion-42"
+          class="emotion-43"
         >
-          <h1>
-            &lt;BlogIcon /&gt;
-          </h1>
-          <h2>
-            Size:
-          </h2>
           <div
-            className="emotion-2"
+            class="emotion-42"
           >
+            <h1>
+              &lt;BlogIcon /&gt;
+            </h1>
+            <h2>
+              Size:
+            </h2>
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              xsmall
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="16px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="16px"
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              small
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="24px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
+                xsmall
+              </div>
+              <div
+                class="emotion-1"
               >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="16px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="16px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
             </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              medium
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="32px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="32px"
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              large
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="40px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="40px"
+                small
+              </div>
+              <div
+                class="emotion-1"
               >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
             </div>
-          </div>
-          <h2>
-            Custom size:
-          </h2>
-          <div
-            className="emotion-2"
-          >
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              height=1em
-              <br />
-              width=1em
+              <div
+                class="emotion-0"
+              >
+                medium
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="32px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="32px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
             </div>
             <div
-              className="emotion-1"
+              class="emotion-2"
             >
+              <div
+                class="emotion-0"
+              >
+                large
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="40px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="40px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Custom size:
+            </h2>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=1em
+                <br />
+                width=1em
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="1em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=16px
+                <br />
+                width=16px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="16px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="16px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=24px
+                <br />
+                width=24px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=32px
+                <br />
+                width=32px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="32px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="32px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=40px
+                <br />
+                width=40px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="40px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="40px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=64px
+                <br />
+                width=64px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="64px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="64px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Color:
+            </h2>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(102, 51, 153);"
+                >
+                  #663399
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#663399"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(255, 178, 56);"
+                >
+                  #ffb238
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#ffb238"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(232, 153, 206);"
+                >
+                  #e899ce
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#e899ce"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(184, 0, 0);"
+                >
+                  #b80000
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#b80000"
+                  data-testid="icon-blog"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Inline
+            </h2>
+            <p>
+              Lorem ipsum 
               <svg
-                aria-hidden={true}
+                aria-hidden="true"
                 data-testid="icon-blog"
                 fill="none"
-                fillRule="evenodd"
+                fill-rule="evenodd"
                 height="1em"
                 preserveAspectRatio="xMidYMid meet"
                 stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-              >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=16px
-              <br />
-              width=16px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="16px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="16px"
-              >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=24px
-              <br />
-              width=24px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="24px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
+                stroke-width="1"
+                style="vertical-align: middle;"
                 viewBox="0 0 24 24"
                 width="24px"
               >
                 <path
                   d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
               </svg>
-            </div>
+               foo bar
+            </p>
           </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=32px
-              <br />
-              width=32px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="32px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="32px"
-              >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=40px
-              <br />
-              width=40px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="40px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="40px"
-              >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=64px
-              <br />
-              width=64px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="64px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="64px"
-              >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <h2>
-            Color:
-          </h2>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#663399",
-                  }
-                }
-              >
-                #663399
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#663399"
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#ffb238",
-                  }
-                }
-              >
-                #ffb238
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#ffb238"
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#e899ce",
-                  }
-                }
-              >
-                #e899ce
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#e899ce"
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#b80000",
-                  }
-                }
-              >
-                #b80000
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#b80000"
-                data-testid="icon-blog"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <h2>
-            Inline
-          </h2>
-          <p>
-            Lorem ipsum 
-            <svg
-              aria-hidden={true}
-              data-testid="icon-blog"
-              fill="none"
-              fillRule="evenodd"
-              height="1em"
-              preserveAspectRatio="xMidYMid meet"
-              stroke="currentColor"
-              strokeWidth="1"
-              style={
-                Object {
-                  "verticalAlign": "middle",
-                }
-              }
-              viewBox="0 0 24 24"
-              width="24px"
-            >
-              <path
-                d="M8.49188 11.265L7.43188 15.508L11.6739 14.447L18.0379 8.083L14.8559 4.901L8.49188 11.265Z"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M21.751 4.37097L22.811 5.43097C22.9504 5.57027 23.061 5.73567 23.1364 5.91772C23.2119 6.09978 23.2507 6.29491 23.2507 6.49197C23.2507 6.68904 23.2119 6.88417 23.1364 7.06622C23.061 7.24827 22.9504 7.41367 22.811 7.55297L19.5 10.863"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M18.038 8.083L21.751 4.371C22.0322 4.0897 22.1901 3.70824 22.1901 3.3105C22.1901 2.91275 22.0322 2.53129 21.751 2.25L20.69 1.189C20.4087 0.90779 20.0272 0.749817 19.6295 0.749817C19.2317 0.749817 18.8502 0.90779 18.569 1.189L14.856 4.9"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M18.75 14.25V21.75C18.75 22.1478 18.592 22.5294 18.3107 22.8107C18.0294 23.092 17.6478 23.25 17.25 23.25H2.25C1.85218 23.25 1.47064 23.092 1.18934 22.8107C0.908035 22.5294 0.75 22.1478 0.75 21.75V6.75C0.75 6.35218 0.908035 5.97064 1.18934 5.68934C1.47064 5.40804 1.85218 5.25 2.25 5.25H9.75"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-             foo bar
-          </p>
         </div>
       </div>
     </div>
@@ -16970,299 +24202,581 @@ exports[`Storyshots icons/Single icons CheckIcon 1`] = `
   justify-content: space-around;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-43"
-      >
+      <div>
         <div
-          className="emotion-42"
+          class="emotion-43"
         >
-          <h1>
-            &lt;CheckIcon /&gt;
-          </h1>
-          <h2>
-            Size:
-          </h2>
           <div
-            className="emotion-2"
+            class="emotion-42"
           >
+            <h1>
+              &lt;CheckIcon /&gt;
+            </h1>
+            <h2>
+              Size:
+            </h2>
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              xsmall
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="16px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="16px"
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              small
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="24px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
+                xsmall
+              </div>
+              <div
+                class="emotion-1"
               >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="16px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="16px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
             </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              medium
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="32px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="32px"
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              large
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="40px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="40px"
+                small
+              </div>
+              <div
+                class="emotion-1"
               >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
             </div>
-          </div>
-          <h2>
-            Custom size:
-          </h2>
-          <div
-            className="emotion-2"
-          >
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              height=1em
-              <br />
-              width=1em
+              <div
+                class="emotion-0"
+              >
+                medium
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="32px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="32px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
             </div>
             <div
-              className="emotion-1"
+              class="emotion-2"
             >
+              <div
+                class="emotion-0"
+              >
+                large
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="40px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="40px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Custom size:
+            </h2>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=1em
+                <br />
+                width=1em
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="1em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=16px
+                <br />
+                width=16px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="16px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="16px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=24px
+                <br />
+                width=24px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=32px
+                <br />
+                width=32px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="32px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="32px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=40px
+                <br />
+                width=40px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="40px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="40px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=64px
+                <br />
+                width=64px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="64px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="64px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Color:
+            </h2>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(102, 51, 153);"
+                >
+                  #663399
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#663399"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(255, 178, 56);"
+                >
+                  #ffb238
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#ffb238"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(232, 153, 206);"
+                >
+                  #e899ce
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#e899ce"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(184, 0, 0);"
+                >
+                  #b80000
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#b80000"
+                  data-testid="icon-check"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="none"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
+                  />
+                  <path
+                    d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
+                  />
+                  <path
+                    d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Inline
+            </h2>
+            <p>
+              Lorem ipsum 
               <svg
-                aria-hidden={true}
+                aria-hidden="true"
                 data-testid="icon-check"
                 fill="currentColor"
-                fillRule="evenodd"
+                fill-rule="evenodd"
                 height="1em"
                 preserveAspectRatio="xMidYMid meet"
                 stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-              >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=16px
-              <br />
-              width=16px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="16px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="16px"
-              >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=24px
-              <br />
-              width=24px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="24px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
+                stroke-width="1"
+                style="vertical-align: middle;"
                 viewBox="0 0 24 24"
                 width="24px"
               >
@@ -17276,367 +24790,9 @@ exports[`Storyshots icons/Single icons CheckIcon 1`] = `
                   d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
                 />
               </svg>
-            </div>
+               foo bar
+            </p>
           </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=32px
-              <br />
-              width=32px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="32px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="32px"
-              >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=40px
-              <br />
-              width=40px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="40px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="40px"
-              >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=64px
-              <br />
-              width=64px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="64px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="64px"
-              >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <h2>
-            Color:
-          </h2>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#663399",
-                  }
-                }
-              >
-                #663399
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#663399"
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#ffb238",
-                  }
-                }
-              >
-                #ffb238
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#ffb238"
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#e899ce",
-                  }
-                }
-              >
-                #e899ce
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#e899ce"
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#b80000",
-                  }
-                }
-              >
-                #b80000
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#b80000"
-                data-testid="icon-check"
-                fill="currentColor"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="none"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-                />
-                <path
-                  d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-                />
-                <path
-                  d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-                />
-              </svg>
-            </div>
-          </div>
-          <h2>
-            Inline
-          </h2>
-          <p>
-            Lorem ipsum 
-            <svg
-              aria-hidden={true}
-              data-testid="icon-check"
-              fill="currentColor"
-              fillRule="evenodd"
-              height="1em"
-              preserveAspectRatio="xMidYMid meet"
-              stroke="none"
-              strokeWidth="1"
-              style={
-                Object {
-                  "verticalAlign": "middle",
-                }
-              }
-              viewBox="0 0 24 24"
-              width="24px"
-            >
-              <path
-                d="M9.3 16.7l-3.1-4.3A1 1 0 0 1 7.8 11l3.7 3.9c.6.6.6 1.6 0 2.1-.7.5-1.7.4-2.2-.3z"
-              />
-              <path
-                d="M9.6 17c-.7-.6-.7-1.5-.2-2.2l7.3-8a1 1 0 0 1 1.6 1.3l-6.6 8.6c-.5.7-1.5.8-2.1.3z"
-              />
-              <path
-                d="M9.7 13c.4.5.7.8 1.1.3.5-.5-.1 1.3-.1 1.3l-1.5-.5.5-1z"
-              />
-            </svg>
-             foo bar
-          </p>
         </div>
       </div>
     </div>
@@ -17710,988 +24866,912 @@ exports[`Storyshots icons/Single icons EcommerceIcon 1`] = `
   justify-content: space-around;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-43"
-      >
+      <div>
         <div
-          className="emotion-42"
+          class="emotion-43"
         >
-          <h1>
-            &lt;EcommerceIcon /&gt;
-          </h1>
-          <h2>
-            Size:
-          </h2>
           <div
-            className="emotion-2"
+            class="emotion-42"
           >
+            <h1>
+              &lt;EcommerceIcon /&gt;
+            </h1>
+            <h2>
+              Size:
+            </h2>
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              xsmall
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="16px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="16px"
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              small
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="24px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
+                xsmall
+              </div>
+              <div
+                class="emotion-1"
               >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="16px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="16px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
             </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              medium
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="32px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="32px"
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              large
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="40px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="40px"
+                small
+              </div>
+              <div
+                class="emotion-1"
               >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
             </div>
-          </div>
-          <h2>
-            Custom size:
-          </h2>
-          <div
-            className="emotion-2"
-          >
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              height=1em
-              <br />
-              width=1em
+              <div
+                class="emotion-0"
+              >
+                medium
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="32px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="32px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
             </div>
             <div
-              className="emotion-1"
+              class="emotion-2"
             >
+              <div
+                class="emotion-0"
+              >
+                large
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="40px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="40px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Custom size:
+            </h2>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=1em
+                <br />
+                width=1em
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="1em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=16px
+                <br />
+                width=16px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="16px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="16px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=24px
+                <br />
+                width=24px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=32px
+                <br />
+                width=32px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="32px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="32px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=40px
+                <br />
+                width=40px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="40px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="40px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=64px
+                <br />
+                width=64px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="64px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="64px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Color:
+            </h2>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(102, 51, 153);"
+                >
+                  #663399
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#663399"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(255, 178, 56);"
+                >
+                  #ffb238
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#ffb238"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(232, 153, 206);"
+                >
+                  #e899ce
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#e899ce"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(184, 0, 0);"
+                >
+                  #b80000
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#b80000"
+                  data-testid="icon-ecommerce"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M16.4999 7.5L15.6709 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 7.5L9.828 3.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Inline
+            </h2>
+            <p>
+              Lorem ipsum 
               <svg
-                aria-hidden={true}
+                aria-hidden="true"
                 data-testid="icon-ecommerce"
                 fill="none"
-                fillRule="evenodd"
+                fill-rule="evenodd"
                 height="1em"
                 preserveAspectRatio="xMidYMid meet"
                 stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-              >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=16px
-              <br />
-              width=16px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="16px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="16px"
-              >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=24px
-              <br />
-              width=24px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="24px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
+                stroke-width="1"
+                style="vertical-align: middle;"
                 viewBox="0 0 24 24"
                 width="24px"
               >
                 <path
                   d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
               </svg>
-            </div>
+               foo bar
+            </p>
           </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=32px
-              <br />
-              width=32px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="32px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="32px"
-              >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=40px
-              <br />
-              width=40px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="40px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="40px"
-              >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=64px
-              <br />
-              width=64px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="64px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="64px"
-              >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <h2>
-            Color:
-          </h2>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#663399",
-                  }
-                }
-              >
-                #663399
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#663399"
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#ffb238",
-                  }
-                }
-              >
-                #ffb238
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#ffb238"
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#e899ce",
-                  }
-                }
-              >
-                #e899ce
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#e899ce"
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#b80000",
-                  }
-                }
-              >
-                #b80000
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#b80000"
-                data-testid="icon-ecommerce"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M16.4999 7.5L15.6709 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M9 7.5L9.828 3.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <h2>
-            Inline
-          </h2>
-          <p>
-            Lorem ipsum 
-            <svg
-              aria-hidden={true}
-              data-testid="icon-ecommerce"
-              fill="none"
-              fillRule="evenodd"
-              height="1em"
-              preserveAspectRatio="xMidYMid meet"
-              stroke="currentColor"
-              strokeWidth="1"
-              style={
-                Object {
-                  "verticalAlign": "middle",
-                }
-              }
-              viewBox="0 0 24 24"
-              width="24px"
-            >
-              <path
-                d="M3.75 5.25001C3.74961 4.96756 3.80495 4.6878 3.91286 4.42677C4.02076 4.16574 4.17912 3.92857 4.37884 3.72885C4.57857 3.52912 4.81574 3.37077 5.07677 3.26286C5.33779 3.15496 5.61755 3.09961 5.9 3.10001"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M0.75 4.687C0.75 3.64284 1.16479 2.64145 1.90312 1.90312C2.64145 1.16479 3.64284 0.75 4.687 0.75"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M10.5001 16.5H7.6731C7.39125 16.5008 7.11717 16.4077 6.89422 16.2353C6.67127 16.0628 6.51217 15.821 6.4421 15.548L4.5421 9.061C4.49636 8.87508 4.49359 8.68119 4.534 8.49405C4.57441 8.3069 4.65694 8.13143 4.77532 7.98095C4.89369 7.83047 5.04481 7.70895 5.21718 7.62561C5.38955 7.54228 5.57864 7.49932 5.7701 7.5H18.9801C19.1719 7.49866 19.3614 7.54116 19.5343 7.62424C19.7071 7.70732 19.8587 7.82878 19.9775 7.97937C20.0962 8.12996 20.179 8.30569 20.2195 8.49314C20.26 8.68059 20.2571 8.87482 20.2111 9.061L19.9001 10.116"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M16.4999 7.5L15.6709 3.75"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M9 7.5L9.828 3.75"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M23.135 23.25L23.235 22.128C23.301 21.4017 23.1001 20.6762 22.67 20.0873C22.2399 19.4983 21.6099 19.0862 20.898 18.928L16.726 18V12C16.726 11.6022 16.5679 11.2206 16.2866 10.9393C16.0053 10.658 15.6238 10.5 15.226 10.5C14.8282 10.5 14.4466 10.658 14.1653 10.9393C13.884 11.2206 13.726 11.6022 13.726 12V21.75L12.026 20.472C11.731 20.2504 11.3659 20.1428 10.9979 20.1688C10.6298 20.1949 10.2836 20.3528 10.0227 20.6137C9.7618 20.8746 9.60383 21.2209 9.5778 21.5889C9.55176 21.9569 9.65942 22.322 9.88098 22.617L10.355 23.25"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-             foo bar
-          </p>
         </div>
       </div>
     </div>
@@ -18765,1138 +25845,1062 @@ exports[`Storyshots icons/Single icons PortfolioIcon 1`] = `
   justify-content: space-around;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-43"
-      >
+      <div>
         <div
-          className="emotion-42"
+          class="emotion-43"
         >
-          <h1>
-            &lt;PortfolioIcon /&gt;
-          </h1>
-          <h2>
-            Size:
-          </h2>
           <div
-            className="emotion-2"
+            class="emotion-42"
           >
+            <h1>
+              &lt;PortfolioIcon /&gt;
+            </h1>
+            <h2>
+              Size:
+            </h2>
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              xsmall
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="16px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="16px"
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              small
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="24px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
+                xsmall
+              </div>
+              <div
+                class="emotion-1"
               >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="16px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="16px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
             </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              medium
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="32px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="32px"
+              <div
+                class="emotion-0"
               >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              large
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="40px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="40px"
+                small
+              </div>
+              <div
+                class="emotion-1"
               >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
             </div>
-          </div>
-          <h2>
-            Custom size:
-          </h2>
-          <div
-            className="emotion-2"
-          >
             <div
-              className="emotion-0"
+              class="emotion-2"
             >
-              height=1em
-              <br />
-              width=1em
+              <div
+                class="emotion-0"
+              >
+                medium
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="32px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="32px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
             </div>
             <div
-              className="emotion-1"
+              class="emotion-2"
             >
+              <div
+                class="emotion-0"
+              >
+                large
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="40px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="40px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Custom size:
+            </h2>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=1em
+                <br />
+                width=1em
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="1em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=16px
+                <br />
+                width=16px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="16px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="16px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=24px
+                <br />
+                width=24px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="24px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=32px
+                <br />
+                width=32px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="32px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="32px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=40px
+                <br />
+                width=40px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="40px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="40px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                height=64px
+                <br />
+                width=64px
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="64px"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="64px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Color:
+            </h2>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(102, 51, 153);"
+                >
+                  #663399
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#663399"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(255, 178, 56);"
+                >
+                  #ffb238
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#ffb238"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(232, 153, 206);"
+                >
+                  #e899ce
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#e899ce"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="emotion-2"
+            >
+              <div
+                class="emotion-0"
+              >
+                <span
+                  style="color: rgb(184, 0, 0);"
+                >
+                  #b80000
+                </span>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <svg
+                  aria-hidden="true"
+                  color="#b80000"
+                  data-testid="icon-portfolio"
+                  fill="none"
+                  fill-rule="evenodd"
+                  height="3em"
+                  preserveAspectRatio="xMidYMid meet"
+                  stroke="currentColor"
+                  stroke-width="1"
+                  style="vertical-align: middle;"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path
+                    d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M6.74609 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M17.2461 2.24799V0.747986"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2>
+              Inline
+            </h2>
+            <p>
+              Lorem ipsum 
               <svg
-                aria-hidden={true}
+                aria-hidden="true"
                 data-testid="icon-portfolio"
                 fill="none"
-                fillRule="evenodd"
+                fill-rule="evenodd"
                 height="1em"
                 preserveAspectRatio="xMidYMid meet"
                 stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="1em"
-              >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=16px
-              <br />
-              width=16px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="16px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="16px"
-              >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=24px
-              <br />
-              width=24px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="24px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
+                stroke-width="1"
+                style="vertical-align: middle;"
                 viewBox="0 0 24 24"
                 width="24px"
               >
                 <path
                   d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
                 <path
                   d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
               </svg>
-            </div>
+               foo bar
+            </p>
           </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=32px
-              <br />
-              width=32px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="32px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="32px"
-              >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=40px
-              <br />
-              width=40px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="40px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="40px"
-              >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              height=64px
-              <br />
-              width=64px
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="64px"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="64px"
-              >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <h2>
-            Color:
-          </h2>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#663399",
-                  }
-                }
-              >
-                #663399
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#663399"
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#ffb238",
-                  }
-                }
-              >
-                #ffb238
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#ffb238"
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#e899ce",
-                  }
-                }
-              >
-                #e899ce
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#e899ce"
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            className="emotion-2"
-          >
-            <div
-              className="emotion-0"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#b80000",
-                  }
-                }
-              >
-                #b80000
-              </span>
-            </div>
-            <div
-              className="emotion-1"
-            >
-              <svg
-                aria-hidden={true}
-                color="#b80000"
-                data-testid="icon-portfolio"
-                fill="none"
-                fillRule="evenodd"
-                height="3em"
-                preserveAspectRatio="xMidYMid meet"
-                stroke="currentColor"
-                strokeWidth="1"
-                style={
-                  Object {
-                    "verticalAlign": "middle",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M6.74609 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M17.2461 2.24799V0.747986"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-          </div>
-          <h2>
-            Inline
-          </h2>
-          <p>
-            Lorem ipsum 
-            <svg
-              aria-hidden={true}
-              data-testid="icon-portfolio"
-              fill="none"
-              fillRule="evenodd"
-              height="1em"
-              preserveAspectRatio="xMidYMid meet"
-              stroke="currentColor"
-              strokeWidth="1"
-              style={
-                Object {
-                  "verticalAlign": "middle",
-                }
-              }
-              viewBox="0 0 24 24"
-              width="24px"
-            >
-              <path
-                d="M6.43308 15.749C6.06531 14.8383 5.92674 13.8512 6.02954 12.8744C6.13233 11.8976 6.47335 10.961 7.02265 10.1468C7.57196 9.33253 8.31275 8.66561 9.17999 8.20454C10.0472 7.74347 11.0144 7.50235 11.9966 7.50235C12.9788 7.50235 13.9459 7.74347 14.8132 8.20454C15.6804 8.66561 16.4212 9.33253 16.9705 10.1468C17.5198 10.961 17.8608 11.8976 17.9636 12.8744C18.0664 13.8512 17.9279 14.8383 17.5601 15.749"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M10.1551 7.78601L11.8461 10.048C11.9643 10.2056 12.0503 10.3849 12.0992 10.5757C12.1481 10.7666 12.1589 10.9651 12.131 11.1601C12.1032 11.3551 12.0372 11.5428 11.9368 11.7123C11.8364 11.8817 11.7037 12.0298 11.5461 12.148L9.74609 13.498V14.248C9.74609 14.6458 9.58806 15.0274 9.30675 15.3087C9.02545 15.59 8.64392 15.748 8.24609 15.748"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M17.629 11.427L15.323 12.587C15.0175 12.7396 14.7732 12.9918 14.6305 13.302C14.4878 13.6121 14.4551 13.9618 14.538 14.293L14.91 15.749"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M6.74609 2.24799V0.747986"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M17.2461 2.24799V0.747986"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M7.5 18.748C7.5 19.1458 7.65804 19.5273 7.93934 19.8086C8.22064 20.09 8.60218 20.248 9 20.248H15C15.3978 20.248 15.7794 20.09 16.0607 19.8086C16.342 19.5273 16.5 19.1458 16.5 18.748"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M22.2461 15.748H1.74609C1.19381 15.748 0.746094 16.1957 0.746094 16.748V22.248C0.746094 22.8003 1.19381 23.248 1.74609 23.248H22.2461C22.7984 23.248 23.2461 22.8003 23.2461 22.248V16.748C23.2461 16.1957 22.7984 15.748 22.2461 15.748Z"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M3 15.748V3.74799C3 3.35016 3.15804 2.96863 3.43934 2.68733C3.72064 2.40602 4.10218 2.24799 4.5 2.24799H19.5C19.8978 2.24799 20.2794 2.40602 20.5607 2.68733C20.842 2.96863 21 3.35016 21 3.74799V15.748"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-             foo bar
-          </p>
         </div>
       </div>
     </div>
@@ -19904,280 +26908,221 @@ exports[`Storyshots icons/Single icons PortfolioIcon 1`] = `
 </div>
 `;
 
-exports[`Storyshots skeletons/BaseButton tags/components 1`] = `
-.emotion-0 {
+exports[`Storyshots skeletons/BaseAnchor default 1`] = `
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
 }
 
-.emotion-0 > * {
-  margin: 20px;
+.emotion-0 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
 }
 
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
-      <div
-        className="emotion-0"
-      >
-        <button
-          disabled={false}
-          type="button"
+      <div>
+        <div
+          class="emotion-1"
         >
-          <span>
-            Button
-          </span>
-        </button>
-        <a
-          href="https://gatsbyjs.com"
-          rel=" noopener noreferrer"
-          role="button"
-          target="_blank"
+          <div
+            class="emotion-0"
+          >
+            <a
+              href="https://gatsbyjs.com"
+              rel=" noopener noreferrer"
+              target="_blank"
+            >
+              Anchor
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/BaseButton default 1`] = `
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-0 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-1"
         >
-          <span>
-            &lt;a&gt; tag
-          </span>
-        </a>
-        <a
-          LinkComponent={
-            [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "children": "Breadcrumb 1",
-                    "className": "css-nn640c",
-                    "onClick": undefined,
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": <UNDEFINED>
-                      Link
-                       
-                      <MdArrowForward />
-                    </UNDEFINED>,
-                    "className": "css-16iroc0-Link",
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": Array [
-                      <_default />,
-                      "General",
-                    ],
-                    "className": "css-1whqxin",
-                    "onClick": [Function],
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": "Site Details",
-                    "className": "css-1whqxin",
-                    "onClick": [Function],
-                    "to": "#",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": "Contributors",
-                    "className": "css-1whqxin",
-                    "onClick": [Function],
-                    "to": "#",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": "Environment Variables",
-                    "className": "css-1whqxin",
-                    "onClick": [Function],
-                    "to": "#",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": Array [
-                      false,
-                      "Integrations",
-                    ],
-                    "className": "css-1whqxin",
-                    "onClick": [Function],
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": Array [
-                      false,
-                      "Preview",
-                    ],
-                    "className": "css-1whqxin",
-                    "onClick": [Function],
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": Array [
-                      false,
-                      "Danger Zone",
-                    ],
-                    "className": "css-1whqxin",
-                    "onClick": [Function],
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": <Content
-                      DefaultIcon={[Function]}
-                      label={undefined}
-                    >
-                      Subscribe
-                    </Content>,
-                    "className": "css-1kidtzk-Button",
-                    "onClick": [Function],
-                    "role": "button",
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": <Content
-                      DefaultIcon={[Function]}
-                      label={undefined}
-                    >
-                      Contact sales
-                    </Content>,
-                    "className": "css-1kidtzk-Button",
-                    "onClick": [Function],
-                    "role": "button",
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": <Content
-                      DefaultIcon={[Function]}
-                      label={undefined}
-                    >
-                      Get started for free
-                    </Content>,
-                    "className": "css-1o2e1oz-Button",
-                    "role": "button",
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": <Content
-                      DefaultIcon={[Function]}
-                      label={undefined}
-                    >
-                      Pick
-                    </Content>,
-                    "className": "css-1w2nrqi-Button",
-                    "onClick": [Function],
-                    "role": "button",
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": <Content
-                      DefaultIcon={false}
-                      label={undefined}
-                    >
-                      <MdHelpOutline />
-                    </Content>,
-                    "className": "css-1tdli1t-Button",
-                    "role": "button",
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": <Content
-                      DefaultIcon={false}
-                      label={undefined}
-                    >
-                      <MdHelpOutline />
-                    </Content>,
-                    "className": "css-1tdli1t-Button",
-                    "role": "button",
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "children": <Content
-                      DefaultIcon={false}
-                      label={undefined}
-                    >
-                      <MdHelpOutline />
-                    </Content>,
-                    "className": "css-1tdli1t-Button",
-                    "role": "button",
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-                Array [
-                  Object {
-                    "LinkComponent": [MockFunction] {
-                      "calls": [Circular],
-                    },
-                    "children": <Content
-                      DefaultIcon={undefined}
-                      label={undefined}
-                    >
-                      Gatsby &lt;Link&gt; component
-                    </Content>,
-                    "role": "button",
-                    "to": "/",
-                  },
-                  Object {},
-                ],
-              ],
-            }
-          }
-          href="/"
-          role="button"
+          <div
+            class="emotion-0"
+          >
+            <button
+              type="button"
+            >
+              Button
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/BaseButton with loading state 1`] = `
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-0 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-1"
         >
-          <span>
-            Gatsby &lt;Link&gt; component
-          </span>
-        </a>
+          <div
+            class="emotion-0"
+          >
+            <button
+              disabled=""
+              type="button"
+            >
+              <span>
+                Loading...
+              </span>
+               
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/BaseLink default 1`] = `
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-0 {
+  display: grid;
+  justify-items: start;
+  grid-gap: 2rem;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-1"
+        >
+          <div
+            class="emotion-0"
+          >
+            <a
+              aria-current="page"
+              class=""
+              href="/"
+            >
+              Link
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -20185,45 +27130,20 @@ exports[`Storyshots skeletons/BaseButton tags/components 1`] = `
 `;
 
 exports[`Storyshots skeletons/ContentBox 'toggle' (default) behaviour with a static button 1`] = `
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
       <div>
         <div>
-          This is a PRIMARY content of this ContentBox
-        </div>
-        <button
-          onClick={[Function]}
-          tone="BRAND"
-        >
-          Toggle
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots skeletons/ContentBox 'toggle' behaviour with buttons swap  1`] = `
-<div
-  className="storybook-readme-story"
->
-  <div
-    style={Object {}}
-  >
-    <div>
-      <div>
-        <div>
-          This is a PRIMARY content of this ContentBox
+          <div>
+            This is a PRIMARY content of this ContentBox
+          </div>
           <button
-            onClick={[Function]}
             tone="BRAND"
           >
-            Show SECONDARY content
+            Toggle
           </button>
         </div>
       </div>
@@ -20232,24 +27152,46 @@ exports[`Storyshots skeletons/ContentBox 'toggle' behaviour with buttons swap  1
 </div>
 `;
 
-exports[`Storyshots skeletons/ContentBox 'unfold' behaviour with  a static button 1`] = `
-<div
-  className="storybook-readme-story"
->
+exports[`Storyshots skeletons/ContentBox 'toggle' behaviour with buttons swap  1`] = `
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
       <div>
         <div>
-          This is a PRIMARY content of this ContentBox
+          <div>
+            This is a PRIMARY content of this ContentBox
+            <button
+              tone="BRAND"
+            >
+              Show SECONDARY content
+            </button>
+          </div>
         </div>
-        <button
-          onClick={[Function]}
-          tone="BRAND"
-        >
-          Toggle
-        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots skeletons/ContentBox 'unfold' behaviour with  a static button 1`] = `
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div>
+          <div>
+            This is a PRIMARY content of this ContentBox
+          </div>
+          <button
+            tone="BRAND"
+          >
+            Toggle
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -20257,23 +27199,22 @@ exports[`Storyshots skeletons/ContentBox 'unfold' behaviour with  a static butto
 `;
 
 exports[`Storyshots skeletons/ContentBox 'unfold' behaviour with buttons swap 1`] = `
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
       <div>
         <div>
-          This is a PRIMARY content of this ContentBox
+          <div>
+            This is a PRIMARY content of this ContentBox
+          </div>
+          <button
+            tone="BRAND"
+          >
+            Unfold
+          </button>
         </div>
-        <button
-          onClick={[Function]}
-          tone="BRAND"
-        >
-          Unfold
-        </button>
       </div>
     </div>
   </div>
@@ -20281,20 +27222,19 @@ exports[`Storyshots skeletons/ContentBox 'unfold' behaviour with buttons swap 1`
 `;
 
 exports[`Storyshots skeletons/ContentBox 'unfold' behaviour with no PRIMARY content 1`] = `
-<div
-  className="storybook-readme-story"
->
+<div>
   <div
-    style={Object {}}
+    class="storybook-readme-story"
   >
     <div>
       <div>
-        <button
-          onClick={[Function]}
-          tone="BRAND"
-        >
-          Toggle
-        </button>
+        <div>
+          <button
+            tone="BRAND"
+          >
+            Toggle
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/__tests__/icons.test.js
+++ b/__tests__/icons.test.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "react-testing-library"
+import { render } from "@testing-library/react"
 
 import * as icons from "../src/components/icons/icons"
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(j|t)sx?$": `<rootDir>/jest-preprocess.js`,
   },
   moduleNameMapper: {
-    ".+prismCodeThemes.+\\.(css|styl|less|sass|scss)$": `<rootDir>/__mocks__/styleMock.js`,
+    ".+(prismCodeThemes|reach\\/dialog).+\\.(css|styl|less|sass|scss)$": `<rootDir>/__mocks__/styleMock.js`,
     ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
     ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|md)$": `<rootDir>/__mocks__/fileMock.js`,
   },

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@storybook/react": "^5.0.11",
     "@storybook/source-loader": "^5.2.0-alpha.14",
     "@svgr/rollup": "^2.4.1",
+    "@testing-library/react": "^9.3.2",
     "@types/react": "16.8.1",
     "@types/react-dom": "16.8.1",
     "@types/storybook__addon-knobs": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "react-icons": "^3.2.1",
     "react-storybook-addon-chapters": "^3.1.5",
     "react-test-renderer": "^16.8.6",
-    "react-testing-library": "^5.6.1",
     "rollup": "^0.64.1",
     "rollup-plugin-babel": "^4.0.1",
     "rollup-plugin-commonjs": "^9.1.3",

--- a/setup-test-env.js
+++ b/setup-test-env.js
@@ -1,7 +1,5 @@
 import { createSerializer } from "jest-emotion"
 import * as emotion from "emotion"
-import styled from "@emotion/styled"
 import "jest-dom/extend-expect"
-import "react-testing-library/cleanup-after-each"
 
 expect.addSnapshotSerializer(createSerializer(emotion))

--- a/src/components/CopyButton/__tests__/CopyButton.test.tsx
+++ b/src/components/CopyButton/__tests__/CopyButton.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, fireEvent } from "react-testing-library"
+import { render, fireEvent } from "@testing-library/react"
 import "jest-dom/extend-expect"
 
 import { CopyButton } from "../index"

--- a/src/components/CopyButton/__tests__/__snapshots__/CopyButton.test.tsx.snap
+++ b/src/components/CopyButton/__tests__/__snapshots__/CopyButton.test.tsx.snap
@@ -61,14 +61,6 @@ exports[`<PrimaryButton> renders unchanged 1`] = `
   transform: scale(1);
 }
 
-.emotion-0 svg:last-child {
-  margin-right: -0.25em;
-}
-
-.emotion-0 svg:first-child {
-  margin-left: -0.30em;
-}
-
 .emotion-0:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
@@ -95,9 +87,7 @@ html[dir="rtl"] .emotion-0 {
     title="Copy to clipboard"
     type="button"
   >
-    <span>
-      Copy
-    </span>
+    Copy
   </button>
 </div>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,7 +1035,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@7.5.5", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.3", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5":
+"@babel/runtime@7.5.5", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
@@ -6062,16 +6062,6 @@ dom-serializer@0:
   dependencies:
     domelementtype "^2.0.1"
     entities "^2.0.0"
-
-dom-testing-library@^3.13.1:
-  version "3.19.4"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.19.4.tgz#f5b737f59ee9749a4568fa353f1f59be97c888c3"
-  integrity sha512-GJOx8CLpnkvM3takILOsld/itUUc9+7Qh6caN1Spj6+9jIgNPY36fsvoH7sEgYokC0lBRdttO7G7fIFYCXlmcA==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^24.7.0"
-    wait-for-expect "^1.1.1"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -13290,7 +13280,7 @@ pretty-format@^23.0.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.7.0, pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -14020,14 +14010,6 @@ react-test-renderer@^16.8.6:
     prop-types "^15.6.2"
     react-is "^16.9.0"
     scheduler "^0.15.0"
-
-react-testing-library@^5.6.1:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.9.0.tgz#e1c8a586d2f2cbd5f0035474ca90258eef1fece6"
-  integrity sha512-T303PJZvrLKeeiPpjmMD1wxVpzEg9yI0qteH/cUvpFqNHOzPe3yN+Pu+jo9JlxuTMvVGPAmCAcgZ3sEtEDpJUQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    dom-testing-library "^3.13.1"
 
 react-textarea-autosize@^7.1.0:
   version "7.1.0"
@@ -17032,11 +17014,6 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.3.0.tgz#65241ce355425f907f5d127bdb5e72c412ff830c"
-  integrity sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==
 
 wait-for-expect@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1049,6 +1049,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.6.0", "@babel/runtime@^7.6.2":
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.2.tgz#111a78002a5c25fc8e3361bedc9529c696b85a6a"
+  integrity sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -2263,6 +2270,27 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@testing-library/dom@^6.3.0":
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.10.1.tgz#da5bf5065d3f9e484aef4cc495f4e1a5bea6df2e"
+  integrity sha512-5BPKxaO+zSJDUbVZBRNf9KrmDkm/EcjjaHSg3F9+031VZyPACKXlwLBjVzZxheunT9m72DoIq7WvyE457/Xweg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    "@types/testing-library__dom" "^6.0.0"
+    aria-query "3.0.0"
+    pretty-format "^24.9.0"
+    wait-for-expect "^3.0.0"
+
+"@testing-library/react@^9.3.2":
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.3.2.tgz#418000daa980dafd2d9420cc733d661daece9aa0"
+  integrity sha512-J6ftWtm218tOLS175MF9eWCxGp+X+cUXCpkPIin8KAXWtyZbr9CbqJ8M8QNd6spZxJDAGlw+leLG4MJWLlqVgg==
+  dependencies:
+    "@babel/runtime" "^7.6.0"
+    "@testing-library/dom" "^6.3.0"
+    "@types/testing-library__react" "^9.1.0"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -2441,6 +2469,13 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-dom@*":
+  version "16.9.4"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.4.tgz#0b58df09a60961dcb77f62d4f1832427513420df"
+  integrity sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@16.8.1":
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.1.tgz#e43810a5e44b37854a9c7cd99e6c43e4f522c7c6"
@@ -2484,6 +2519,21 @@
   dependencies:
     "@types/react" "*"
     "@types/webpack-env" "*"
+
+"@types/testing-library__dom@*", "@types/testing-library__dom@^6.0.0":
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.10.0.tgz#590d76e3875a7c536dc744eb530cbf51b6483404"
+  integrity sha512-mL/GMlyQxiZplbUuFNwA0vAI3k3uJNSf6slr5AVve9TXmfLfyefNT0uHHnxwdYuPMxYD5gI/+dgAvc/5opW9JQ==
+  dependencies:
+    pretty-format "^24.3.0"
+
+"@types/testing-library__react@^9.1.0":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.2.tgz#e33af9124c60a010fc03a34eff8f8a34a75c4351"
+  integrity sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==
+  dependencies:
+    "@types/react-dom" "*"
+    "@types/testing-library__dom" "*"
 
 "@types/tinycolor2@^1.4.1":
   version "1.4.2"
@@ -3140,7 +3190,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^3.0.0:
+aria-query@3.0.0, aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
@@ -13240,7 +13290,7 @@ pretty-format@^23.0.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^24.0.0, pretty-format@^24.7.0, pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.7.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -16987,6 +17037,11 @@ wait-for-expect@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.3.0.tgz#65241ce355425f907f5d127bdb5e72c412ff830c"
   integrity sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==
+
+wait-for-expect@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.1.tgz#ec204a76b0038f17711e575720aaf28505ac7185"
+  integrity sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
This PR should cover the "fixing" part of #116. It fixes as couple of issues happening during `yarn test`:
* `@reach/portal` used under the hood of our modals was breaking snapshot tests, probably due to  those running on `react-test-renderer` and not having access to refs. Using `render` from `@testing-library/react` as `renderer` option for storyshots addon  helped with this problem.
* Side effect of importing `@reach/dialog/styles.css` wasn't handled by Jest config correctly, I've added this file to `moduleNameMapper` configuration.
* I had to omit stories for Decorative dots from snapshot testing since they are impure and get rendered in a different way each time, which ruins the purpose of snapshots.

I've also updated `react-testing-library` to the latest `@testing-library/react` since there aren't any breaking changes.