### PR TITLE
chore: add CommonJS bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": [
     "dist"
   ],
-  "main": "dist/index.esm.js",
+  "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "jsnext:main": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,43 +11,56 @@ import pkg from "./package.json"
 
 const extensions = [`.js`, `.jsx`, `.ts`, `.tsx`]
 
-export default {
-  input: pkg.source,
-  preserveModules: true,
-  output: {
-    dir: pkg.files[0],
-    format: "esm",
-    entryFileNames: `[name].[format].js`,
-    sourcemap: true,
+const plugins = [
+  external(),
+  svg({
+    base64: true,
+  }),
+  babel({
+    exclude: `node_modules/**`,
+    extensions,
+  }),
+  resolve({ extensions }),
+  commonjs({
+    namedExports: {
+      "highlight-words-core": ["findAll"],
+    },
+  }),
+  postcss({
+    extensions: [`.css`],
+  }),
+  // TODO The following two plugins should be removed once all src is using TypeScript
+  copy({
+    targets: [
+      { src: `dist/index-ts-only.d.ts`, dest: `dist/`, rename: `index.d.ts` },
+    ],
+    hook: `buildStart`,
+  }),
+  del({
+    targets: `dist/index-ts-only.d.ts`,
+    hook: `buildEnd`,
+  }),
+]
+
+export default [
+  {
+    input: pkg.source,
+    preserveModules: true,
+    output: {
+      dir: pkg.files[0],
+      format: "esm",
+      entryFileNames: `[name].[format].js`,
+      sourcemap: true,
+    },
+    plugins,
   },
-  plugins: [
-    external(),
-    svg({
-      base64: true,
-    }),
-    babel({
-      exclude: `node_modules/**`,
-      extensions,
-    }),
-    resolve({ extensions }),
-    commonjs({
-      namedExports: {
-        "highlight-words-core": ["findAll"],
-      },
-    }),
-    postcss({
-      extensions: [`.css`],
-    }),
-    // TODO The following two plugins should be removed once all src is using TypeScript
-    copy({
-      targets: [
-        { src: `dist/index-ts-only.d.ts`, dest: `dist/`, rename: `index.d.ts` },
-      ],
-      hook: `buildStart`,
-    }),
-    del({
-      targets: `dist/index-ts-only.d.ts`,
-      hook: `buildEnd`,
-    }),
-  ],
-}
+  {
+    input: pkg.source,
+    output: {
+      file: pkg.main,
+      format: "cjs",
+      sourcemap: true,
+    },
+    plugins,
+  },
+]


### PR DESCRIPTION
Adds a CommonJS bundle in addition to ESM one. This is done mostly to avoid Jest tests breaking due when node_modules are not being transpiled.