### PR TITLE
fix: use 'bold' font weight for active SidebarNav link

### DIFF
--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -83,7 +83,7 @@ const baseNavItemCss: ThemeCss = theme => ({
 
 const baseNavItemActiveCss: ThemeCss = theme => ({
   color: theme.colors.purple[50],
-  fontWeight: theme.fontWeights.bold,
+  fontWeight: `bold`,
 })
 
 const navItemIconCss: ThemeCss = theme => ({


### PR DESCRIPTION
So, apparently our `theme.fontWeights.bold` is not the same as `"bold"` for some of our fonts, it actually looks bolder, so I've updated `SidebarNav` to use `"bold"` for its "active" items. It should still give enough distinction to identify an active item in addition to the color usage.
