### PR TITLE
Add support for external links

### DIFF
--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -360,6 +360,32 @@ exports[`Storyshots BaseLink default 1`] = `
 </div>
 `;
 
+exports[`Storyshots BaseLink external 1`] = `
+<div>
+  <div
+    class="storybook-readme-story"
+  >
+    <div>
+      <div>
+        <div
+          class="css-3ga7ji"
+        >
+          <div
+            class="css-gkzmg7"
+          >
+            <a
+              href="http://www.bing.com"
+            >
+              Search
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots BaseNavigation BaseNavigation.Hamburger 1`] = `
 <div>
   <div

--- a/src/components/BaseLink/BaseLink.stories.tsx
+++ b/src/components/BaseLink/BaseLink.stories.tsx
@@ -21,3 +21,10 @@ storiesOf(`BaseLink`, module)
       </StoryUtils.Stack>
     </StoryUtils.Container>
   ))
+  .add(`external`, () => (
+    <StoryUtils.Container>
+      <StoryUtils.Stack>
+        <BaseLink to="http://www.bing.com">Search</BaseLink>
+      </StoryUtils.Stack>
+    </StoryUtils.Container>
+  ))

--- a/src/components/BaseLink/BaseLink.tsx
+++ b/src/components/BaseLink/BaseLink.tsx
@@ -4,6 +4,16 @@ import { Link, GatsbyLinkProps } from "gatsby"
 export type BaseLinkProps<TState> = Omit<GatsbyLinkProps<TState>, "ref">
 
 export function BaseLink({ to, role, children, ...rest }: BaseLinkProps<any>) {
+  const isExternal = to.match(/(^http|^mailto)/i)
+
+  if (isExternal) {
+    return (
+      <a href={to} role={role} {...rest}>
+        {children}
+      </a>
+    )
+  }
+
   return (
     <Link to={to} role={role} {...rest}>
       {children}


### PR DESCRIPTION
For the Willit.build project, we need a link to Gatsby Cloud. Since WIB is its own project, this needs to be an external link:

<img width="638" alt="Screenshot 2020-02-25 at 11 21 28 AM" src="https://user-images.githubusercontent.com/6692932/75266908-0d336c80-57c1-11ea-87b1-5b7e693d08ac.png">

This component uses Navigation.Button, which is ultimately a wrapper around BaseLink.

In my side-projects, I often add a bit of logic to my base link component, to switch to an `<a>` if the link appears to be external. 

Alternatively I could add a prop, `isExternal`, but in my experience it can be deciphered correctly almost all of the time, and we can always add an override if we run into an edge-case.