### PR TITLE
fix: remove static properties from TextArea form fields

### DIFF
--- a/src/components/form-skeletons/components/InputFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/InputFieldSkeleton.tsx
@@ -43,16 +43,16 @@ export const InputFieldSkeletonControl = React.forwardRef<
 })
 
 export type InputFieldSkeletonLabelProps = FormFieldSkeletonLabelProps
-export function InputFieldSkeletonLabel(props: FormFieldSkeletonLabelProps) {
+export function InputFieldSkeletonLabel(props: InputFieldSkeletonLabelProps) {
   return <FormFieldSkeletonLabel {...props} />
 }
 
 export type InputFieldSkeletonHintProps = FormFieldSkeletonHintProps
-export function InputFieldSkeletonHint(props: FormFieldSkeletonHintProps) {
+export function InputFieldSkeletonHint(props: InputFieldSkeletonHintProps) {
   return <FormFieldSkeletonHint {...props} />
 }
 
 export type InputFieldSkeletonErrorProps = FormFieldSkeletonErrorProps
-export function InputFieldSkeletonError(props: FormFieldSkeletonErrorProps) {
+export function InputFieldSkeletonError(props: InputFieldSkeletonErrorProps) {
   return <FormFieldSkeletonError {...props} />
 }

--- a/src/components/form-skeletons/components/TextAreaFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/TextAreaFieldSkeleton.tsx
@@ -1,9 +1,19 @@
 import React from "react"
-import FormFieldSkeleton, { FormFieldSkeletonProps } from "./FormFieldSkeleton"
+import FormFieldSkeleton, {
+  FormFieldSkeletonProps,
+  useFormFieldSkeleton,
+  FormFieldSkeletonLabelProps,
+  FormFieldSkeletonLabel,
+  FormFieldSkeletonHintProps,
+  FormFieldSkeletonHint,
+  FormFieldSkeletonErrorProps,
+  FormFieldSkeletonError,
+} from "./FormFieldSkeleton"
 import { getFinalAriaDescribedBy } from "../utils"
 import { OmitControlProps } from "../sharedTypes"
 
-function TextAreaFieldSkeleton(props: FormFieldSkeletonProps) {
+export type TextAreaFieldSkeletonProps = FormFieldSkeletonProps
+export function TextAreaFieldSkeleton(props: TextAreaFieldSkeletonProps) {
   return <FormFieldSkeleton {...props} />
 }
 
@@ -11,11 +21,11 @@ export type TextAreaFieldSkeletonControlProps = OmitControlProps<
   JSX.IntrinsicElements["textarea"]
 >
 
-TextAreaFieldSkeleton.Control = React.forwardRef<
+export const TextAreaFieldSkeletonControl = React.forwardRef<
   HTMLTextAreaElement,
   TextAreaFieldSkeletonControlProps
->((props, ref) => {
-  const { id, hasError, meta } = FormFieldSkeleton.useFormFieldSkeleton()
+>(function TextAreaFieldSkeletonControl(props, ref) {
+  const { id, hasError, meta } = useFormFieldSkeleton()
 
   return (
     <textarea
@@ -30,13 +40,24 @@ TextAreaFieldSkeleton.Control = React.forwardRef<
     />
   )
 })
-TextAreaFieldSkeleton.Control.displayName = `TextAreaFieldSkeleton.Control`
 
-TextAreaFieldSkeleton.Label = FormFieldSkeleton.Label
-TextAreaFieldSkeleton.Label.displayName = `TextAreaFieldSkeleton.Label`
-TextAreaFieldSkeleton.Hint = FormFieldSkeleton.Hint
-TextAreaFieldSkeleton.Hint.displayName = `TextAreaFieldSkeleton.Hint`
-TextAreaFieldSkeleton.Error = FormFieldSkeleton.Error
-TextAreaFieldSkeleton.Error.displayName = `TextAreaFieldSkeleton.Hint`
+export type TextAreaFieldSkeletonLabelProps = FormFieldSkeletonLabelProps
+export function TextAreaFieldSkeletonLabel(
+  props: TextAreaFieldSkeletonLabelProps
+) {
+  return <FormFieldSkeletonLabel {...props} />
+}
 
-export default TextAreaFieldSkeleton
+export type TextAreaFieldSkeletonHintProps = FormFieldSkeletonHintProps
+export function TextAreaFieldSkeletonHint(
+  props: TextAreaFieldSkeletonHintProps
+) {
+  return <FormFieldSkeletonHint {...props} />
+}
+
+export type TextAreaFieldSkeletonErrorProps = FormFieldSkeletonErrorProps
+export function TextAreaFieldSkeletonError(
+  props: TextAreaFieldSkeletonErrorProps
+) {
+  return <FormFieldSkeletonError {...props} />
+}

--- a/src/components/form-skeletons/stories/form.stories.tsx
+++ b/src/components/form-skeletons/stories/form.stories.tsx
@@ -14,7 +14,13 @@ import {
   InputFieldSkeletonHint,
 } from "../components/InputFieldSkeleton"
 import SingleCheckboxFieldSkeleton from "../components/SingleCheckboxFieldSkeleton"
-import TextAreaFieldSkeleton from "../components/TextAreaFieldSkeleton"
+import {
+  TextAreaFieldSkeleton,
+  TextAreaFieldSkeletonLabel,
+  TextAreaFieldSkeletonControl,
+  TextAreaFieldSkeletonError,
+  TextAreaFieldSkeletonHint,
+} from "../components/TextAreaFieldSkeleton"
 import CheckboxGroupFieldSkeleton from "../components/CheckboxGroupFieldSkeleton"
 import RadioButtonFieldSkeleton from "../components/RadioButtonFieldSkeleton"
 import SelectFieldSkeleton from "../components/SelectFieldSkeleton"
@@ -74,14 +80,12 @@ storiesOf(`form-skeletons`, module)
             hasHint={!!hint}
           >
             <div>
-              <TextAreaFieldSkeleton.Label>
-                Text Area
-              </TextAreaFieldSkeleton.Label>
-              <TextAreaFieldSkeleton.Control
+              <TextAreaFieldSkeletonLabel>Text Area</TextAreaFieldSkeletonLabel>
+              <TextAreaFieldSkeletonControl
                 onChange={e => action(`Change`)(e.target.value)}
               />
-              <TextAreaFieldSkeleton.Error>{error}</TextAreaFieldSkeleton.Error>
-              <TextAreaFieldSkeleton.Hint>{hint}</TextAreaFieldSkeleton.Hint>
+              <TextAreaFieldSkeletonError>{error}</TextAreaFieldSkeletonError>
+              <TextAreaFieldSkeletonHint>{hint}</TextAreaFieldSkeletonHint>
             </div>
           </TextAreaFieldSkeleton>
           <br />

--- a/src/components/form/components/InputField.tsx
+++ b/src/components/form/components/InputField.tsx
@@ -26,7 +26,8 @@ import {
 } from "../../form-skeletons/components/InputFieldSkeleton"
 import { Theme } from "../../../theme"
 
-export function InputField(props: InputFieldSkeletonProps) {
+export type InputFieldProps = InputFieldSkeletonProps
+export function InputField(props: InputFieldProps) {
   return <InputFieldSkeleton {...props}></InputFieldSkeleton>
 }
 

--- a/src/components/form/components/TextAreaConnectedField.tsx
+++ b/src/components/form/components/TextAreaConnectedField.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
 import { getIn, useFormikContext } from "formik"
-import TextAreaFieldBlock from "./TextAreaFieldBlock"
+import { TextAreaFieldBlock } from "./TextAreaFieldBlock"
 import Case from "case"
 import { TextAreaFieldBlockProps } from "./TextAreaFieldBlock"
 
@@ -11,7 +11,9 @@ export type TextAreaConnectedFieldProps = {
   label?: React.ReactNode
 } & Omit<TextAreaFieldBlockProps, "id" | "label">
 
-const TextAreaConnectedField: React.FC<TextAreaConnectedFieldProps> = props => {
+export const TextAreaConnectedField: React.FC<
+  TextAreaConnectedFieldProps
+> = props => {
   const id = `${props.name}Field`
   const label = Case.sentence(props.name)
   const {
@@ -37,5 +39,3 @@ const TextAreaConnectedField: React.FC<TextAreaConnectedFieldProps> = props => {
     />
   )
 }
-
-export default TextAreaConnectedField

--- a/src/components/form/components/TextAreaField.tsx
+++ b/src/components/form/components/TextAreaField.tsx
@@ -3,17 +3,33 @@ import { jsx } from "@emotion/core"
 import React from "react"
 
 import {
-  FormFieldSkeleton,
   FormFieldSkeletonProps,
+  useFormFieldSkeleton,
 } from "../../form-skeletons/components/FormFieldSkeleton"
-import { FormField, getFieldStackStyles } from "./FormField"
+import {
+  getFieldStackStyles,
+  FormFieldStack,
+  FormFieldStackProps,
+  FormFieldLabelProps,
+  useStyledFieldLabel,
+  useStyledFieldError,
+  useStyledFieldHint,
+} from "./FormField"
 import { getInputStyles } from "./FormField.helpers"
-import TextAreaFieldSkeleton, {
+import {
+  TextAreaFieldSkeleton,
   TextAreaFieldSkeletonControlProps,
+  TextAreaFieldSkeletonControl,
+  TextAreaFieldSkeletonLabel,
+  TextAreaFieldSkeletonErrorProps,
+  TextAreaFieldSkeletonError,
+  TextAreaFieldSkeletonHintProps,
+  TextAreaFieldSkeletonHint,
 } from "../../form-skeletons/components/TextAreaFieldSkeleton"
 import { Theme } from "../../../theme"
 
-function TextAreaField(props: FormFieldSkeletonProps) {
+export type TextAreaFieldProps = FormFieldSkeletonProps
+export function TextAreaField(props: FormFieldSkeletonProps) {
   return <TextAreaFieldSkeleton {...props}></TextAreaFieldSkeleton>
 }
 
@@ -22,11 +38,11 @@ export type TextAreaFieldControlProps = Omit<
   "ref"
 >
 
-const Control = React.forwardRef<
+export const TextAreaFieldControl = React.forwardRef<
   HTMLTextAreaElement,
   TextAreaFieldControlProps
->((props, ref) => {
-  const { hasError } = FormFieldSkeleton.useFormFieldSkeleton()
+>(function TextAreaFieldControl(props, ref) {
+  const { hasError } = useFormFieldSkeleton()
 
   const placeholder =
     props.placeholder && props.disabled
@@ -34,7 +50,7 @@ const Control = React.forwardRef<
       : props.placeholder
 
   return (
-    <TextAreaFieldSkeleton.Control
+    <TextAreaFieldSkeletonControl
       ref={ref}
       css={(theme: Theme) => [
         getInputStyles(theme, hasError),
@@ -52,19 +68,34 @@ const Control = React.forwardRef<
   )
 })
 
-TextAreaField.Control = Control
-TextAreaField.Control.displayName = `TextAreaField.Control`
+export type TextAreaFieldWrapperProps = FormFieldStackProps
+export const TextAreaFieldWrapper = FormFieldStack
 
-TextAreaField.Wrapper = FormField.Stack
-TextAreaField.Wrapper.displayName = `TextAreaField.StackWrapper`
+export type TextAreaFieldLabelProps = FormFieldLabelProps
+export function TextAreaFieldLabel({
+  children,
+  size,
+  isRequired,
+  ...props
+}: TextAreaFieldLabelProps) {
+  const styledProps = useStyledFieldLabel(children, { size, isRequired })
 
-TextAreaField.Label = FormField.Label
-TextAreaField.Label.displayName = `TextAreaField.Label`
+  return <TextAreaFieldSkeletonLabel {...props} {...styledProps} />
+}
 
-TextAreaField.Hint = FormField.Hint
-TextAreaField.Hint.displayName = `TextAreaField.Hint`
+export type TextAreaFieldErrorProps = TextAreaFieldSkeletonErrorProps
+export function TextAreaFieldError({
+  children,
+  ...props
+}: TextAreaFieldErrorProps) {
+  const styledProps = useStyledFieldError(children)
 
-TextAreaField.Error = FormField.Error
-TextAreaField.Error.displayName = `TextAreaField.Hint`
+  return <TextAreaFieldSkeletonError {...props} {...styledProps} />
+}
 
-export default TextAreaField
+export type TextAreaFieldHintProps = TextAreaFieldSkeletonHintProps
+export function TextAreaFieldHint(props: TextAreaFieldHintProps) {
+  const styledProps = useStyledFieldHint()
+
+  return <TextAreaFieldSkeletonHint {...props} {...styledProps} />
+}

--- a/src/components/form/components/TextAreaFieldBlock.tsx
+++ b/src/components/form/components/TextAreaFieldBlock.tsx
@@ -2,7 +2,15 @@
 import { jsx } from "@emotion/core"
 import React, { ReactNode } from "react"
 
-import TextAreaField, { TextAreaFieldControlProps } from "./TextAreaField"
+import {
+  TextAreaField,
+  TextAreaFieldControlProps,
+  TextAreaFieldWrapper,
+  TextAreaFieldLabel,
+  TextAreaFieldControl,
+  TextAreaFieldHint,
+  TextAreaFieldError,
+} from "./TextAreaField"
 import { FormFieldLabelSize } from "./FormField.helpers"
 import { ErrorValidationMode } from "../../form-skeletons/components/FormFieldSkeleton"
 
@@ -15,10 +23,10 @@ export type TextAreaFieldBlockProps = {
   validationMode?: ErrorValidationMode
 } & TextAreaFieldControlProps
 
-const TextAreaFieldBlock = React.forwardRef<
+export const TextAreaFieldBlock = React.forwardRef<
   HTMLTextAreaElement,
   TextAreaFieldBlockProps
->((props, ref) => {
+>(function TextAreaFieldBlock(props, ref) {
   const {
     id,
     label,
@@ -32,18 +40,16 @@ const TextAreaFieldBlock = React.forwardRef<
 
   return (
     <TextAreaField id={id} hasError={!!error} hasHint={!!hint}>
-      <TextAreaField.Wrapper className={className}>
-        <TextAreaField.Label size={labelSize} isRequired={!!rest.required}>
+      <TextAreaFieldWrapper className={className}>
+        <TextAreaFieldLabel size={labelSize} isRequired={!!rest.required}>
           {label}
-        </TextAreaField.Label>
-        <TextAreaField.Control ref={ref} {...rest} />
-        <TextAreaField.Hint>{hint}</TextAreaField.Hint>
-        <TextAreaField.Error validationMode={validationMode}>
+        </TextAreaFieldLabel>
+        <TextAreaFieldControl ref={ref} {...rest} />
+        <TextAreaFieldHint>{hint}</TextAreaFieldHint>
+        <TextAreaFieldError validationMode={validationMode}>
           {error}
-        </TextAreaField.Error>
-      </TextAreaField.Wrapper>
+        </TextAreaFieldError>
+      </TextAreaFieldWrapper>
     </TextAreaField>
   )
 })
-
-export default TextAreaFieldBlock

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -2,11 +2,9 @@ export * from "./components/InputField"
 export * from "./components/InputFieldBlock"
 export * from "./components/InputConnectedField"
 
-export { default as TextAreaField } from "./components/TextAreaField"
-export { default as TextAreaFieldBlock } from "./components/TextAreaFieldBlock"
-export {
-  default as TextAreaConnectedField,
-} from "./components/TextAreaConnectedField"
+export * from "./components/TextAreaField"
+export * from "./components/TextAreaFieldBlock"
+export * from "./components/TextAreaConnectedField"
 
 export { default as SelectField } from "./components/SelectField"
 export { default as SelectFieldBlock } from "./components/SelectFieldBlock"

--- a/src/components/form/stories/form.FormField.stories.tsx
+++ b/src/components/form/stories/form.FormField.stories.tsx
@@ -14,7 +14,14 @@ import {
   InputFieldHint,
   InputFieldError,
 } from "../components/InputField"
-import TextAreaField from "../components/TextAreaField"
+import {
+  TextAreaField,
+  TextAreaFieldWrapper,
+  TextAreaFieldLabel,
+  TextAreaFieldControl,
+  TextAreaFieldHint,
+  TextAreaFieldError,
+} from "../components/TextAreaField"
 import SelectField from "../components/SelectField"
 import CheckboxField from "../components/CheckboxField"
 import CheckboxGroupField from "../components/CheckboxGroupField"
@@ -93,14 +100,14 @@ storiesOf(`form/FormField`, module)
           </InputField>
 
           <TextAreaField id="example-1b" hasError={!!error} hasHint={!!hint}>
-            <TextAreaField.Wrapper>
-              <TextAreaField.Label size={size}>Description</TextAreaField.Label>
-              <TextAreaField.Control
+            <TextAreaFieldWrapper>
+              <TextAreaFieldLabel size={size}>Description</TextAreaFieldLabel>
+              <TextAreaFieldControl
                 onChange={e => action(`Change`)(e.target.value)}
               />
-              <TextAreaField.Hint>{hint}</TextAreaField.Hint>
-              <TextAreaField.Error>{error}</TextAreaField.Error>
-            </TextAreaField.Wrapper>
+              <TextAreaFieldHint>{hint}</TextAreaFieldHint>
+              <TextAreaFieldError>{error}</TextAreaFieldError>
+            </TextAreaFieldWrapper>
           </TextAreaField>
 
           <SelectField id="example-1c" hasError={!!error} hasHint={!!hint}>
@@ -226,12 +233,12 @@ storiesOf(`form/FormField`, module)
           </InputField>
 
           <TextAreaField id="example-3b">
-            <TextAreaField.Wrapper>
-              <TextAreaField.Label isRequired={true}>
+            <TextAreaFieldWrapper>
+              <TextAreaFieldLabel isRequired={true}>
                 Description
-              </TextAreaField.Label>
-              <TextAreaField.Control required />
-            </TextAreaField.Wrapper>
+              </TextAreaFieldLabel>
+              <TextAreaFieldControl required />
+            </TextAreaFieldWrapper>
           </TextAreaField>
 
           <RadioButtonField id="example-3c">

--- a/src/components/form/stories/form.TextareaField.stories.tsx
+++ b/src/components/form/stories/form.TextareaField.stories.tsx
@@ -7,8 +7,15 @@ import { text, radios, boolean } from "@storybook/addon-knobs"
 import { StoryUtils } from "../../../utils/storybook"
 import README from "../README_TEXTAREA_FIELD.md"
 import { action } from "@storybook/addon-actions"
-import TextAreaField from "../components/TextAreaField"
-import TextAreaFieldBlock from "../components/TextAreaFieldBlock"
+import {
+  TextAreaField,
+  TextAreaFieldWrapper,
+  TextAreaFieldLabel,
+  TextAreaFieldControl,
+  TextAreaFieldHint,
+  TextAreaFieldError,
+} from "../components/TextAreaField"
+import { TextAreaFieldBlock } from "../components/TextAreaFieldBlock"
 import { FormFieldLabelSize } from "../components/FormField.helpers"
 import { enumToOptions } from "../../../utils/helpers"
 import colors from "../../../theme/colors"
@@ -42,23 +49,23 @@ storiesOf(`form`, module)
       <StoryUtils.Container>
         <Wrapper>
           <TextAreaField id="example-1a" hasError={!!error} hasHint={true}>
-            <TextAreaField.Wrapper>
-              <TextAreaField.Label size={size} isRequired={required}>
+            <TextAreaFieldWrapper>
+              <TextAreaFieldLabel size={size} isRequired={required}>
                 Comment
-              </TextAreaField.Label>
-              <TextAreaField.Control
+              </TextAreaFieldLabel>
+              <TextAreaFieldControl
                 onChange={e => action(`Change`)(e.target.value)}
                 placeholder={placeholder}
                 disabled={disabled}
                 required={required}
               />
-              <TextAreaField.Hint>
+              <TextAreaFieldHint>
                 {hint
                   ? hint
                   : `This field is built with 'TextAreaField' and subcomponents placed explicitly as its children`}
-              </TextAreaField.Hint>
-              <TextAreaField.Error>{error}</TextAreaField.Error>
-            </TextAreaField.Wrapper>
+              </TextAreaFieldHint>
+              <TextAreaFieldError>{error}</TextAreaFieldError>
+            </TextAreaFieldWrapper>
           </TextAreaField>
 
           <TextAreaFieldBlock

--- a/src/components/form/stories/form.WithFormik.stories.tsx
+++ b/src/components/form/stories/form.WithFormik.stories.tsx
@@ -13,11 +13,18 @@ import {
   InputFieldError,
   InputFieldHint,
 } from "../components/InputField"
-import TextAreaField from "../components/TextAreaField"
+import {
+  TextAreaField,
+  TextAreaFieldWrapper,
+  TextAreaFieldLabel,
+  TextAreaFieldControl,
+  TextAreaFieldHint,
+  TextAreaFieldError,
+} from "../components/TextAreaField"
 import { InputFieldBlock } from "../components/InputFieldBlock"
 import { InputConnectedField } from "../components/InputConnectedField"
-import TextAreaFieldBlock from "../components/TextAreaFieldBlock"
-import TextAreaConnectedField from "../components/TextAreaConnectedField"
+import { TextAreaFieldBlock } from "../components/TextAreaFieldBlock"
+import { TextAreaConnectedField } from "../components/TextAreaConnectedField"
 import SelectField from "../components/SelectField"
 import SelectFieldBlock from "../components/SelectFieldBlock"
 import SelectConnectedField from "../components/SelectConnectedField"
@@ -235,21 +242,21 @@ storiesOf(`form/Formik usage examples`, module)
                     hasError={!!(touched.description && errors.description)}
                     hasHint={true}
                   >
-                    <TextAreaField.Wrapper css={stackItemCss}>
-                      <TextAreaField.Label>Description</TextAreaField.Label>
-                      <TextAreaField.Control
+                    <TextAreaFieldWrapper css={stackItemCss}>
+                      <TextAreaFieldLabel>Description</TextAreaFieldLabel>
+                      <TextAreaFieldControl
                         name="description"
                         onChange={handleChange}
                         onBlur={handleBlur}
                         value={values.description}
                       />
-                      <TextAreaField.Hint>{`Be concise, the field can't be longer than ${DESCRIPTION_MAX_LENGTH} characters`}</TextAreaField.Hint>
-                      <TextAreaField.Error>
+                      <TextAreaFieldHint>{`Be concise, the field can't be longer than ${DESCRIPTION_MAX_LENGTH} characters`}</TextAreaFieldHint>
+                      <TextAreaFieldError>
                         {touched.description && errors.description
                           ? errors.description
                           : ``}
-                      </TextAreaField.Error>
-                    </TextAreaField.Wrapper>
+                      </TextAreaFieldError>
+                    </TextAreaFieldWrapper>
                   </TextAreaField>
 
                   <SelectField


### PR DESCRIPTION
In continuation of #213, here's a PR to replace static properties with named exports for `TextAreaField` and `TextAreaFieldSkeleton`.

It also fixes some minor type mismatches in `InputFieldSkeleton`.