### PR TITLE
fix: remove static properties from Input form fields

### DIFF
--- a/src/components/form-skeletons/components/FormFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/FormFieldSkeleton.tsx
@@ -70,7 +70,9 @@ export type FormFieldSkeletonLabelProps = Omit<
   "ref" | "htmlFor"
 >
 
-const FormFieldSkeletonLabel: React.FC<FormFieldSkeletonLabelProps> = props => {
+export const FormFieldSkeletonLabel: React.FC<
+  FormFieldSkeletonLabelProps
+> = props => {
   const { id } = useFormFieldSkeleton()
 
   return <label htmlFor={id} {...props} />
@@ -81,7 +83,7 @@ export type FormFieldSkeletonHintProps = Omit<
   "ref" | "id"
 >
 
-const FormFieldSkeletonHint: React.FC<FormFieldSkeletonHintProps> = ({
+export const FormFieldSkeletonHint: React.FC<FormFieldSkeletonHintProps> = ({
   children,
   ...rest
 }) => {
@@ -100,7 +102,7 @@ export type FormFieldSkeletonErrorProps = Omit<
   "ref" | "id"
 > & { validationMode?: ErrorValidationMode }
 
-const FormFieldSkeletonError: React.FC<FormFieldSkeletonErrorProps> = ({
+export const FormFieldSkeletonError: React.FC<FormFieldSkeletonErrorProps> = ({
   children,
   validationMode,
   ...rest
@@ -122,6 +124,7 @@ export function FormFieldSkeleton(props: FormFieldSkeletonProps) {
   return <FormFieldSkeletonProvider {...props} />
 }
 
+// TODO remove these one all form skeletons have their static properties removed
 FormFieldSkeleton.displayName = `FormFieldSkeleton`
 FormFieldSkeleton.Label = FormFieldSkeletonLabel
 FormFieldSkeleton.Label.displayName = `FormFieldSkeleton.Label`
@@ -133,7 +136,7 @@ FormFieldSkeleton.useFormFieldSkeleton = useFormFieldSkeleton
 
 export default FormFieldSkeleton
 
-function useFormFieldSkeleton() {
+export function useFormFieldSkeleton() {
   return React.useContext(FormFieldSkeletonContext)
 }
 

--- a/src/components/form-skeletons/components/InputFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/InputFieldSkeleton.tsx
@@ -1,9 +1,20 @@
 import React from "react"
-import FormFieldSkeleton, { FormFieldSkeletonProps } from "./FormFieldSkeleton"
+import {
+  FormFieldSkeleton,
+  FormFieldSkeletonProps,
+  useFormFieldSkeleton,
+  FormFieldSkeletonLabel,
+  FormFieldSkeletonLabelProps,
+  FormFieldSkeletonHintProps,
+  FormFieldSkeletonHint,
+  FormFieldSkeletonErrorProps,
+  FormFieldSkeletonError,
+} from "./FormFieldSkeleton"
 import { getFinalAriaDescribedBy } from "../utils"
 import { OmitControlProps } from "../sharedTypes"
 
-function InputFieldSkeleton(props: FormFieldSkeletonProps) {
+export type InputFieldSkeletonProps = FormFieldSkeletonProps
+export function InputFieldSkeleton(props: InputFieldSkeletonProps) {
   return <FormFieldSkeleton {...props} />
 }
 
@@ -11,11 +22,11 @@ export type InputFieldSkeletonControlProps = OmitControlProps<
   JSX.IntrinsicElements["input"]
 >
 
-InputFieldSkeleton.Control = React.forwardRef<
+export const InputFieldSkeletonControl = React.forwardRef<
   HTMLInputElement,
   InputFieldSkeletonControlProps
->((props, ref) => {
-  const { id, hasError, meta } = FormFieldSkeleton.useFormFieldSkeleton()
+>(function InputFieldSkeletonControl(props, ref) {
+  const { id, hasError, meta } = useFormFieldSkeleton()
 
   return (
     <input
@@ -30,13 +41,18 @@ InputFieldSkeleton.Control = React.forwardRef<
     />
   )
 })
-InputFieldSkeleton.Control.displayName = `InputFieldSkeleton.Control`
 
-InputFieldSkeleton.Label = FormFieldSkeleton.Label
-InputFieldSkeleton.Label.displayName = `InputFieldSkeleton.Label`
-InputFieldSkeleton.Hint = FormFieldSkeleton.Hint
-InputFieldSkeleton.Hint.displayName = `InputFieldSkeleton.Hint`
-InputFieldSkeleton.Error = FormFieldSkeleton.Error
-InputFieldSkeleton.Error.displayName = `InputFieldSkeleton.Hint`
+export type InputFieldSkeletonLabelProps = FormFieldSkeletonLabelProps
+export function InputFieldSkeletonLabel(props: FormFieldSkeletonLabelProps) {
+  return <FormFieldSkeletonLabel {...props} />
+}
 
-export default InputFieldSkeleton
+export type InputFieldSkeletonHintProps = FormFieldSkeletonHintProps
+export function InputFieldSkeletonHint(props: FormFieldSkeletonHintProps) {
+  return <FormFieldSkeletonHint {...props} />
+}
+
+export type InputFieldSkeletonErrorProps = FormFieldSkeletonErrorProps
+export function InputFieldSkeletonError(props: FormFieldSkeletonErrorProps) {
+  return <FormFieldSkeletonError {...props} />
+}

--- a/src/components/form-skeletons/stories/form.stories.tsx
+++ b/src/components/form-skeletons/stories/form.stories.tsx
@@ -6,7 +6,13 @@ import { text } from "@storybook/addon-knobs"
 import { StoryUtils } from "../../../utils/storybook"
 import README from "../README.md"
 import { action } from "@storybook/addon-actions"
-import InputFieldSkeleton from "../components/InputFieldSkeleton"
+import {
+  InputFieldSkeleton,
+  InputFieldSkeletonLabel,
+  InputFieldSkeletonControl,
+  InputFieldSkeletonError,
+  InputFieldSkeletonHint,
+} from "../components/InputFieldSkeleton"
 import SingleCheckboxFieldSkeleton from "../components/SingleCheckboxFieldSkeleton"
 import TextAreaFieldSkeleton from "../components/TextAreaFieldSkeleton"
 import CheckboxGroupFieldSkeleton from "../components/CheckboxGroupFieldSkeleton"
@@ -53,12 +59,12 @@ storiesOf(`form-skeletons`, module)
             hasHint={!!hint}
           >
             <div>
-              <InputFieldSkeleton.Label>Input</InputFieldSkeleton.Label>
-              <InputFieldSkeleton.Control
+              <InputFieldSkeletonLabel>Input</InputFieldSkeletonLabel>
+              <InputFieldSkeletonControl
                 onChange={e => action(`Change`)(e.target.value)}
               />
-              <InputFieldSkeleton.Error>{error}</InputFieldSkeleton.Error>
-              <InputFieldSkeleton.Hint>{hint}</InputFieldSkeleton.Hint>
+              <InputFieldSkeletonError>{error}</InputFieldSkeletonError>
+              <InputFieldSkeletonHint>{hint}</InputFieldSkeletonHint>
             </div>
           </InputFieldSkeleton>
           <br />

--- a/src/components/form-skeletons/stories/storyUtils.ts
+++ b/src/components/form-skeletons/stories/storyUtils.ts
@@ -1,0 +1,20 @@
+export function getGroupFieldStoryOptions() {
+  return [
+    `Assire var Anahid`,
+    `Francesca Findabair`,
+    `Fringilla Vigo`,
+    `Ida Emean aep Sivney`,
+    `Keira Metz`,
+    `Margarita Laux-Antille`,
+    `Philippa Eilhart`,
+    `Sabrina Glevissig`,
+    `Sheala de Tancarville`,
+    `Triss Merigold`,
+    `Yennefer of Vengerberg`,
+  ].map(name => {
+    return {
+      label: name,
+      value: name.toLowerCase().replace(/\s/g, `-`),
+    }
+  })
+}

--- a/src/components/form/components/InputConnectedField.tsx
+++ b/src/components/form/components/InputConnectedField.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
 import { getIn, useFormikContext } from "formik"
-import InputFieldBlock from "./InputFieldBlock"
+import { InputFieldBlock } from "./InputFieldBlock"
 import Case from "case"
 import { InputFieldBlockProps } from "./InputFieldBlock"
 
@@ -11,7 +11,9 @@ export type InputConnectedFieldProps = {
   label?: React.ReactNode
 } & Omit<InputFieldBlockProps, "id" | "label">
 
-const InputConnectedField: React.FC<InputConnectedFieldProps> = props => {
+export const InputConnectedField: React.FC<
+  InputConnectedFieldProps
+> = props => {
   const id = `${props.name}Field`
   const label = Case.sentence(props.name)
   const {
@@ -37,5 +39,3 @@ const InputConnectedField: React.FC<InputConnectedFieldProps> = props => {
     />
   )
 }
-
-export default InputConnectedField

--- a/src/components/form/components/InputField.tsx
+++ b/src/components/form/components/InputField.tsx
@@ -2,59 +2,85 @@
 import { jsx } from "@emotion/core"
 import React from "react"
 
+import { useFormFieldSkeleton } from "../../form-skeletons/components/FormFieldSkeleton"
 import {
-  FormFieldSkeleton,
-  FormFieldSkeletonProps,
-} from "../../form-skeletons/components/FormFieldSkeleton"
-import { FormField, getFieldStackStyles } from "./FormField"
+  getFieldStackStyles,
+  FormFieldStack,
+  FormFieldLabelProps,
+  FormFieldStackProps,
+  useStyledFieldHint,
+  useStyledFieldError,
+  useStyledFieldLabel,
+} from "./FormField"
 import { getInputStyles } from "./FormField.helpers"
-import InputFieldSkeleton, {
+import {
+  InputFieldSkeleton,
   InputFieldSkeletonControlProps,
+  InputFieldSkeletonControl,
+  InputFieldSkeletonHintProps,
+  InputFieldSkeletonHint,
+  InputFieldSkeletonErrorProps,
+  InputFieldSkeletonError,
+  InputFieldSkeletonLabel,
+  InputFieldSkeletonProps,
 } from "../../form-skeletons/components/InputFieldSkeleton"
 import { Theme } from "../../../theme"
 
-function InputField(props: FormFieldSkeletonProps) {
+export function InputField(props: InputFieldSkeletonProps) {
   return <InputFieldSkeleton {...props}></InputFieldSkeleton>
 }
 
 export type InputFieldControlProps = Omit<InputFieldSkeletonControlProps, "ref">
 
-const Control = React.forwardRef<HTMLInputElement, InputFieldControlProps>(
-  (props, ref) => {
-    const { hasError } = FormFieldSkeleton.useFormFieldSkeleton()
+export const InputFieldControl = React.forwardRef<
+  HTMLInputElement,
+  InputFieldControlProps
+>(function InputFieldControl(props, ref) {
+  const { hasError } = useFormFieldSkeleton()
 
-    const placeholder =
-      props.placeholder && props.disabled
-        ? `The field is disabled`
-        : props.placeholder
+  const placeholder =
+    props.placeholder && props.disabled
+      ? `The field is disabled`
+      : props.placeholder
 
-    return (
-      <InputFieldSkeleton.Control
-        ref={ref}
-        css={(theme: Theme) => [
-          getFieldStackStyles(`item`, theme),
-          getInputStyles(theme, hasError),
-        ]}
-        {...props}
-        placeholder={placeholder}
-      />
-    )
-  }
-)
+  return (
+    <InputFieldSkeletonControl
+      ref={ref}
+      css={(theme: Theme) => [
+        getFieldStackStyles(`item`, theme),
+        getInputStyles(theme, hasError),
+      ]}
+      {...props}
+      placeholder={placeholder}
+    />
+  )
+})
 
-InputField.Control = Control
-InputField.Control.displayName = `InputField.Control`
+export type InputFieldWrapperProps = FormFieldStackProps
+export const InputFieldWrapper = FormFieldStack
 
-InputField.Wrapper = FormField.Stack
-InputField.Wrapper.displayName = `InputField.StackWrapper`
+export type InputFieldLabelProps = FormFieldLabelProps
+export function InputFieldLabel({
+  children,
+  size,
+  isRequired,
+  ...props
+}: InputFieldLabelProps) {
+  const styledProps = useStyledFieldLabel(children, { size, isRequired })
 
-InputField.Label = FormField.Label
-InputField.Label.displayName = `InputField.Label`
+  return <InputFieldSkeletonLabel {...props} {...styledProps} />
+}
 
-InputField.Hint = FormField.Hint
-InputField.Hint.displayName = `InputField.Hint`
+export type InputFieldErrorProps = InputFieldSkeletonErrorProps
+export function InputFieldError({ children, ...props }: InputFieldErrorProps) {
+  const styledProps = useStyledFieldError(children)
 
-InputField.Error = FormField.Error
-InputField.Error.displayName = `InputField.Hint`
+  return <InputFieldSkeletonError {...props} {...styledProps} />
+}
 
-export default InputField
+export type InputFieldHintProps = InputFieldSkeletonHintProps
+export function InputFieldHint(props: InputFieldHintProps) {
+  const styledProps = useStyledFieldHint()
+
+  return <InputFieldSkeletonHint {...props} {...styledProps} />
+}

--- a/src/components/form/components/InputFieldBlock.tsx
+++ b/src/components/form/components/InputFieldBlock.tsx
@@ -2,7 +2,15 @@
 import { jsx } from "@emotion/core"
 import React, { ReactNode } from "react"
 
-import InputField, { InputFieldControlProps } from "./InputField"
+import {
+  InputField,
+  InputFieldControlProps,
+  InputFieldWrapper,
+  InputFieldLabel,
+  InputFieldControl,
+  InputFieldHint,
+  InputFieldError,
+} from "./InputField"
 import { FormFieldLabelSize } from "./FormField.helpers"
 import { ErrorValidationMode } from "../../form-skeletons/components/FormFieldSkeleton"
 
@@ -15,7 +23,7 @@ export type InputFieldBlockProps = {
   validationMode?: ErrorValidationMode
 } & InputFieldControlProps
 
-const InputFieldBlock = React.forwardRef<
+export const InputFieldBlock = React.forwardRef<
   HTMLInputElement,
   InputFieldBlockProps
 >((props, ref) => {
@@ -32,18 +40,16 @@ const InputFieldBlock = React.forwardRef<
 
   return (
     <InputField id={id} hasError={!!error} hasHint={!!hint}>
-      <InputField.Wrapper className={className}>
-        <InputField.Label size={labelSize} isRequired={!!rest.required}>
+      <InputFieldWrapper className={className}>
+        <InputFieldLabel size={labelSize} isRequired={!!rest.required}>
           {label}
-        </InputField.Label>
-        <InputField.Control ref={ref} {...rest} />
-        <InputField.Hint>{hint}</InputField.Hint>
-        <InputField.Error validationMode={validationMode}>
+        </InputFieldLabel>
+        <InputFieldControl ref={ref} {...rest} />
+        <InputFieldHint>{hint}</InputFieldHint>
+        <InputFieldError validationMode={validationMode}>
           {error}
-        </InputField.Error>
-      </InputField.Wrapper>
+        </InputFieldError>
+      </InputFieldWrapper>
     </InputField>
   )
 })
-
-export default InputFieldBlock

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,8 +1,6 @@
-export { default as InputField } from "./components/InputField"
-export { default as InputFieldBlock } from "./components/InputFieldBlock"
-export {
-  default as InputConnectedField,
-} from "./components/InputConnectedField"
+export * from "./components/InputField"
+export * from "./components/InputFieldBlock"
+export * from "./components/InputConnectedField"
 
 export { default as TextAreaField } from "./components/TextAreaField"
 export { default as TextAreaFieldBlock } from "./components/TextAreaFieldBlock"

--- a/src/components/form/stories/form.FormField.stories.tsx
+++ b/src/components/form/stories/form.FormField.stories.tsx
@@ -6,7 +6,14 @@ import { text, radios } from "@storybook/addon-knobs"
 import { action } from "@storybook/addon-actions"
 import README from "../README_FORM_FIELD.md"
 import { StoryUtils } from "../../../utils/storybook"
-import InputField from "../components/InputField"
+import {
+  InputField,
+  InputFieldWrapper,
+  InputFieldLabel,
+  InputFieldControl,
+  InputFieldHint,
+  InputFieldError,
+} from "../components/InputField"
 import TextAreaField from "../components/TextAreaField"
 import SelectField from "../components/SelectField"
 import CheckboxField from "../components/CheckboxField"
@@ -75,14 +82,14 @@ storiesOf(`form/FormField`, module)
       <StoryUtils.Container>
         <Wrapper>
           <InputField id="example-1a" hasError={!!error} hasHint={!!hint}>
-            <InputField.Wrapper>
-              <InputField.Label size={size}>Title</InputField.Label>
-              <InputField.Control
+            <InputFieldWrapper>
+              <InputFieldLabel size={size}>Title</InputFieldLabel>
+              <InputFieldControl
                 onChange={e => action(`Change`)(e.target.value)}
               />
-              <InputField.Hint>{hint}</InputField.Hint>
-              <InputField.Error>{error}</InputField.Error>
-            </InputField.Wrapper>
+              <InputFieldHint>{hint}</InputFieldHint>
+              <InputFieldError>{error}</InputFieldError>
+            </InputFieldWrapper>
           </InputField>
 
           <TextAreaField id="example-1b" hasError={!!error} hasHint={!!hint}>
@@ -183,24 +190,24 @@ storiesOf(`form/FormField`, module)
       <StoryUtils.Container>
         <Wrapper>
           <InputField id="example-2a" hasError={false} hasHint={false}>
-            <InputField.Wrapper>
-              <InputField.Label size="L">Label size L</InputField.Label>
-              <InputField.Control />
-            </InputField.Wrapper>
+            <InputFieldWrapper>
+              <InputFieldLabel size="L">Label size L</InputFieldLabel>
+              <InputFieldControl />
+            </InputFieldWrapper>
           </InputField>
           <InputField id="example-2b" hasError={false} hasHint={false}>
-            <InputField.Wrapper>
-              <InputField.Label size="M">
+            <InputFieldWrapper>
+              <InputFieldLabel size="M">
                 Label size M (default value)
-              </InputField.Label>
-              <InputField.Control />
-            </InputField.Wrapper>
+              </InputFieldLabel>
+              <InputFieldControl />
+            </InputFieldWrapper>
           </InputField>
           <InputField id="example-2" hasError={false} hasHint={false}>
-            <InputField.Wrapper>
-              <InputField.Label size="S">Label size S</InputField.Label>
-              <InputField.Control />
-            </InputField.Wrapper>
+            <InputFieldWrapper>
+              <InputFieldLabel size="S">Label size S</InputFieldLabel>
+              <InputFieldControl />
+            </InputFieldWrapper>
           </InputField>
         </Wrapper>
       </StoryUtils.Container>
@@ -212,10 +219,10 @@ storiesOf(`form/FormField`, module)
       <StoryUtils.Container>
         <Wrapper>
           <InputField id="example-3a">
-            <InputField.Wrapper>
-              <InputField.Label isRequired={true}>First name</InputField.Label>
-              <InputField.Control required />
-            </InputField.Wrapper>
+            <InputFieldWrapper>
+              <InputFieldLabel isRequired={true}>First name</InputFieldLabel>
+              <InputFieldControl required />
+            </InputFieldWrapper>
           </InputField>
 
           <TextAreaField id="example-3b">
@@ -247,12 +254,12 @@ storiesOf(`form/FormField`, module)
           </RadioButtonField>
 
           <InputField id="example-3d">
-            <InputField.Wrapper>
-              <InputField.Label isRequired={true}>
+            <InputFieldWrapper>
+              <InputFieldLabel isRequired={true}>
                 Give us your <strong>name</strong>
-              </InputField.Label>
-              <InputField.Control required />
-            </InputField.Wrapper>
+              </InputFieldLabel>
+              <InputFieldControl required />
+            </InputFieldWrapper>
           </InputField>
         </Wrapper>
       </StoryUtils.Container>
@@ -264,62 +271,62 @@ storiesOf(`form/FormField`, module)
       <StoryUtils.Container>
         <Wrapper>
           <InputField id="example-4a" hasError={true}>
-            <InputField.Wrapper>
-              <InputField.Label>First name</InputField.Label>
-              <InputField.Control />
-              <InputField.Hint></InputField.Hint>
-              <InputField.Error>Short error message.</InputField.Error>
-            </InputField.Wrapper>
+            <InputFieldWrapper>
+              <InputFieldLabel>First name</InputFieldLabel>
+              <InputFieldControl />
+              <InputFieldHint></InputFieldHint>
+              <InputFieldError>Short error message.</InputFieldError>
+            </InputFieldWrapper>
           </InputField>
 
           <InputField id="example-4b" hasError={true}>
-            <InputField.Wrapper>
-              <InputField.Label>First name</InputField.Label>
-              <InputField.Control />
-              <InputField.Hint></InputField.Hint>
-              <InputField.Error>
+            <InputFieldWrapper>
+              <InputFieldLabel>First name</InputFieldLabel>
+              <InputFieldControl />
+              <InputFieldHint></InputFieldHint>
+              <InputFieldError>
                 Long error message ... ut enim ad minim veniam, quis nostrud
                 exercitation ullamco laboris nisi ut aliquip ex ea commodo
                 consequat.
-              </InputField.Error>
-            </InputField.Wrapper>
+              </InputFieldError>
+            </InputFieldWrapper>
           </InputField>
 
           <InputField id="example-4c" hasHint={true}>
-            <InputField.Wrapper>
-              <InputField.Label>First name</InputField.Label>
-              <InputField.Control />
-              <InputField.Hint>Short hint.</InputField.Hint>
-              <InputField.Error></InputField.Error>
-            </InputField.Wrapper>
+            <InputFieldWrapper>
+              <InputFieldLabel>First name</InputFieldLabel>
+              <InputFieldControl />
+              <InputFieldHint>Short hint.</InputFieldHint>
+              <InputFieldError></InputFieldError>
+            </InputFieldWrapper>
           </InputField>
 
           <InputField id="example-4d" hasHint={true}>
-            <InputField.Wrapper>
-              <InputField.Label>First name</InputField.Label>
-              <InputField.Control />
-              <InputField.Hint>
+            <InputFieldWrapper>
+              <InputFieldLabel>First name</InputFieldLabel>
+              <InputFieldControl />
+              <InputFieldHint>
                 Long hint ... excepteur sint occaecat cupidatat non proident,
                 sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </InputField.Hint>
-              <InputField.Error></InputField.Error>
-            </InputField.Wrapper>
+              </InputFieldHint>
+              <InputFieldError></InputFieldError>
+            </InputFieldWrapper>
           </InputField>
 
           <InputField id="example-4e" hasHint={true} hasError={true}>
-            <InputField.Wrapper>
-              <InputField.Label>First name</InputField.Label>
-              <InputField.Control />
-              <InputField.Hint>
+            <InputFieldWrapper>
+              <InputFieldLabel>First name</InputFieldLabel>
+              <InputFieldControl />
+              <InputFieldHint>
                 Long hint ... excepteur sint occaecat cupidatat non proident,
                 sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </InputField.Hint>
-              <InputField.Error>
+              </InputFieldHint>
+              <InputFieldError>
                 Long error message ... ut enim ad minim veniam, quis nostrud
                 exercitation ullamco laboris nisi ut aliquip ex ea commodo
                 consequat.
-              </InputField.Error>
-            </InputField.Wrapper>
+              </InputFieldError>
+            </InputFieldWrapper>
           </InputField>
         </Wrapper>
       </StoryUtils.Container>

--- a/src/components/form/stories/form.InputField.stories.tsx
+++ b/src/components/form/stories/form.InputField.stories.tsx
@@ -8,8 +8,15 @@ import { text, radios, boolean } from "@storybook/addon-knobs"
 import { StoryUtils } from "../../../utils/storybook"
 import README from "../README_INPUT_FIELD.md"
 import { action } from "@storybook/addon-actions"
-import InputField from "../components/InputField"
-import InputFieldBlock from "../components/InputFieldBlock"
+import {
+  InputField,
+  InputFieldWrapper,
+  InputFieldLabel,
+  InputFieldControl,
+  InputFieldHint,
+  InputFieldError,
+} from "../components/InputField"
+import { InputFieldBlock } from "../components/InputFieldBlock"
 import { FormFieldLabelSize } from "../components/FormField.helpers"
 import { enumToOptions } from "../../../utils/helpers"
 import { Wrapper } from "./stories.utils"
@@ -43,23 +50,23 @@ storiesOf(`form`, module)
       <StoryUtils.Container>
         <Wrapper>
           <InputField id="example-1a" hasError={!!error} hasHint={true}>
-            <InputField.Wrapper>
-              <InputField.Label size={size} isRequired={required}>
+            <InputFieldWrapper>
+              <InputFieldLabel size={size} isRequired={required}>
                 First name
-              </InputField.Label>
-              <InputField.Control
+              </InputFieldLabel>
+              <InputFieldControl
                 onChange={e => action(`Change`)(e.target.value)}
                 placeholder={placeholder}
                 disabled={disabled}
                 required={required}
               />
-              <InputField.Hint>
+              <InputFieldHint>
                 {hint
                   ? hint
                   : ` This field is built with 'InputField' and subcomponents placed  explicitly as its children`}
-              </InputField.Hint>
-              <InputField.Error>{error}</InputField.Error>
-            </InputField.Wrapper>
+              </InputFieldHint>
+              <InputFieldError>{error}</InputFieldError>
+            </InputFieldWrapper>
           </InputField>
 
           <InputFieldBlock

--- a/src/components/form/stories/form.WithFormik.stories.tsx
+++ b/src/components/form/stories/form.WithFormik.stories.tsx
@@ -5,10 +5,17 @@ import React from "react"
 import { storiesOf } from "@storybook/react"
 import README from "../README_FORMIK.md"
 import { StoryUtils } from "../../../utils/storybook"
-import InputField from "../components/InputField"
+import {
+  InputField,
+  InputFieldWrapper,
+  InputFieldControl,
+  InputFieldLabel,
+  InputFieldError,
+  InputFieldHint,
+} from "../components/InputField"
 import TextAreaField from "../components/TextAreaField"
-import InputFieldBlock from "../components/InputFieldBlock"
-import InputConnectedField from "../components/InputConnectedField"
+import { InputFieldBlock } from "../components/InputFieldBlock"
+import { InputConnectedField } from "../components/InputConnectedField"
 import TextAreaFieldBlock from "../components/TextAreaFieldBlock"
 import TextAreaConnectedField from "../components/TextAreaConnectedField"
 import SelectField from "../components/SelectField"
@@ -204,25 +211,23 @@ storiesOf(`form/Formik usage examples`, module)
                     hasError={!!(touched.title && errors.title)}
                     hasHint={true}
                   >
-                    <InputField.Wrapper css={stackItemCss}>
-                      <InputField.Label isRequired={true}>
-                        Title
-                      </InputField.Label>
-                      <InputField.Control
+                    <InputFieldWrapper css={stackItemCss}>
+                      <InputFieldLabel isRequired={true}>Title</InputFieldLabel>
+                      <InputFieldControl
                         name="title"
                         value={values.title}
                         onChange={handleChange}
                         onBlur={handleBlur}
                         required
                       />
-                      <InputField.Hint>
+                      <InputFieldHint>
                         At least {TITLE_MIN_LENGTH} and not more than{" "}
                         {TITLE_MAX_LENGTH} characters
-                      </InputField.Hint>
-                      <InputField.Error>
+                      </InputFieldHint>
+                      <InputFieldError>
                         {touched.title && errors.title ? errors.title : ``}
-                      </InputField.Error>
-                    </InputField.Wrapper>
+                      </InputFieldError>
+                    </InputFieldWrapper>
                   </InputField>
 
                   <TextAreaField


### PR DESCRIPTION
This PR is the first in a series of changes needed to get rid of static properties from our components to enable Webpack tree shaking. It only covers `InputFieldSkeleton`, `InputField` and `InputFieldBlock` components, as well as makes some updates in `FormFieldSkeleton` and `FormField` which are necessary for this work.

The changes can be generally described as follows:
* `FormFieldSkeleton` now exports its compound parts in addition to specifying them as static properties:
  ```javascript
  export const FormFieldSkeletonLabel = props => {
    /* ... */
  }
  FormFieldSkeleton.Label = FormFieldSkeletonLabel
  ```
  This is done to avoid rewriting ALL of form skeletons and fields; we'll omit static properties once all of skeleton components rely on named exports. 
* `FormField` is changed in a similar fashion to `FormFieldSkeleton`, plus I've added some hooks for styling field errors, labels and hints so that we can use components from respective skeletons instead of generic ones from `FormFieldSkeleton`
* `InputField` now has no static properties; its compound components are exposed as named exports, for example `InputFieldControl` instead of `InputField.Control`
* Because of dropping static properties, it doesn't make much sense to use default exports, so compound components are using named exports instead (similar to ReachUI)

I also have to warn that we these changes won't enable proper tree shaking by themselves, since some of form components rely on `React.forwardRef`, which also cannot be tree-shaken 🤦‍♂ I am working on a babel plugin to fix this issue, it should be ready relatively soon.
