### PR TITLE
feat: fit fallback text to Avatar size

### DIFF
--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -302,6 +302,7 @@ exports[`Storyshots Avatar AvatarsGroup 1`] = `
               >
                 <span
                   aria-label="John Doe"
+                  style="font-size: 0.6875px;"
                 >
                   JD
                 </span>
@@ -323,6 +324,7 @@ exports[`Storyshots Avatar AvatarsGroup 1`] = `
               >
                 <span
                   aria-label="More users not displayed"
+                  style="font-size: 0.6875px;"
                 >
                   +1
                 </span>

--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -153,6 +153,259 @@ exports[`Storyshots Avatar Avatar 1`] = `
 </div>
 `;
 
+exports[`Storyshots Avatar Avatar fallback text fit 1`] = `
+.emotion-6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.emotion-2 {
+  background: #f0f0f2;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  color: #635e69;
+  width: 32px;
+  height: 32px;
+  font-size: 0.875rem;
+}
+
+.emotion-0 {
+  background: #f0f0f2;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  color: #635e69;
+  width: 20px;
+  height: 20px;
+  font-size: 0.5rem;
+}
+
+.emotion-1 {
+  background: #f0f0f2;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  color: #635e69;
+  width: 24px;
+  height: 24px;
+  font-size: 0.75rem;
+}
+
+.emotion-3 {
+  background: #f0f0f2;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  color: #635e69;
+  width: 48px;
+  height: 48px;
+  font-size: 1.25rem;
+}
+
+.emotion-4 {
+  background: #f0f0f2;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  color: #635e69;
+  width: 64px;
+  height: 64px;
+  font-size: 1.75rem;
+}
+
+.emotion-5 {
+  background: #f0f0f2;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  color: #635e69;
+  width: 128px;
+  height: 128px;
+  font-size: 3.75rem;
+}
+
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="emotion-6"
+        >
+          <div>
+            <span
+              class="emotion-0"
+              title="Avatar of size XS"
+            >
+              <span
+                aria-label="Avatar of size XS"
+                style="font-size: 0.5px;"
+              >
+                A
+              </span>
+            </span>
+            <span
+              class="emotion-1"
+              title="Avatar of size S"
+            >
+              <span
+                aria-label="Avatar of size S"
+                style="font-size: 0.625px;"
+              >
+                A
+              </span>
+            </span>
+            <span
+              class="emotion-2"
+              title="Avatar of size M"
+            >
+              <span
+                aria-label="Avatar of size M"
+                style="font-size: 0.6875px;"
+              >
+                A
+              </span>
+            </span>
+            <span
+              class="emotion-3"
+              title="Avatar of size L"
+            >
+              <span
+                aria-label="Avatar of size L"
+                style="font-size: 0.875px;"
+              >
+                A
+              </span>
+            </span>
+            <span
+              class="emotion-4"
+              title="Avatar of size XL"
+            >
+              <span
+                aria-label="Avatar of size XL"
+                style="font-size: 1.125px;"
+              >
+                A
+              </span>
+            </span>
+            <span
+              class="emotion-5"
+              title="Avatar of size XXL"
+            >
+              <span
+                aria-label="Avatar of size XXL"
+                style="font-size: 3.4375px;"
+              >
+                A
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Avatar AvatarsGroup 1`] = `
 .emotion-7 {
   -webkit-align-items: center;

--- a/src/components/Avatar/Avatar.helpers.tsx
+++ b/src/components/Avatar/Avatar.helpers.tsx
@@ -1,0 +1,54 @@
+type FitTextOptions = {
+  maxWidth: number
+  minFontSizeInRem: number
+  maxFontSizeInRem: number
+}
+
+// The following is based on textFit library https://github.com/STRML/textFit
+export function fitText<T extends HTMLElement>({
+  maxWidth: maxTextWidth = 1,
+  minFontSizeInRem,
+  maxFontSizeInRem,
+}: FitTextOptions) {
+  return (element: T | null) => {
+    if (!element) {
+      return
+    }
+    const parent = element.parentElement
+
+    if (!parent) {
+      return
+    }
+
+    // Get base font size so that we can parse rem into px
+    const baseFontSize = parseFloat(
+      window.getComputedStyle(document.documentElement).fontSize
+    )
+
+    let low = baseFontSize * minFontSizeInRem
+    let high = baseFontSize * maxFontSizeInRem
+
+    const maxWidth = parent.clientWidth * maxTextWidth
+    const maxHeight = parent.clientHeight * maxWidth
+
+    let fontSize = low
+    let mid
+
+    // Binary search to find the most fitting font size
+    while (low <= high) {
+      mid = (high + low) / 2
+      element.style.fontSize = mid + "px"
+      if (
+        element.scrollWidth <= maxWidth &&
+        element.scrollHeight <= maxHeight
+      ) {
+        fontSize = mid
+        low = mid + 1
+      } else {
+        high = mid - 1
+      }
+    }
+
+    element.style.fontSize = `${fontSize}px`
+  }
+}

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -7,6 +7,7 @@ import { StoryUtils } from "../../utils/storybook"
 import README from "./README.md"
 import Avatar from "./Avatar"
 import AvatarsGroup from "./AvatarsGroup"
+import { AvatarSize } from "./index"
 
 storiesOf(`Avatar`, module)
   .addParameters({
@@ -40,6 +41,24 @@ storiesOf(`Avatar`, module)
               "M"
             )}
           />
+        </div>
+      </StoryUtils.Container>
+    )
+  })
+  .add(`Avatar fallback text fit`, () => {
+    const sizes: AvatarSize[] = ["XS", "S", "M", "L", "XL", "XXL"]
+    return (
+      <StoryUtils.Container>
+        <div>
+          {sizes.map(size => (
+            <Avatar
+              key={size}
+              src=""
+              label={`Avatar of size ${size}`}
+              fallback={text("fallback text", "A")}
+              size={size}
+            />
+          ))}
         </div>
       </StoryUtils.Container>
     )

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,9 +1,11 @@
 /** @jsx jsx */
+import React from "react"
 import { jsx } from "@emotion/core"
 import { css } from "@emotion/core"
 import AvatarSkeleton from "./AvatarSkeleton"
 import { AvatarSize } from "./types"
-import { DEFAULT_SIZE } from "./constants"
+import { DEFAULT_SIZE, placeholderFontSizes } from "./constants"
+import { fitText } from "./Avatar.helpers"
 
 const imageCss = css({
   objectFit: "cover",
@@ -13,14 +15,24 @@ const imageCss = css({
   margin: 0,
 })
 
+const maxFallbackTextWidth: Record<AvatarSize, number> = {
+  XS: 0.9,
+  S: 0.9,
+  M: 0.9,
+  L: 0.8,
+  XL: 0.8,
+  XXL: 0.8,
+}
+
 export type AvatarProps = {
-  src: string;
-  label: string;
-  fallback?: React.ReactNode;
-  size?: AvatarSize;
-  borderColor?: string | null;
-  className?: string;
-  style?: React.CSSProperties;
+  src: string
+  label: string
+  fallback?: React.ReactNode
+  size?: AvatarSize
+  borderColor?: string | null
+  fitTextFallback?: boolean
+  className?: string
+  style?: React.CSSProperties
 }
 
 export default function Avatar({
@@ -32,6 +44,12 @@ export default function Avatar({
   className,
   style,
 }: AvatarProps) {
+  const textFitter = fitText<HTMLSpanElement>({
+    maxWidth: maxFallbackTextWidth[size],
+    minFontSizeInRem: parseFloat(placeholderFontSizes.XS),
+    maxFontSizeInRem: parseFloat(placeholderFontSizes[size]),
+  })
+
   return (
     <AvatarSkeleton
       size={size}
@@ -43,7 +61,9 @@ export default function Avatar({
       {src ? (
         <img css={imageCss} src={src} alt={label} />
       ) : (
-        <span aria-label={label}>{fallback}</span>
+        <span aria-label={label} ref={textFitter}>
+          {fallback}
+        </span>
       )}
     </AvatarSkeleton>
   )

--- a/src/components/Avatar/constants.tsx
+++ b/src/components/Avatar/constants.tsx
@@ -25,7 +25,7 @@ export const placeholderFontSizes: Record<AvatarSize, string> = {
   XS: `0.5rem`,
   S: fontSizes[0],
   M: fontSizes[1],
-  L: fontSizes[3],
-  XL: fontSizes[4],
-  XXL: fontSizes[6],
+  L: fontSizes[4],
+  XL: fontSizes[6],
+  XXL: fontSizes[12],
 }


### PR DESCRIPTION
Fixes #136 by using binary search to find the most fitting font size for an avatar fallback text. Inspired by and based on [textFit](https://github.com/STRML/textFit).

![ezgif-3-7cc8229a2654](https://user-images.githubusercontent.com/4366711/73902056-7a4e8480-4849-11ea-9d9b-4708118eb604.gif)
