### PR TITLE
fix: remove static properties from ToggleGutter, fix label styling

### DIFF
--- a/src/components/Toggle/ToggleCheckbox.tsx
+++ b/src/components/Toggle/ToggleCheckbox.tsx
@@ -4,7 +4,11 @@ import React from "react"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"
 import { AtomTone } from "../../theme/types"
 import { Theme } from "../../theme"
-import ToggleGutter from "./ToggleGutter"
+import ToggleGutter, {
+  ToggleGutterTagName,
+  toggleGutterCheckedCss,
+  toggleGutterFocusCss,
+} from "./ToggleGutter"
 import { toggleLabelCss } from "./Toggle.styles"
 
 type BaseToggleProps = Omit<JSX.IntrinsicElements["input"], "ref" | "type"> & {
@@ -22,13 +26,10 @@ const BaseToggle = React.forwardRef<HTMLInputElement, BaseToggleProps>(
           css={(theme: Theme) => [
             visuallyHiddenCss,
             {
-              [`&:checked + ${ToggleGutter.tagName}`]: ToggleGutter.getCheckedCss(
-                theme,
+              [`&:checked + ${ToggleGutterTagName}`]: toggleGutterCheckedCss(
                 tone
-              ),
-              [`&:focus + ${ToggleGutter.tagName}`]: ToggleGutter.getFocusCss(
-                theme
-              ),
+              )(theme),
+              [`&:focus + ${ToggleGutterTagName}`]: toggleGutterFocusCss(theme),
             },
           ]}
           {...rest}

--- a/src/components/Toggle/ToggleGutter.tsx
+++ b/src/components/Toggle/ToggleGutter.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
 import { AtomTone } from "../../theme/types"
-import { Theme } from "../../theme"
+import { Theme, ThemeCss } from "../../theme"
 
 export type ToggleGutterProps = JSX.IntrinsicElements["span"]
 
@@ -45,14 +45,16 @@ export default function ToggleGutter(props: ToggleGutterProps) {
   )
 }
 
-ToggleGutter.tagName = "span"
+export const ToggleGutterTagName = "span"
 
-ToggleGutter.getFocusCss = (theme: Theme) => ({
+export const toggleGutterFocusCss: ThemeCss = (theme: Theme) => ({
   boxShadow: `0 0 0 3px ${theme.colors.blue[30]}`,
   outline: `0`,
 })
 
-ToggleGutter.getCheckedCss = (theme: Theme, tone: AtomTone = `BRAND`) => ({
+export const toggleGutterCheckedCss = (
+  tone: AtomTone = `BRAND`
+): ThemeCss => theme => ({
   background: theme.tones[tone].medium,
   ":after": {
     left: `calc(100% - 18px)`,

--- a/src/components/Toggle/ToggleSwitch.tsx
+++ b/src/components/Toggle/ToggleSwitch.tsx
@@ -4,7 +4,11 @@ import React from "react"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"
 import { AtomTone } from "../../theme/types"
 import { Theme } from "../../theme"
-import ToggleGutter from "./ToggleGutter"
+import ToggleGutter, {
+  ToggleGutterTagName,
+  toggleGutterCheckedCss,
+  toggleGutterFocusCss,
+} from "./ToggleGutter"
 import { toggleLabelCss } from "./Toggle.styles"
 
 export type ToggleSwitchProps = Omit<
@@ -62,14 +66,17 @@ export default function ToggleSwitch({
       id={id}
       className={className}
       style={style}
-      css={theme => ({
-        display: `flex`,
-        alignItems: `center`,
-        // We can rely on "> ToggleGutter.tagName" here since we have full control over direct children
-        [`&:focus-within > ${ToggleGutter.tagName}`]: ToggleGutter.getFocusCss(
-          theme
-        ),
-      })}
+      css={theme => [
+        {
+          display: `flex`,
+          alignItems: `center`,
+          // We can rely on "> ToggleGutterTagName" here since we have full control over direct children
+          [`&:focus-within > ${ToggleGutterTagName}`]: toggleGutterFocusCss(
+            theme
+          ),
+        },
+        toggleLabelCss(theme),
+      ]}
       onClick={e => {
         if (!inputOnRef.current || !inputOffRef.current) {
           return
@@ -91,12 +98,11 @@ export default function ToggleSwitch({
             inputOn.focus()
             inputOn.click()
           }
-        } else if (target.tagName === ToggleGutter.tagName.toUpperCase()) {
+        } else if (target.tagName === ToggleGutterTagName.toUpperCase()) {
           toggle()
         }
       }}
       onKeyPress={e => {
-        console.log({ key: e.key })
         if (e.key !== " ") {
           return
         }
@@ -113,13 +119,11 @@ export default function ToggleSwitch({
         ref={inputOffRef}
         {...rest}
       />
-      <label htmlFor={optionOffId} css={toggleLabelCss}>
-        {labelOff}
-      </label>
+      <label htmlFor={optionOffId}>{labelOff}</label>
       <ToggleGutter
         css={(theme: Theme) => [
           { marginLeft: theme.space[3], marginRight: theme.space[3] },
-          isOn && ToggleGutter.getCheckedCss(theme, tone),
+          isOn && toggleGutterCheckedCss(tone)(theme),
         ]}
       />
       <input
@@ -132,9 +136,7 @@ export default function ToggleSwitch({
         ref={inputOnRef}
         {...rest}
       />
-      <label htmlFor={optionOnId} css={toggleLabelCss}>
-        {labelOn}
-      </label>
+      <label htmlFor={optionOnId}>{labelOn}</label>
     </div>
   )
 }


### PR DESCRIPTION
* Remove static properties from internal `ToggleGutter` component to allow tree shaking with Webpack
* Lift up the default label styles for `ToggleCheckbox` and `ToggleSwitch` for easier customization 