### PR TITLE
Adding XS size to avatar

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -30,6 +30,7 @@ storiesOf(`Avatar`, module)
             size={radios(
               "size",
               {
+                xsmall: "XS",
                 small: "S",
                 medium: "M",
                 large: "L",
@@ -63,6 +64,7 @@ storiesOf(`Avatar`, module)
             size={radios(
               "size",
               {
+                xsmall: "XS",
                 small: "S",
                 medium: "M",
                 large: "L",

--- a/src/components/Avatar/constants.tsx
+++ b/src/components/Avatar/constants.tsx
@@ -4,6 +4,7 @@ import { AvatarSize } from "./types"
 export const DEFAULT_SIZE: AvatarSize = "M"
 
 export const avatarSizeValues: Record<AvatarSize, string> = {
+  XS: "20px",
   S: "24px",
   M: "32px",
   L: "48px",
@@ -11,6 +12,7 @@ export const avatarSizeValues: Record<AvatarSize, string> = {
 }
 
 export const borderSizeValues: Record<AvatarSize, number> = {
+  XS: 0.5,
   S: 1,
   M: 2,
   L: 3,
@@ -18,6 +20,7 @@ export const borderSizeValues: Record<AvatarSize, number> = {
 }
 
 export const placeholderFontSizes: Record<AvatarSize, string> = {
+  XS: fontSizes["4xs"],
   S: fontSizes["2xs"],
   M: fontSizes["xs"],
   L: fontSizes["m"],

--- a/src/components/Avatar/types.ts
+++ b/src/components/Avatar/types.ts
@@ -1,1 +1,1 @@
-export type AvatarSize = "S" | "M" | "L" | "XL"
+export type AvatarSize = "XS" | "S" | "M" | "L" | "XL"


### PR DESCRIPTION
Adding an XS size to avatar to fix the first point of https://github.com/gatsby-inc/mansion/issues/5848

Here's the picture in XS, it's small 😝

<img width="58" alt="Screenshot 2019-12-10 at 08 58 34" src="https://user-images.githubusercontent.com/3874873/70506991-c623cc80-1b2b-11ea-96e2-58cf627d5b49.png">

<img width="205" alt="Screenshot 2019-12-10 at 08 58 24" src="https://user-images.githubusercontent.com/3874873/70507004-cae88080-1b2b-11ea-8607-3853301c29c4.png">
