### PR TITLE
fix: remove static properties from Select form fields

### DIFF
--- a/src/components/form-skeletons/components/SelectFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/SelectFieldSkeleton.tsx
@@ -1,28 +1,38 @@
 import React from "react"
-import FormFieldSkeleton, { FormFieldSkeletonProps } from "./FormFieldSkeleton"
+import FormFieldSkeleton, {
+  FormFieldSkeletonProps,
+  useFormFieldSkeleton,
+  FormFieldSkeletonLabelProps,
+  FormFieldSkeletonLabel,
+  FormFieldSkeletonHintProps,
+  FormFieldSkeletonHint,
+  FormFieldSkeletonErrorProps,
+  FormFieldSkeletonError,
+} from "./FormFieldSkeleton"
 import { getFinalAriaDescribedBy } from "../utils"
 import { OmitControlProps } from "../sharedTypes"
 
-function SelectFieldSkeleton(props: FormFieldSkeletonProps) {
+export type SelectFieldSkeletonProps = FormFieldSkeletonProps
+export function SelectFieldSkeleton(props: FormFieldSkeletonProps) {
   return <FormFieldSkeleton {...props} />
 }
 
 export type SelectFieldSkeletonControlOption = {
-  value: string;
-  label: string;
+  value: string
+  label: string
 }
 
 export type SelectFieldSkeletonControlProps = OmitControlProps<
   JSX.IntrinsicElements["select"]
 > & {
-  options: SelectFieldSkeletonControlOption[];
+  options: SelectFieldSkeletonControlOption[]
 }
 
-SelectFieldSkeleton.Control = React.forwardRef<
+export const SelectFieldSkeletonControl = React.forwardRef<
   HTMLSelectElement,
   SelectFieldSkeletonControlProps
->(({ options, ...rest }, ref) => {
-  const { id, hasError, meta } = FormFieldSkeleton.useFormFieldSkeleton()
+>(function SelectFieldSkeletonControl({ options, ...rest }, ref) {
+  const { id, hasError, meta } = useFormFieldSkeleton()
 
   return (
     <select
@@ -39,16 +49,6 @@ SelectFieldSkeleton.Control = React.forwardRef<
     </select>
   )
 })
-SelectFieldSkeleton.Control.displayName = `SelectFieldSkeleton.Control`
-
-SelectFieldSkeleton.Label = FormFieldSkeleton.Label
-SelectFieldSkeleton.Label.displayName = `SelectFieldSkeleton.Label`
-SelectFieldSkeleton.Hint = FormFieldSkeleton.Hint
-SelectFieldSkeleton.Hint.displayName = `SelectFieldSkeleton.Hint`
-SelectFieldSkeleton.Error = FormFieldSkeleton.Error
-SelectFieldSkeleton.Error.displayName = `SelectFieldSkeleton.Hint`
-
-export default SelectFieldSkeleton
 
 function renderOption({ label, value }: SelectFieldSkeletonControlOption) {
   return (
@@ -56,4 +56,19 @@ function renderOption({ label, value }: SelectFieldSkeletonControlOption) {
       {label}
     </option>
   )
+}
+
+export type SelectFieldSkeletonLabelProps = FormFieldSkeletonLabelProps
+export function SelectFieldSkeletonLabel(props: SelectFieldSkeletonLabelProps) {
+  return <FormFieldSkeletonLabel {...props} />
+}
+
+export type SelectFieldSkeletonHintProps = FormFieldSkeletonHintProps
+export function SelectFieldSkeletonHint(props: SelectFieldSkeletonHintProps) {
+  return <FormFieldSkeletonHint {...props} />
+}
+
+export type SelectFieldSkeletonErrorProps = FormFieldSkeletonErrorProps
+export function SelectFieldSkeletonError(props: SelectFieldSkeletonErrorProps) {
+  return <FormFieldSkeletonError {...props} />
 }

--- a/src/components/form-skeletons/stories/form.stories.tsx
+++ b/src/components/form-skeletons/stories/form.stories.tsx
@@ -17,7 +17,13 @@ import SingleCheckboxFieldSkeleton from "../components/SingleCheckboxFieldSkelet
 import TextAreaFieldSkeleton from "../components/TextAreaFieldSkeleton"
 import CheckboxGroupFieldSkeleton from "../components/CheckboxGroupFieldSkeleton"
 import RadioButtonFieldSkeleton from "../components/RadioButtonFieldSkeleton"
-import SelectFieldSkeleton from "../components/SelectFieldSkeleton"
+import {
+  SelectFieldSkeleton,
+  SelectFieldSkeletonLabel,
+  SelectFieldSkeletonControl,
+  SelectFieldSkeletonError,
+  SelectFieldSkeletonHint,
+} from "../components/SelectFieldSkeleton"
 
 storiesOf(`form-skeletons`, module)
   .addParameters({
@@ -91,13 +97,13 @@ storiesOf(`form-skeletons`, module)
             hasHint={!!hint}
           >
             <div>
-              <SelectFieldSkeleton.Label>Select</SelectFieldSkeleton.Label>
-              <SelectFieldSkeleton.Control
+              <SelectFieldSkeletonLabel>Select</SelectFieldSkeletonLabel>
+              <SelectFieldSkeletonControl
                 options={options}
                 onChange={e => action(`Change`)(e.target.value)}
               />
-              <SelectFieldSkeleton.Error>{error}</SelectFieldSkeleton.Error>
-              <SelectFieldSkeleton.Hint>{hint}</SelectFieldSkeleton.Hint>
+              <SelectFieldSkeletonError>{error}</SelectFieldSkeletonError>
+              <SelectFieldSkeletonHint>{hint}</SelectFieldSkeletonHint>
             </div>
           </SelectFieldSkeleton>
           <br />

--- a/src/components/form/components/SelectConnectedField.tsx
+++ b/src/components/form/components/SelectConnectedField.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
 import { getIn, useFormikContext } from "formik"
-import SelectFieldBlock from "./SelectFieldBlock"
+import { SelectFieldBlock } from "./SelectFieldBlock"
 import Case from "case"
 import { SelectFieldBlockProps } from "./SelectFieldBlock"
 
@@ -11,7 +11,9 @@ export type SelectConnectedFieldProps = {
   label?: React.ReactNode
 } & Omit<SelectFieldBlockProps, "id" | "label">
 
-const SelectConnectedField: React.FC<SelectConnectedFieldProps> = props => {
+export const SelectConnectedField: React.FC<
+  SelectConnectedFieldProps
+> = props => {
   const id = `${props.name}Field`
   const label = Case.sentence(props.name)
   const {
@@ -37,5 +39,3 @@ const SelectConnectedField: React.FC<SelectConnectedFieldProps> = props => {
     />
   )
 }
-
-export default SelectConnectedField

--- a/src/components/form/components/SelectField.tsx
+++ b/src/components/form/components/SelectField.tsx
@@ -3,17 +3,33 @@ import { jsx } from "@emotion/core"
 import React from "react"
 
 import {
-  FormFieldSkeleton,
   FormFieldSkeletonProps,
+  useFormFieldSkeleton,
 } from "../../form-skeletons/components/FormFieldSkeleton"
-import { FormField, getFieldStackStyles } from "./FormField"
+import {
+  getFieldStackStyles,
+  FormFieldStackProps,
+  FormFieldStack,
+  FormFieldLabelProps,
+  useStyledFieldLabel,
+  useStyledFieldError,
+  useStyledFieldHint,
+} from "./FormField"
 import { getInputStyles } from "./FormField.helpers"
-import SelectFieldSkeleton, {
+import {
+  SelectFieldSkeleton,
   SelectFieldSkeletonControlProps,
+  SelectFieldSkeletonControl,
+  SelectFieldSkeletonLabel,
+  SelectFieldSkeletonErrorProps,
+  SelectFieldSkeletonError,
+  SelectFieldSkeletonHintProps,
+  SelectFieldSkeletonHint,
 } from "../../form-skeletons/components/SelectFieldSkeleton"
 import { Theme } from "../../../theme"
 
-function SelectField(props: FormFieldSkeletonProps) {
+export type SelectFieldProps = FormFieldSkeletonProps
+export function SelectField(props: FormFieldSkeletonProps) {
   return <SelectFieldSkeleton {...props}></SelectFieldSkeleton>
 }
 
@@ -22,42 +38,58 @@ export type SelectFieldControlProps = Omit<
   "ref"
 >
 
-const Control = React.forwardRef<HTMLSelectElement, SelectFieldControlProps>(
-  (props, ref) => {
-    const { hasError } = FormFieldSkeleton.useFormFieldSkeleton()
+export const SelectFieldControl = React.forwardRef<
+  HTMLSelectElement,
+  SelectFieldControlProps
+>(function SelectFieldControl(props, ref) {
+  const { hasError } = useFormFieldSkeleton()
 
-    return (
-      <SelectFieldSkeleton.Control
-        ref={ref}
-        css={(theme: Theme) => [
-          getFieldStackStyles(`item`, theme),
-          getInputStyles(theme, hasError),
-          {
-            padding: `0 ${theme.space[3]}`,
-            backgroundImage: `url("data:image/svg+xml,%3Csvg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 24 24' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z'%3E%3C/path%3E%3C/svg%3E")`,
-            backgroundRepeat: `no-repeat`,
-            backgroundPosition: `right ${theme.space[3]} top 50%, 0 0`,
-          },
-        ]}
-        {...props}
-      />
-    )
-  }
-)
+  return (
+    <SelectFieldSkeletonControl
+      ref={ref}
+      css={(theme: Theme) => [
+        getFieldStackStyles(`item`, theme),
+        getInputStyles(theme, hasError),
+        {
+          padding: `0 ${theme.space[3]}`,
+          backgroundImage: `url("data:image/svg+xml,%3Csvg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 24 24' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z'%3E%3C/path%3E%3C/svg%3E")`,
+          backgroundRepeat: `no-repeat`,
+          backgroundPosition: `right ${theme.space[3]} top 50%, 0 0`,
+        },
+      ]}
+      {...props}
+    />
+  )
+})
 
-SelectField.Control = Control
-SelectField.Control.displayName = `SelectField.Control`
+export type SelectFieldWrapperProps = FormFieldStackProps
+export const SelectFieldWrapper = FormFieldStack
 
-SelectField.Wrapper = FormField.Stack
-SelectField.Wrapper.displayName = `SelectField.StackWrapper`
+export type SelectFieldLabelProps = FormFieldLabelProps
+export function SelectFieldLabel({
+  children,
+  size,
+  isRequired,
+  ...props
+}: SelectFieldLabelProps) {
+  const styledProps = useStyledFieldLabel(children, { size, isRequired })
 
-SelectField.Label = FormField.Label
-SelectField.Label.displayName = `SelectField.Label`
+  return <SelectFieldSkeletonLabel {...props} {...styledProps} />
+}
 
-SelectField.Hint = FormField.Hint
-SelectField.Hint.displayName = `SelectField.Hint`
+export type SelectFieldErrorProps = SelectFieldSkeletonErrorProps
+export function SelectFieldError({
+  children,
+  ...props
+}: SelectFieldErrorProps) {
+  const styledProps = useStyledFieldError(children)
 
-SelectField.Error = FormField.Error
-SelectField.Error.displayName = `SelectField.Hint`
+  return <SelectFieldSkeletonError {...props} {...styledProps} />
+}
 
-export default SelectField
+export type SelectFieldHintProps = SelectFieldSkeletonHintProps
+export function SelectFieldHint(props: SelectFieldHintProps) {
+  const styledProps = useStyledFieldHint()
+
+  return <SelectFieldSkeletonHint {...props} {...styledProps} />
+}

--- a/src/components/form/components/SelectFieldBlock.tsx
+++ b/src/components/form/components/SelectFieldBlock.tsx
@@ -2,7 +2,15 @@
 import { jsx } from "@emotion/core"
 import React, { ReactNode } from "react"
 
-import SelectField, { SelectFieldControlProps } from "./SelectField"
+import {
+  SelectField,
+  SelectFieldControlProps,
+  SelectFieldWrapper,
+  SelectFieldLabel,
+  SelectFieldControl,
+  SelectFieldHint,
+  SelectFieldError,
+} from "./SelectField"
 import { FormFieldLabelSize } from "./FormField.helpers"
 import { ErrorValidationMode } from "../../form-skeletons/components/FormFieldSkeleton"
 
@@ -15,10 +23,10 @@ export type SelectFieldBlockProps = {
   validationMode?: ErrorValidationMode
 } & SelectFieldControlProps
 
-const SelectFieldBlock = React.forwardRef<
+export const SelectFieldBlock = React.forwardRef<
   HTMLSelectElement,
   SelectFieldBlockProps
->((props, ref) => {
+>(function SelectFieldBlock(props, ref) {
   const {
     id,
     label,
@@ -32,18 +40,16 @@ const SelectFieldBlock = React.forwardRef<
 
   return (
     <SelectField id={id} hasError={!!error} hasHint={!!hint}>
-      <SelectField.Wrapper className={className}>
-        <SelectField.Label size={labelSize} isRequired={!!rest.required}>
+      <SelectFieldWrapper className={className}>
+        <SelectFieldLabel size={labelSize} isRequired={!!rest.required}>
           {label}
-        </SelectField.Label>
-        <SelectField.Control ref={ref} {...rest} />
-        <SelectField.Hint>{hint}</SelectField.Hint>
-        <SelectField.Error validationMode={validationMode}>
+        </SelectFieldLabel>
+        <SelectFieldControl ref={ref} {...rest} />
+        <SelectFieldHint>{hint}</SelectFieldHint>
+        <SelectFieldError validationMode={validationMode}>
           {error}
-        </SelectField.Error>
-      </SelectField.Wrapper>
+        </SelectFieldError>
+      </SelectFieldWrapper>
     </SelectField>
   )
 })
-
-export default SelectFieldBlock

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -8,11 +8,9 @@ export {
   default as TextAreaConnectedField,
 } from "./components/TextAreaConnectedField"
 
-export { default as SelectField } from "./components/SelectField"
-export { default as SelectFieldBlock } from "./components/SelectFieldBlock"
-export {
-  default as SelectConnectedField,
-} from "./components/SelectConnectedField"
+export * from "./components/SelectField"
+export * from "./components/SelectFieldBlock"
+export * from "./components/SelectConnectedField"
 
 export { default as CheckboxField } from "./components/CheckboxField"
 export { default as CheckboxFieldBlock } from "./components/CheckboxFieldBlock"

--- a/src/components/form/stories/form.FormField.stories.tsx
+++ b/src/components/form/stories/form.FormField.stories.tsx
@@ -15,7 +15,14 @@ import {
   InputFieldError,
 } from "../components/InputField"
 import TextAreaField from "../components/TextAreaField"
-import SelectField from "../components/SelectField"
+import {
+  SelectField,
+  SelectFieldWrapper,
+  SelectFieldLabel,
+  SelectFieldControl,
+  SelectFieldHint,
+  SelectFieldError,
+} from "../components/SelectField"
 import CheckboxField from "../components/CheckboxField"
 import CheckboxGroupField from "../components/CheckboxGroupField"
 import RadioButtonField from "../components/RadioButtonField"
@@ -104,15 +111,15 @@ storiesOf(`form/FormField`, module)
           </TextAreaField>
 
           <SelectField id="example-1c" hasError={!!error} hasHint={!!hint}>
-            <SelectField.Wrapper>
-              <SelectField.Label size={size}>Author</SelectField.Label>
-              <SelectField.Control
+            <SelectFieldWrapper>
+              <SelectFieldLabel size={size}>Author</SelectFieldLabel>
+              <SelectFieldControl
                 options={authors}
                 onChange={e => action(`Change`)(e.target.value)}
               />
-              <SelectField.Hint>{hint}</SelectField.Hint>
-              <SelectField.Error>{error}</SelectField.Error>
-            </SelectField.Wrapper>
+              <SelectFieldHint>{hint}</SelectFieldHint>
+              <SelectFieldError>{error}</SelectFieldError>
+            </SelectFieldWrapper>
           </SelectField>
 
           <CheckboxGroupField

--- a/src/components/form/stories/form.SelectField.stories.tsx
+++ b/src/components/form/stories/form.SelectField.stories.tsx
@@ -7,8 +7,15 @@ import { text, radios, boolean } from "@storybook/addon-knobs"
 import { StoryUtils } from "../../../utils/storybook"
 import README from "../README_SELECT_FIELD.md"
 import { action } from "@storybook/addon-actions"
-import SelectField from "../components/SelectField"
-import SelectFieldBlock from "../components/SelectFieldBlock"
+import {
+  SelectField,
+  SelectFieldWrapper,
+  SelectFieldLabel,
+  SelectFieldControl,
+  SelectFieldHint,
+  SelectFieldError,
+} from "../components/SelectField"
+import { SelectFieldBlock } from "../components/SelectFieldBlock"
 import { FormFieldLabelSize } from "../components/FormField.helpers"
 import { enumToOptions } from "../../../utils/helpers"
 import { Wrapper } from "./stories.utils"
@@ -61,23 +68,23 @@ storiesOf(`form`, module)
       <StoryUtils.Container>
         <Wrapper>
           <SelectField id="example-1a" hasError={!!error} hasHint={true}>
-            <SelectField.Wrapper>
-              <SelectField.Label isRequired={required} size={size}>
+            <SelectFieldWrapper>
+              <SelectFieldLabel isRequired={required} size={size}>
                 Author
-              </SelectField.Label>
-              <SelectField.Control
+              </SelectFieldLabel>
+              <SelectFieldControl
                 options={options}
                 onChange={e => action(`Change`)(e.target.value)}
                 disabled={disabled}
                 required={required}
               />
-              <SelectField.Hint>
+              <SelectFieldHint>
                 {hint
                   ? hint
                   : `This field is built with 'SelectField' and subcomponents placed explicitly as its children`}
-              </SelectField.Hint>
-              <SelectField.Error>{error}</SelectField.Error>
-            </SelectField.Wrapper>
+              </SelectFieldHint>
+              <SelectFieldError>{error}</SelectFieldError>
+            </SelectFieldWrapper>
           </SelectField>
 
           <SelectFieldBlock

--- a/src/components/form/stories/form.WithFormik.stories.tsx
+++ b/src/components/form/stories/form.WithFormik.stories.tsx
@@ -18,9 +18,15 @@ import { InputFieldBlock } from "../components/InputFieldBlock"
 import { InputConnectedField } from "../components/InputConnectedField"
 import TextAreaFieldBlock from "../components/TextAreaFieldBlock"
 import TextAreaConnectedField from "../components/TextAreaConnectedField"
-import SelectField from "../components/SelectField"
-import SelectFieldBlock from "../components/SelectFieldBlock"
-import SelectConnectedField from "../components/SelectConnectedField"
+import {
+  SelectField,
+  SelectFieldWrapper,
+  SelectFieldLabel,
+  SelectFieldControl,
+  SelectFieldError,
+} from "../components/SelectField"
+import { SelectFieldBlock } from "../components/SelectFieldBlock"
+import { SelectConnectedField } from "../components/SelectConnectedField"
 import CheckboxField from "../components/CheckboxField"
 import CheckboxFieldBlock from "../components/CheckboxFieldBlock"
 import CheckboxConnectedField from "../components/CheckboxConnectedField"
@@ -256,21 +262,21 @@ storiesOf(`form/Formik usage examples`, module)
                     id="authorField"
                     hasError={!!(touched.author && errors.author)}
                   >
-                    <SelectField.Wrapper css={stackItemCss}>
-                      <SelectField.Label isRequired={true}>
+                    <SelectFieldWrapper css={stackItemCss}>
+                      <SelectFieldLabel isRequired={true}>
                         Author
-                      </SelectField.Label>
-                      <SelectField.Control
+                      </SelectFieldLabel>
+                      <SelectFieldControl
                         name="author"
                         options={authors}
                         value={values.author}
                         onChange={handleChange}
                         onBlur={handleBlur}
                       />
-                      <SelectField.Error>
+                      <SelectFieldError>
                         {touched.author && errors.author ? errors.author : ``}
-                      </SelectField.Error>
-                    </SelectField.Wrapper>
+                      </SelectFieldError>
+                    </SelectFieldWrapper>
                   </SelectField>
 
                   <RadioButtonField


### PR DESCRIPTION
In continuation of #213, here's a PR to replace static properties with named exports for `SelectField` and `SelectFieldSkeleton`.