### PR TITLE
Update navigation component

### DIFF
--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -12080,6 +12080,7 @@ exports[`Storyshots Navigation default example 1`] = `
   display: inline-flex;
   position: relative;
   color: #000000;
+  margin-bottom: 0;
   padding: 0 0.75rem;
 }
 
@@ -12821,6 +12822,7 @@ exports[`Storyshots Navigation inverted example 1`] = `
   display: inline-flex;
   position: relative;
   color: #ffffff;
+  margin-bottom: 0;
   padding: 0 0.75rem;
 }
 
@@ -13362,6 +13364,7 @@ exports[`Storyshots Navigation with item links as children 1`] = `
   display: inline-flex;
   position: relative;
   color: #000000;
+  margin-bottom: 0;
   padding: 0 0.75rem;
 }
 
@@ -14158,6 +14161,7 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
   display: inline-flex;
   position: relative;
   color: #000000;
+  margin-bottom: 0;
   padding: 0 0.75rem;
 }
 
@@ -14909,6 +14913,7 @@ exports[`Storyshots Navigation with item links as props and children 1`] = `
   display: inline-flex;
   position: relative;
   color: #000000;
+  margin-bottom: 0;
   padding: 0 0.75rem;
 }
 
@@ -15299,6 +15304,7 @@ exports[`Storyshots Navigation with nested item links as children 1`] = `
   display: inline-flex;
   position: relative;
   color: #000000;
+  margin-bottom: 0;
   padding: 0 0.75rem;
 }
 

--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -2855,7 +2855,6 @@ exports[`Storyshots BaseNavigation usage example 1`] = `
   display: inline-block;
   position: absolute;
   top: 95%;
-  right: 0;
   left: 0;
   margin: 0;
   padding: 0.75rem 0;
