### PR TITLE
Adjusting sidenav style

### DIFF
--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -1467,7 +1467,7 @@ exports[`Storyshots SidebarNav usage example 1`] = `
 
 .emotion-0 {
   color: inherit;
-  line-height: 1.25rem;
+  line-height: 1.25;
   -webkit-text-decoration: none;
   text-decoration: none;
 }

--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -1467,7 +1467,7 @@ exports[`Storyshots SidebarNav usage example 1`] = `
 
 .emotion-0 {
   color: inherit;
-  line-height: 1.375rem;
+  line-height: 1.25rem;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -1479,7 +1479,7 @@ exports[`Storyshots SidebarNav usage example 1`] = `
 }
 
 .emotion-3 {
-  padding: 0.25rem 1rem;
+  padding: 0.5rem 1rem;
   margin-bottom: 0;
   border-left: 1px solid #8a4baf;
   font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
@@ -1497,7 +1497,7 @@ exports[`Storyshots SidebarNav usage example 1`] = `
 }
 
 .emotion-5 {
-  padding: 0.25rem 1rem;
+  padding: 0.5rem 1rem;
   margin-bottom: 0;
   border-left: 1px solid #d9d7e0;
   font-family: Futura PT,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;

--- a/src/components/SidebarNav/SidebarNav.js
+++ b/src/components/SidebarNav/SidebarNav.js
@@ -3,6 +3,7 @@ import { jsx } from "@emotion/core"
 import { Fragment } from "react"
 import { Link } from "gatsby"
 import PropTypes from "prop-types"
+import { lineHeights } from "gatsby-design-tokens"
 
 import colors from "../../theme/colors"
 import { spaces, fontFamilies, fontSizes } from "../../utils/presets"
@@ -104,7 +105,7 @@ const baseItemStyles = active => {
 
 const baseLinkStyles = {
   color: `inherit`,
-  lineHeight: `1.25rem`,
+  lineHeight: lineHeights.dense,
   textDecoration: `none`,
 }
 

--- a/src/components/SidebarNav/SidebarNav.js
+++ b/src/components/SidebarNav/SidebarNav.js
@@ -104,7 +104,7 @@ const baseItemStyles = active => {
 
 const baseLinkStyles = {
   color: `inherit`,
-  lineHeight: `1.375rem`,
+  lineHeight: `1.25rem`,
   textDecoration: `none`,
 }
 
@@ -148,7 +148,7 @@ SidebarNav.Item.propTypes = {
 SidebarNav.SubItem = ({ active, onClick, to, children }) => (
   <li
     css={{
-      padding: `${spaces[`2xs`]} ${spaces.m}`,
+      padding: `${spaces.xs} ${spaces.m}`,
       marginBottom: `0`,
       borderLeft: active
         ? `1px solid ${colors.purple[50]}`


### PR DESCRIPTION
This PR aims to create some spacing between the sidenav elements. In fact, when we have elements on more than one line, it's a bit disturbing and it looks like they are two different items.

This PR addresses: https://github.com/gatsby-inc/mansion/issues/5707

The result:

<img width="356" alt="Screenshot 2019-11-26 at 11 24 41" src="https://user-images.githubusercontent.com/3874873/69621599-b55d5c00-103f-11ea-9e83-018a1a07832c.png">
