### PR TITLE
Update colors token exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,6 @@ export * from "./components/CopyButton"
 
 export { default as colors } from "./theme/colors"
 
-export { palette } from "./utils/presets/colors"
 export { fontFamilies, fontSizes } from "./utils/presets/typography"
 export { spaces } from "./utils/presets/spaces"
 export { breakpoints } from "./utils/presets/breakpoints"

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,9 @@ export { Switch } from "./components/core/Switch"
 
 export * from "./components/CopyButton"
 
-export { colors, palette } from "./utils/presets/colors"
+export { default as colors } from "./theme/colors"
+
+export { palette } from "./utils/presets/colors"
 export { fontFamilies, fontSizes } from "./utils/presets/typography"
 export { spaces } from "./utils/presets/spaces"
 export { breakpoints } from "./utils/presets/breakpoints"


### PR DESCRIPTION
A quick change in exporting `colors` design-tokens, required for https://github.com/gatsby-inc/mansion/pull/5924

- stop exporting `palette`
- export `colors` from `/theme` instead of `/utils/presets`

no changes in components so I push it directly to `master` to not deal with the current stage of `dev`.

Removing  usage of `palette` in the `gatsby-interface` components is in a separate PR -> https://github.com/gatsby-inc/gatsby-interface/pull/165