### PR TITLE
fix: adjust README to new Netlify URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 # Gatsby Interface
 
+<a href="https://www.npmjs.org/package/gatsby-interface">
+  <img src="https://img.shields.io/npm/v/gatsby-interface.svg" alt="Current npm package version." />
+</a>
+<a href="https://npmcharts.com/compare/gatsby-interface?minimal=true">
+  <img src="https://img.shields.io/npm/dm/gatsby-interface.svg" alt="Downloads per month on npm." />
+</a>
+<a href="https://npmcharts.com/compare/gatsby-interface?minimal=true">
+  <img src="https://img.shields.io/npm/dt/gatsby-interface.svg" alt="Total downloads on npm." />
+</a>
+
 Storybook available at [gatsby-interface.netlify.com](https://gatsby-interface.netlify.com/).
 
 ![Storybook](https://user-images.githubusercontent.com/18426780/63871208-b9aea600-c978-11e9-9107-79679b699c6f.png)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gatsby Interface
 
-Storybook [available here](https://reverent-keller-9597e8.netlify.com/)
+Storybook available at [gatsby-interface.netlify.com](https://gatsby-interface.netlify.com/).
 
 ![Storybook](https://user-images.githubusercontent.com/18426780/63871208-b9aea600-c978-11e9-9107-79679b699c6f.png)
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,25 @@ Storybook available at [gatsby-interface.netlify.com](https://gatsby-interface.n
 
 ![Storybook](https://user-images.githubusercontent.com/18426780/63871208-b9aea600-c978-11e9-9107-79679b699c6f.png)
 
+## Installation
+
+Using [npm](https://www.npmjs.com/):
+
+```shell
+npm install gatsby-interface --save
 ```
-yarn storybook
+
+Using [Yarn](https://yarnpkg.com/):
+
+```shell
+yarn add gatsby-interface
 ```
+
+## Development
+
+1. Clone the repository: `git clone https://github.com/gatsby-inc/gatsby-interface.git`.
+2. Install dependencies: `yarn`.
+3. Run Storybook: `yarn storybook`.
 
 These are some patterns and best practices we use when contributing to `gatsby-interface`
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<img src="https://user-images.githubusercontent.com/21834/74070062-35b91980-4a00-11ea-93a8-b77bde7b4c37.png" width="48" height="48" alt="rebeccapurple dot" />
+<br>
+<br>
+
 # Gatsby Interface
 
 Storybook available at [gatsby-interface.netlify.com](https://gatsby-interface.netlify.com/).

--- a/README.md
+++ b/README.md
@@ -38,17 +38,19 @@ yarn add gatsby-interface
 2. Install dependencies: `yarn`.
 3. Run Storybook: `yarn storybook`.
 
-These are some patterns and best practices we use when contributing to `gatsby-interface`
+## Contributing
 
-- Use React hooks and functional components - https://reactjs.org/docs/hooks-intro.html
-- Use CSS props for styling - https://emotion.sh/docs/css-prop
-- Use `gatsby-design-tokens` for styling constants - https://www.gatsbyjs.org/guidelines/design-tokens/
-- Use compound components to make components more composable and flexible - https://kentcdodds.com/blog/compound-components-with-react-hooks
-- Make all PRs against the `dev` branch
-- Use `TONE` and `VARIANT` prop (when appropriate) to determine color styles and version of a component - see Button as an example
-- Make the component as generic as possible so it can be used anywhere by anything
-- In `skeletons` folder, these contain only the functionality of a component (no styles) and can be used within other components
-- Write Storybook stories for any component created - https://storybook.js.org/docs/basics/writing-stories/
+These are some patterns and best practices we use when contributing to `gatsby-interface`:
+
+- Use React hooks and functional components: https://reactjs.org/docs/hooks-intro.html.
+- Use CSS props for styling: https://emotion.sh/docs/css-prop.
+- Use `gatsby-design-tokens` for styling constants: https://www.gatsbyjs.org/guidelines/design-tokens/.
+- Use compound components to make components more composable and flexible: https://kentcdodds.com/blog/compound-components-with-react-hooks.
+- Make all PRs against the `dev` branch.
+- Use `TONE` and `VARIANT` prop (when appropriate) to definie color style and variant of a component — see e. g. `<Button>`.
+- Make the component as generic as possible so it can be used _anywhere_ by _anything_.
+- Components in the `skeletons` folder provide only the functionality, but no styles, and can be used within other components.
+- Write Storybook stories for any component created: https://storybook.js.org/docs/basics/writing-stories/.
 - Typscript coming soon!
 - Unit tests coming soon!
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 Storybook available at [gatsby-interface.netlify.com](https://gatsby-interface.netlify.com/).
 
-![Storybook](https://user-images.githubusercontent.com/18426780/63871208-b9aea600-c978-11e9-9107-79679b699c6f.png)
+![screenshot](https://user-images.githubusercontent.com/21834/77585971-ac916f80-6ee5-11ea-92b4-8cf24284f366.png)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn add gatsby-interface
 
 ### Fonts
 
-Certain Gatsby Interface components currently require the `Futura PT` webfont. These files are git-ignored to prevent the unauthorized release of licensed assets, and are not included in this repository.
+Certain Gatsby Interface components require the `Futura PT` webfont. These files are git-ignored to prevent the unauthorized release of licensed assets, and are not included in this repository.
 
 Gatsby Inc. employees can download these fonts from our [Google Drive](https://drive.google.com/drive/u/1/folders/1DA_iNzLbd1_gvU_FWTzYK6MgLSl85L4v). Put all those folders in `src/assets/futura-pt` and you should be good to go!
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Using [Yarn](https://yarnpkg.com/):
 yarn add gatsby-interface
 ```
 
+### Fonts
+
+Certain Gatsby Interface components currently require the `Futura PT` webfont. These files are git-ignored to prevent the unauthorized release of licensed assets, and are not included in this repository.
+
+Gatsby Inc. employees can download these fonts from our [Google Drive](https://drive.google.com/drive/u/1/folders/1DA_iNzLbd1_gvU_FWTzYK6MgLSl85L4v). Put all those folders in `src/assets/futura-pt` and you should be good to go!
+
 ## Development
 
 1. Clone the repository: `git clone https://github.com/gatsby-inc/gatsby-interface.git`.
@@ -53,12 +59,6 @@ These are some patterns and best practices we use when contributing to `gatsby-i
 - Write Storybook stories for any component created: https://storybook.js.org/docs/basics/writing-stories/.
 - Typscript coming soon!
 - Unit tests coming soon!
-
-### Required assets
-
-Gatsby Interface requires the `futura PT` webfont in several different weights. These files are git-ignored, to prevent the unauthorized release of licensed assets.
-
-Gatsby Inc. employees can download these fonts from [Google Drive](https://drive.google.com/drive/u/1/folders/1DA_iNzLbd1_gvU_FWTzYK6MgLSl85L4v). Put all those folders in `src/assets/futura-pt` and you should be good to go!
 
 ### Chromatic testing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/npm/dt/gatsby-interface.svg" alt="Total downloads on npm." />
 </a>
 
-Storybook available at [gatsby-interface.netlify.com](https://gatsby-interface.netlify.com/).
+Storybook available at [gatsby-interface.netlify.com](https://gatsby-interface.netlify.com/):
 
 ![screenshot](https://user-images.githubusercontent.com/21834/77585971-ac916f80-6ee5-11ea-92b4-8cf24284f366.png)
 


### PR DESCRIPTION
We switched the live Storybook URL from from https://reverent-keller-9597e8.netlify.com/ to https://gatsby-interface.netlify.com/. This PR adjusts the link in the `README`.

Rewrote and reordered stuff a little along the way; preview here: https://github.com/gatsby-inc/gatsby-interface/blob/23dd1c16e0e9c2104f5034fc6a4ab9847dbbf6af/README.md