### PR TITLE
Adding Avatar XXL

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -35,6 +35,7 @@ storiesOf(`Avatar`, module)
                 medium: "M",
                 large: "L",
                 xlarge: "XL",
+                xxlarge: "XXL",
               },
               "M"
             )}
@@ -69,6 +70,7 @@ storiesOf(`Avatar`, module)
                 medium: "M",
                 large: "L",
                 xlarge: "XL",
+                xxlarge: "XXL",
               },
               "M"
             )}

--- a/src/components/Avatar/constants.tsx
+++ b/src/components/Avatar/constants.tsx
@@ -9,6 +9,7 @@ export const avatarSizeValues: Record<AvatarSize, string> = {
   M: "32px",
   L: "48px",
   XL: "64px",
+  XXL: "128px",
 }
 
 export const borderSizeValues: Record<AvatarSize, number> = {
@@ -17,6 +18,7 @@ export const borderSizeValues: Record<AvatarSize, number> = {
   M: 2,
   L: 3,
   XL: 4,
+  XXL: 8,
 }
 
 export const placeholderFontSizes: Record<AvatarSize, string> = {
@@ -25,4 +27,5 @@ export const placeholderFontSizes: Record<AvatarSize, string> = {
   M: fontSizes["xs"],
   L: fontSizes["m"],
   XL: fontSizes["l"],
+  XXL: fontSizes["2xl"],
 }

--- a/src/components/Avatar/types.ts
+++ b/src/components/Avatar/types.ts
@@ -1,1 +1,1 @@
-export type AvatarSize = "XS" | "S" | "M" | "L" | "XL"
+export type AvatarSize = "XS" | "S" | "M" | "L" | "XL" | "XXL"


### PR DESCRIPTION
Adding XXL size for avatar in 128x128 related to https://github.com/gatsby-inc/mansion/issues/5848#issuecomment-564758990

Here's a picture:

<img width="530" alt="Screenshot 2019-12-12 at 11 13 33" src="https://user-images.githubusercontent.com/3874873/70703603-c14c4d80-1cd0-11ea-9d7c-54de00360b7c.png">
<img width="237" alt="Screenshot 2019-12-12 at 11 13 40" src="https://user-images.githubusercontent.com/3874873/70703606-c1e4e400-1cd0-11ea-9d89-1b46b32e23dd.png">
