### PR TITLE
chore: add 'lint:all' and 'format:all' scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:rollup": "rollup -c",
     "stylelint": "stylelint './src/**/*.js'",
     "format": "prettier-eslint --write",
-    "format:all": "yarn format \"src/**/*.js\"",
+    "format:all": "yarn format \"src/**/*.{js,jsx,ts,tsx}\"",
     "lint": "eslint -c .eslintrc --max-warnings=0 --fix --color --ext .js,.jsx,.ts,.tsx --report-unused-disable-directives",
     "lint:all": "yarn lint src",
     "chromatic": "chromatic test",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
     "build:types": "tsc --emitDeclarationOnly -p tsconfig.build-types.json",
     "build:rollup": "rollup -c",
     "stylelint": "stylelint './src/**/*.js'",
-    "format": "prettier-eslint --write \"src/**/*.js\"",
-    "lint": "eslint -c .eslintrc --max-warnings=0 src --fix --color --ext .js,.jsx,.ts,.tsx --report-unused-disable-directives",
+    "format": "prettier-eslint --write",
+    "format:all": "yarn format \"src/**/*.js\"",
+    "lint": "eslint -c .eslintrc --max-warnings=0 --fix --color --ext .js,.jsx,.ts,.tsx --report-unused-disable-directives",
+    "lint:all": "yarn lint src",
     "chromatic": "chromatic test",
     "scaffold:icon": "babel-node --presets @babel/env scripts/scaffold-icon/scaffold-icon.js",
     "release": "standard-version"


### PR DESCRIPTION
This PR changes precommit hooks a little bit to make them more predictable and reliable. Previously, we would run both `lint` and `format` scripts even for files that were not staged for commit due to the way those scripts were configured. This is fixed with the following changes:

* `yarn lint` now supports passing a path (e.g. `yarn lint src/index.ts`)
* `yarn lint:all` has been added to lint every matching file from `src` directory
* `yarn format` now supports passing a path (e.g. `yarn lint src/components/Avatar/*.tsx`)
* `yarn format:all` has been added to format every matching file from `src` directory

These changes allow `lint-staged` to run lint and format scripts only for staged files. 

Once this PR is merged, I'd like us to explore an alternative approach to using ESLint + Prettier; for example, we could consider [the recommended solution](https://prettier.io/docs/en/integrating-with-linters.html#recommended-configuration) of using an ESLint plugin.