### PR TITLE
chore: auto-generate propTypes based on TypeScript types

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,5 +9,5 @@
     "@babel/preset-react",
     "@babel/typescript"
   ],
-  "plugins": ["@babel/plugin-proposal-class-properties"]
+  "plugins": [["babel-plugin-typescript-to-proptypes", { "typeCheck": true }], "@babel/plugin-proposal-class-properties"]
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "babel-plugin-react-docgen": "^2.0.2",
     "babel-plugin-require-context-hook": "^1.0.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+    "babel-plugin-typescript-to-proptypes": "^1.1.0",
     "babel-preset-gatsby": "^0.1.11",
     "chalk": "^2.4.2",
     "commander": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,6 +169,13 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
+"@babel/helper-module-imports@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz#99c095889466e5f7b6d66d98dffc58baaf42654d"
+  integrity sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==
+  dependencies:
+    "@babel/types" "^7.7.0"
+
 "@babel/helper-module-transforms@^7.1.0", "@babel/helper-module-transforms@^7.4.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz#f84ff8a09038dcbca1fd4355661a500937165b4a"
@@ -598,7 +605,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-typescript@^7.2.0":
+"@babel/plugin-syntax-typescript@^7.2.0", "@babel/plugin-syntax-typescript@^7.3.3":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz#a7cc3f66119a9f7ebe2de5383cce193473d65991"
   integrity sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==
@@ -1117,6 +1124,15 @@
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
   integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.7.0":
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.2.tgz#550b82e5571dcd174af576e23f0adba7ffc683f7"
+  integrity sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -3873,6 +3889,15 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
+
+babel-plugin-typescript-to-proptypes@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-typescript-to-proptypes/-/babel-plugin-typescript-to-proptypes-1.1.0.tgz#276f52c54af4c791229eb9d696f1aef55b3d0e53"
+  integrity sha512-GHdotmI+i53UB4Fh1k6jP2oRnbHwI1dHmgXya3GmZV9Qherom9bDhzA3sKW3jWJhBBFf30hcpXP1lLj5C/Vf3g==
+  dependencies:
+    "@babel/helper-module-imports" "^7.7.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.3.3"
 
 babel-preset-fbjs@^3.1.2:
   version "3.2.0"


### PR DESCRIPTION
Should implement #119.

Here are some snippets from the `dist/index.es.js` file generated by `yarn build:rollup` command:
```javascript
Modal.propTypes = {
  type: PropTypes.oneOf(["success", "info", "warn", "error"])
};
```

```javascript
Button.propTypes = {
  size: PropTypes.oneOf(["XL", "L", "M", "S"]),
  tone: PropTypes.oneOf(["BRAND", "SUCCESS", "DANGER", "NEUTRAL"]),
  variant: PropTypes.oneOf(["PRIMARY", "SECONDARY", "GHOST"]),
  leftIcon: PropTypes.node,
  rightIcon: PropTypes.node
};
```

It doesn't seem to work with all TS components: looks like it can't handle `React.forwardRef`.