### PR TITLE
chore: use 'pure' random values in tests

### DIFF
--- a/__tests__/Storyshots.test.js
+++ b/__tests__/Storyshots.test.js
@@ -7,9 +7,4 @@ initStoryshots({
     const { container } = render(storyElement, rendererOptions)
     return container
   },
-  /**
-   * We have to exclude DecorativeDots from snapshots since they are always rendered in a differnet way,
-   * which makes snapshot testing useless
-   */
-  storyKindRegex: /^((?!.*?DecorativeDots).)*$/,
 })

--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -275,6 +275,47 @@ html[dir="rtl"] .emotion-0 {
 </div>
 `;
 
+exports[`Storyshots DecorativeDots Default 1`] = `
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-0"
+        >
+          <svg
+            aria-hidden="true"
+            height="200"
+            style="overflow: visible;"
+            width="300"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots File Upload File Upload with Custom Components 1`] = `
 .emotion-0 {
   -webkit-align-items: center;

--- a/src/components/DecorativeDots/DecorativeDots.tsx
+++ b/src/components/DecorativeDots/DecorativeDots.tsx
@@ -1,7 +1,10 @@
 import * as React from "react"
-import sample from "lodash.sample"
 
 import { palette } from "../../utils/presets"
+import {
+  testSafeMathRandom,
+  testSafeSample,
+} from "../../utils/helpers/testSafeRandomness"
 
 import { getLikelihoodOfBeingBlank } from "./DecorativeDots.helpers"
 import Dot, { DotProps } from "./Dot"
@@ -62,14 +65,15 @@ const generateDotData = (
         numRows
       )
 
-      const isBlank = likelihoodOfBeingBlank * Math.random() < fadeStrength
+      const isBlank =
+        likelihoodOfBeingBlank * testSafeMathRandom() < fadeStrength
 
       if (!isBlank) {
         dots.push({
           x: colIndex * totalDotSpace,
           y: rowIndex * totalDotSpace,
-          color: sample(COLORS) as string,
-          opacity: sample(OPACITIES) as number,
+          color: testSafeSample(COLORS) as string,
+          opacity: testSafeSample(OPACITIES) as number,
           size: dotSize,
         })
       }

--- a/src/utils/helpers/testSafeRandomness.ts
+++ b/src/utils/helpers/testSafeRandomness.ts
@@ -1,0 +1,30 @@
+/**
+  Some components are impure - a good example is DecorativeDots,
+  which purposefully produces a different value for every 
+  instance.
+
+  This works fine in dev/prod, but causes problems with our
+  tests - snapshot tests expect consistent UI given a set of 
+  props!
+
+  These functions can be used instead, which provide consistent
+  values while in the 'test' environment.
+*/
+
+import sample from "lodash.sample"
+
+export const testSafeMathRandom = (defaultValue = 0.5) => {
+  if (process.env.NODE_ENV === "test") {
+    return defaultValue
+  }
+
+  return Math.random()
+}
+
+export const testSafeSample = (arr, defaultIndex = 0) => {
+  if (process.env.NODE_ENV === "test") {
+    return arr[defaultIndex]
+  }
+
+  return sample(arr)
+}

--- a/src/utils/helpers/testSafeRandomness.ts
+++ b/src/utils/helpers/testSafeRandomness.ts
@@ -21,7 +21,7 @@ export const testSafeMathRandom = (defaultValue = 0.5) => {
   return Math.random()
 }
 
-export const testSafeSample = (arr, defaultIndex = 0) => {
+export const testSafeSample = (arr: Array<any>, defaultIndex = 0) => {
   if (process.env.NODE_ENV === "test") {
     return arr[defaultIndex]
   }


### PR DESCRIPTION
in #118, @Elanhant had to disable the storyshot generated tests for my DecorativeDots component, since their inherent randomness caused problems.

[As discussed](https://github.com/gatsby-inc/gatsby-interface/pull/118#discussion_r347988080), this fix allows those components to be tested by removing that impurity while `process.env.NODE_ENV` was `test`. This way we can still test their general structure in a repeatable, predictable way.