@@ -12005,8 +12004,16 @@ exports[`Storyshots Navigation default example 1`] = `
 }
 
 .emotion-27 {
-  margin: 0 0 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding: 0 1rem;
+  width: 100%;
 }
 
 @media (max-width:1065px) {
@@ -12040,7 +12047,16 @@ exports[`Storyshots Navigation default example 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style: none;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 @media (max-width:1065px) {
@@ -12071,7 +12087,6 @@ exports[`Storyshots Navigation default example 1`] = `
   display: inline-block;
   position: absolute;
   top: 95%;
-  right: 0;
   left: 0;
   margin: 0;
   padding: 0.75rem 0;
@@ -12080,19 +12095,17 @@ exports[`Storyshots Navigation default example 1`] = `
 .emotion-3:hover > ul {
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-3:hover > ul:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";
@@ -12223,19 +12236,17 @@ exports[`Storyshots Navigation default example 1`] = `
   padding: 0;
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-9:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";
@@ -12535,8 +12546,16 @@ exports[`Storyshots Navigation inverted example 1`] = `
 }
 
 .emotion-27 {
-  margin: 0 0 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding: 0 1rem;
+  width: 100%;
 }
 
 @media (max-width:1065px) {
@@ -12570,7 +12589,16 @@ exports[`Storyshots Navigation inverted example 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style: none;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 @media (max-width:1065px) {
@@ -12604,19 +12632,17 @@ exports[`Storyshots Navigation inverted example 1`] = `
   padding: 0;
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-9:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";
@@ -12802,7 +12828,6 @@ exports[`Storyshots Navigation inverted example 1`] = `
   display: inline-block;
   position: absolute;
   top: 95%;
-  right: 0;
   left: 0;
   margin: 0;
   padding: 0.75rem 0;
@@ -12811,19 +12836,17 @@ exports[`Storyshots Navigation inverted example 1`] = `
 .emotion-3:hover > ul {
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-3:hover > ul:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";
@@ -13263,8 +13286,16 @@ exports[`Storyshots Navigation with item links as children 1`] = `
 }
 
 .emotion-7 {
-  margin: 0 0 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding: 0 1rem;
+  width: 100%;
 }
 
 @media (max-width:1065px) {
@@ -13298,7 +13329,16 @@ exports[`Storyshots Navigation with item links as children 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style: none;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 @media (max-width:1065px) {
@@ -13329,7 +13369,6 @@ exports[`Storyshots Navigation with item links as children 1`] = `
   display: inline-block;
   position: absolute;
   top: 95%;
-  right: 0;
   left: 0;
   margin: 0;
   padding: 0.75rem 0;
@@ -13338,19 +13377,17 @@ exports[`Storyshots Navigation with item links as children 1`] = `
 .emotion-3:hover > ul {
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-3:hover > ul:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";
@@ -13918,11 +13955,11 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
   }
 }
 
-.emotion-30 {
+.emotion-31 {
   padding: 2rem;
 }
 
-.emotion-29 {
+.emotion-30 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -14044,19 +14081,27 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
   transform: scale(1.2);
 }
 
-.emotion-28 {
-  margin: 0 0 0 auto;
+.emotion-29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding: 0 1rem;
+  width: 100%;
 }
 
 @media (max-width:1065px) {
-  .emotion-28 {
+  .emotion-29 {
     display: none;
   }
 }
 
 @media (max-width:1065px) {
-  .emotion-28 {
+  .emotion-29 {
     display: none;
     position: fixed;
     overflow-y: auto;
@@ -14076,15 +14121,24 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
   }
 }
 
-.emotion-27 {
+.emotion-28 {
   list-style: none;
   margin: 0;
   padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style: none;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 @media (max-width:1065px) {
-  .emotion-27 {
+  .emotion-28 {
     list-style: none;
     margin: 0 auto;
     padding: 0 1rem;
@@ -14111,7 +14165,6 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
   display: inline-block;
   position: absolute;
   top: 95%;
-  right: 0;
   left: 0;
   margin: 0;
   padding: 0.75rem 0;
@@ -14120,19 +14173,17 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
 .emotion-3:hover > ul {
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-3:hover > ul:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";
@@ -14263,19 +14314,17 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
   padding: 0;
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-9:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";
@@ -14348,6 +14397,12 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
 }
 
 .emotion-26 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-27 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14385,13 +14440,13 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
   margin-left: .5rem;
 }
 
-.emotion-26[disabled],
-.emotion-26[disabled]:hover {
+.emotion-27[disabled],
+.emotion-27[disabled]:hover {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-.emotion-26 svg {
+.emotion-27 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -14401,30 +14456,30 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
   transform: scale(1);
 }
 
-.emotion-26:hover:not([disabled]) svg {
+.emotion-27:hover:not([disabled]) svg {
   -webkit-animation: animation-0 1s linear infinite;
   animation: animation-0 1s linear infinite;
 }
 
-.emotion-26:hover {
+.emotion-27:hover {
   background: #542c85;
   border: 1px solid #542c85;
 }
 
-.emotion-26:focus {
+.emotion-27:focus {
   background: #542c85;
   border: 0;
   color: #ffffff;
 }
 
-.emotion-26:hover:not([disabled]) {
+.emotion-27:hover:not([disabled]) {
   background: #542c85;
   border: 0;
   color: #ffffff;
 }
 
 @media (max-width:1065px) {
-  .emotion-26 {
+  .emotion-27 {
     margin-top: .5rem;
   }
 }
@@ -14436,10 +14491,10 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
     <div>
       <div>
         <div
-          class="emotion-30"
+          class="emotion-31"
         >
           <div
-            class="emotion-29"
+            class="emotion-30"
           >
             <button
               aria-expanded=""
@@ -14450,10 +14505,10 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
               />
             </button>
             <nav
-              class="emotion-28"
+              class="emotion-29"
             >
               <ul
-                class="emotion-27"
+                class="emotion-28"
               >
                 <li
                   class="emotion-3"
@@ -14617,8 +14672,11 @@ exports[`Storyshots Navigation with item links as props and button as child 1`] 
                     </span>
                   </a>
                 </li>
-                <a
+                <div
                   class="emotion-26"
+                />
+                <a
+                  class="emotion-27"
                   href="/get-started"
                 >
                   Get started for free
@@ -14775,8 +14833,16 @@ exports[`Storyshots Navigation with item links as props and children 1`] = `
 }
 
 .emotion-7 {
-  margin: 0 0 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding: 0 1rem;
+  width: 100%;
 }
 
 @media (max-width:1065px) {
@@ -14810,7 +14876,16 @@ exports[`Storyshots Navigation with item links as props and children 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style: none;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 @media (max-width:1065px) {
@@ -14841,7 +14916,6 @@ exports[`Storyshots Navigation with item links as props and children 1`] = `
   display: inline-block;
   position: absolute;
   top: 95%;
-  right: 0;
   left: 0;
   margin: 0;
   padding: 0.75rem 0;
@@ -14850,19 +14924,17 @@ exports[`Storyshots Navigation with item links as props and children 1`] = `
 .emotion-3:hover > ul {
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-3:hover > ul:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";
@@ -15151,8 +15223,16 @@ exports[`Storyshots Navigation with nested item links as children 1`] = `
 }
 
 .emotion-10 {
-  margin: 0 0 0 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding: 0 1rem;
+  width: 100%;
 }
 
 @media (max-width:1065px) {
@@ -15186,7 +15266,16 @@ exports[`Storyshots Navigation with nested item links as children 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style: none;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 @media (max-width:1065px) {
@@ -15217,7 +15306,6 @@ exports[`Storyshots Navigation with nested item links as children 1`] = `
   display: inline-block;
   position: absolute;
   top: 95%;
-  right: 0;
   left: 0;
   margin: 0;
   padding: 0.75rem 0;
@@ -15226,19 +15314,17 @@ exports[`Storyshots Navigation with nested item links as children 1`] = `
 .emotion-8:hover > ul {
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-8:hover > ul:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";
@@ -15369,19 +15455,17 @@ exports[`Storyshots Navigation with nested item links as children 1`] = `
   padding: 0;
   font-size: 0.875rem;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-  left: auto;
   right: 0;
   box-shadow: 0px 4px 16px rgba(46,41,51,0.08),0px 8px 24px rgba(71,63,79,0.16);
   background: #ffffff;
-  width: 260px;
+  width: 450px;
   border-radius: 2px;
 }
 
 .emotion-7:after {
   position: absolute;
   top: -6px;
-  right: 16px;
-  margin: 0 0 0 -6px;
+  left: 30px;
   width: 12px;
   height: 12px;
   content: " ";

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,11 +11,11 @@ export type ButtonTone = "BRAND" | "SUCCESS" | "DANGER" | "NEUTRAL"
 export type ButtonVariant = "PRIMARY" | "SECONDARY" | "GHOST"
 
 export type ButtonStyleProps = {
-  size?: ButtonSize;
-  tone?: ButtonTone;
-  variant?: ButtonVariant;
-  leftIcon?: React.ReactNode;
-  rightIcon?: React.ReactNode;
+  size?: ButtonSize
+  tone?: ButtonTone
+  variant?: ButtonVariant
+  leftIcon?: React.ReactNode
+  rightIcon?: React.ReactNode
 }
 
 export type ButtonProps = BaseButtonProps & ButtonStyleProps

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -7,7 +7,7 @@ const Navigation = ({
   items,
   isInverted = false,
   mobileNavMediaQuery = `@media (max-width: 1065px)`,
-  ...rest
+  ...delegated
 }) => (
   <BaseNavigation
     items={items}
@@ -25,27 +25,25 @@ const Navigation = ({
     DropdownToggle={Navigation.DropdownToggle}
     Button={Navigation.Button}
     css={styles.Navigation.default}
-    {...rest}
+    {...delegated}
   />
 )
 
-Navigation.Hamburger = ({ ...rest }) => (
-  <BaseNavigation.Hamburger {...rest}></BaseNavigation.Hamburger>
-)
+Navigation.Hamburger = delegated => <BaseNavigation.Hamburger {...delegated} />
 
-Navigation.HamburgerIcon = ({ ...rest }) => {
+Navigation.HamburgerIcon = delegated => {
   const { isMobileNavOpen } = BaseNavigation.useNavigationContext()
 
   return (
     <BaseNavigation.HamburgerIcon
       css={styles.HamburgerIcon}
       className={isMobileNavOpen ? `active` : ``}
-      {...rest}
+      {...delegated}
     />
   )
 }
 
-Navigation.Nav = ({ ...rest }) => {
+Navigation.Nav = delegated => {
   const {
     mobileNavMediaQuery,
     isMobileNavOpen,
@@ -55,12 +53,10 @@ Navigation.Nav = ({ ...rest }) => {
     <BaseNavigation.Nav
       css={{
         ...styles.Nav.default,
-        [mobileNavMediaQuery]: {
-          ...styles.Nav.mobile(isMobileNavOpen),
-        },
+        [mobileNavMediaQuery]: styles.Nav.mobile(isMobileNavOpen),
       }}
-      {...rest}
-    ></BaseNavigation.Nav>
+      {...delegated}
+    />
   )
 }
 
@@ -68,38 +64,34 @@ Navigation.Spacer = delegated => {
   return <div css={{ flex: 1 }} {...delegated} />
 }
 
-Navigation.List = ({ ...rest }) => {
+Navigation.List = delegated => {
   const { mobileNavMediaQuery } = BaseNavigation.useNavigationContext()
 
   return (
     <BaseNavigation.List
       css={{
         ...styles.List.default,
-        [mobileNavMediaQuery]: {
-          ...styles.List.mobile,
-        },
+        [mobileNavMediaQuery]: styles.List.mobile,
       }}
-      {...rest}
+      {...delegated}
     />
   )
 }
 
-Navigation.Item = ({ ...rest }) => {
+Navigation.Item = delegated => {
   const { mobileNavMediaQuery } = BaseNavigation.useNavigationContext()
 
   return (
     <BaseNavigation.Item
       css={{
         ...styles.Item.default,
-        [mobileNavMediaQuery]: {
-          ...styles.Item.mobile,
-        },
+        [mobileNavMediaQuery]: styles.Item.mobile,
       }}
-      {...rest}
-    ></BaseNavigation.Item>
+      {...delegated}
+    />
   )
 }
-Navigation.ItemLink = ({ ...rest }) => {
+Navigation.ItemLink = delegated => {
   const {
     isInverted,
     mobileNavMediaQuery,
@@ -109,76 +101,66 @@ Navigation.ItemLink = ({ ...rest }) => {
     <BaseNavigation.ItemLink
       css={{
         ...styles.ItemLink.default(isInverted),
-        [mobileNavMediaQuery]: {
-          ...styles.ItemLink.mobile,
-        },
+        [mobileNavMediaQuery]: styles.ItemLink.mobile,
       }}
-      {...rest}
-    ></BaseNavigation.ItemLink>
+      {...delegated}
+    />
   )
 }
 
-Navigation.Dropdown = ({ ...rest }) => {
+Navigation.Dropdown = delegated => {
   const { mobileNavMediaQuery } = BaseNavigation.useNavigationContext()
 
   return (
     <BaseNavigation.Dropdown
       css={{
         ...styles.Dropdown.default,
-        [mobileNavMediaQuery]: {
-          ...styles.Dropdown.mobile,
-        },
+        [mobileNavMediaQuery]: styles.Dropdown.mobile,
       }}
-      {...rest}
-    ></BaseNavigation.Dropdown>
+      {...delegated}
+    />
   )
 }
 
-Navigation.DropdownToggle = ({ ...rest }) => {
+Navigation.DropdownToggle = delegated => {
   const { mobileNavMediaQuery } = BaseNavigation.useNavigationContext()
 
   return (
     <BaseNavigation.DropdownToggle
       css={{
         ...styles.DropdownToggle.default,
-        [mobileNavMediaQuery]: {
-          ...styles.DropdownToggle.mobile,
-        },
+        [mobileNavMediaQuery]: styles.DropdownToggle.mobile,
       }}
-      {...rest}
-    ></BaseNavigation.DropdownToggle>
+      {...delegated}
+    />
   )
 }
 
-Navigation.DropdownItem = ({ ...rest }) => {
+Navigation.DropdownItem = delegated => {
   const { mobileNavMediaQuery } = BaseNavigation.useNavigationContext()
 
   return (
     <BaseNavigation.DropdownItem
       css={{
         ...styles.DropdownItem.default,
-        [mobileNavMediaQuery]: {
-          ...styles.DropdownItem.mobile,
-        },
+        [mobileNavMediaQuery]: styles.DropdownItem.mobile,
       }}
-      {...rest}
-    ></BaseNavigation.DropdownItem>
+      {...delegated}
+    />
   )
 }
 
-Navigation.Button = ({ ...rest }) => {
+Navigation.Button = delegated => {
   const { mobileNavMediaQuery } = BaseNavigation.useNavigationContext()
 
   return (
     <BaseNavigation.LinkButton
       css={{
         ...styles.Button.default,
-        [mobileNavMediaQuery]: {
-          ...styles.Button.mobile,
-        },
+        [mobileNavMediaQuery]: styles.Button.mobile,
       }}
-      {...rest}
-    ></BaseNavigation.LinkButton>
+      {...delegated}
+    />
   )
 }
 

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -24,9 +24,7 @@ const Navigation = ({
     DropdownItem={Navigation.DropdownItem}
     DropdownToggle={Navigation.DropdownToggle}
     Button={Navigation.Button}
-    css={{
-      ...styles.Navigation.default,
-    }}
+    css={styles.Navigation.default}
     {...rest}
   />
 )
@@ -40,12 +38,10 @@ Navigation.HamburgerIcon = ({ ...rest }) => {
 
   return (
     <BaseNavigation.HamburgerIcon
-      css={{
-        ...styles.HamburgerIcon,
-      }}
+      css={styles.HamburgerIcon}
       className={isMobileNavOpen ? `active` : ``}
       {...rest}
-    ></BaseNavigation.HamburgerIcon>
+    />
   )
 }
 
@@ -66,6 +62,10 @@ Navigation.Nav = ({ ...rest }) => {
       {...rest}
     ></BaseNavigation.Nav>
   )
+}
+
+Navigation.Spacer = delegated => {
+  return <div css={{ flex: 1 }} {...delegated} />
 }
 
 Navigation.List = ({ ...rest }) => {

--- a/src/components/Navigation/Navigation.stories.js
+++ b/src/components/Navigation/Navigation.stories.js
@@ -104,6 +104,7 @@ storiesOf(`Navigation`, module)
   .add(`with item links as props and button as child`, () => (
     <div css={{ padding: `2rem` }}>
       <Navigation items={items}>
+        <Navigation.Spacer />
         <Navigation.Button linkTo="/get-started">
           Get started for free
         </Navigation.Button>

--- a/src/components/skeletons/BaseNavigation/BaseNavigationStyles.js
+++ b/src/components/skeletons/BaseNavigation/BaseNavigationStyles.js
@@ -24,7 +24,6 @@ const BaseNavigationDropdownOpenStyles = {
   display: `inline-block`,
   position: `absolute`,
   top: `95%`,
-  right: 0,
   left: 0,
   margin: 0,
   padding: `0.75rem 0`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export { Breadcrumb } from "./components/Breadcrumb"
 export { Switch } from "./components/Switch"
 
 export { Navigation } from "./components/Navigation"
+export { BaseNavigation } from "./components/skeletons/BaseNavigation"
 
 export * from "./components/CopyButton"
 

--- a/src/theme/styles/navigation.js
+++ b/src/theme/styles/navigation.js
@@ -121,6 +121,7 @@ const DropdownMobileStyles = {
 
 styles.Item = {
   default: {
+    marginBottom: 0,
     padding: `0 ${spaces.s}`,
     "&:hover > ul": {
       ...DropdownOpenStyles,

--- a/src/theme/styles/navigation.js
+++ b/src/theme/styles/navigation.js
@@ -37,8 +37,10 @@ styles.HamburgerIcon = {
 
 styles.Nav = {
   default: {
-    margin: `0 0 0 auto`,
+    display: `flex`,
+    justifyContent: `space-between`,
     padding: `0 ${spaces.m}`,
+    width: "100%",
   },
   mobile: isMobileNavOpen => {
     return {
@@ -61,7 +63,10 @@ styles.Nav = {
 
 styles.List = {
   default: {
+    display: `flex`,
     listStyle: `none`,
+    width: `100%`,
+    alignItems: "center",
   },
   mobile: {
     listStyle: `none`,
@@ -79,18 +84,17 @@ styles.List = {
 const DropdownOpenStyles = {
   fontSize: fontSizes[1],
   fontFamily: fonts.system.join(`,`),
-  left: `auto`,
   right: 0,
   boxShadow: `0px 4px 16px rgba(46, 41, 51, 0.08), 0px 8px 24px rgba(71, 63, 79, 0.16)`,
   background: colors.white,
-  width: 260,
+  width: 450,
   borderRadius: 2,
+
   // color: colors.grey[50],
   ":after": {
     position: `absolute`,
     top: -6,
-    right: 16,
-    margin: `0 0 0 -6px`,
+    left: 30,
     width: 12,
     height: 12,
     content: `" "`,

--- a/src/theme/styles/navigation.js
+++ b/src/theme/styles/navigation.js
@@ -90,7 +90,6 @@ const DropdownOpenStyles = {
   width: 450,
   borderRadius: 2,
 
-  // color: colors.grey[50],
   ":after": {
     position: `absolute`,
     top: -6,


### PR DESCRIPTION
This PR makes a few small tweaks:

- Aligns nav items to the right instead of left, to match latest designs
- Tweak dropdown positioning
- Adds `Nav.Spacer` to allow items to be pushed to the right
- Code cleanup (mostly carrying over some of the stuff I did in `BaseNavigationStyles`, in a previous PR, to `Navigation`)

Storybook GIF:

![story](https://user-images.githubusercontent.com/6692932/70470799-dee3a200-1a99-11ea-81af-c31de6275ec0.gif)


In-app Screenshots:

![Screenshot 2019-12-06 at 4 27 39 PM](https://user-images.githubusercontent.com/6692932/70357634-64224900-1845-11ea-8ef6-e412ef983ccc.png)
![Screenshot 2019-12-06 at 4 27 58 PM](https://user-images.githubusercontent.com/6692932/70357636-65ec0c80-1845-11ea-8fb4-e5fe63595371.png)
![Screenshot 2019-12-06 at 4 28 01 PM](https://user-images.githubusercontent.com/6692932/70357641-68e6fd00-1845-11ea-9f10-7e11ce9b4b19.png)
