### PR TITLE
CSS reset for Navigation list items

### DIFF
--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -150,7 +150,7 @@ Navigation.DropdownItem = delegated => {
   )
 }
 
-Navigation.Button = ({ linkTo, ...delegated }) => {
+Navigation.Button = ({ linkTo, className, ...delegated }) => {
   const { mobileNavMediaQuery } = BaseNavigation.useNavigationContext()
 
   const isExternal = linkTo.match(/(^http|^mailto)/i)
@@ -162,14 +162,14 @@ Navigation.Button = ({ linkTo, ...delegated }) => {
 
   if (isExternal) {
     return (
-      <li css={cssStyles}>
+      <li css={cssStyles} className={className}>
         <BaseNavigation.AnchorButton href={linkTo} {...delegated} />
       </li>
     )
   }
 
   return (
-    <li css={cssStyles}>
+    <li css={cssStyles} className={className}>
       <BaseNavigation.LinkButton linkTo={linkTo} {...delegated} />
     </li>
   )

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -162,23 +162,15 @@ Navigation.Button = ({ linkTo, ...delegated }) => {
 
   if (isExternal) {
     return (
-      <li>
-        <BaseNavigation.AnchorButton
-          href={linkTo}
-          css={cssStyles}
-          {...delegated}
-        />
+      <li css={cssStyles}>
+        <BaseNavigation.AnchorButton href={linkTo} {...delegated} />
       </li>
     )
   }
 
   return (
-    <li>
-      <BaseNavigation.LinkButton
-        linkTo={linkTo}
-        css={cssStyles}
-        {...delegated}
-      />
+    <li css={cssStyles}>
+      <BaseNavigation.LinkButton linkTo={linkTo} {...delegated} />
     </li>
   )
 }

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -150,26 +150,26 @@ Navigation.DropdownItem = delegated => {
   )
 }
 
-Navigation.Button = ({ linkTo, className, ...delegated }) => {
+Navigation.Button = ({ linkTo, ...delegated }) => {
   const { mobileNavMediaQuery } = BaseNavigation.useNavigationContext()
 
   const isExternal = linkTo.match(/(^http|^mailto)/i)
 
   const cssStyles = {
-    ...styles.Button.default,
-    [mobileNavMediaQuery]: styles.Button.mobile,
+    ...styles.ButtonItem.default,
+    [mobileNavMediaQuery]: styles.ButtonItem.mobile,
   }
 
   if (isExternal) {
     return (
-      <li css={cssStyles} className={className}>
+      <li css={cssStyles}>
         <BaseNavigation.AnchorButton href={linkTo} {...delegated} />
       </li>
     )
   }
 
   return (
-    <li css={cssStyles} className={className}>
+    <li css={cssStyles}>
       <BaseNavigation.LinkButton linkTo={linkTo} {...delegated} />
     </li>
   )

--- a/src/components/Navigation/Navigation.stories.js
+++ b/src/components/Navigation/Navigation.stories.js
@@ -81,6 +81,7 @@ storiesOf(`Navigation`, module)
     <div css={{ padding: `2rem` }}>
       <Navigation items={items2}>
         <Navigation.Item item={{ name: `Contact`, linkTo: `/contact/` }} />
+        <Navigation.Button linkTo="/">Test</Navigation.Button>
       </Navigation>
     </div>
   ))

--- a/src/theme/styles/navigation.js
+++ b/src/theme/styles/navigation.js
@@ -6,6 +6,11 @@ import { hexToRGBA } from "../../utils/helpers/hexToRgb"
 import space from "../../theme/space"
 import transition from "../../theme/transition"
 
+const liReset = {
+  margin: 0,
+  padding: 0,
+}
+
 const styles = {}
 
 styles.Navigation = {
@@ -124,6 +129,7 @@ const DropdownMobileStyles = {
 
 styles.Item = {
   default: {
+    ...liReset,
     marginBottom: 0,
     padding: `0 ${space[4]}`,
     "&:hover > ul": {
@@ -249,8 +255,9 @@ styles.DropdownItem = {
   },
 }
 
-styles.Button = {
+styles.ButtonItem = {
   default: {
+    ...liReset,
     marginLeft: `.5rem`,
   },
   mobile: {

--- a/src/theme/styles/navigation.js
+++ b/src/theme/styles/navigation.js
@@ -251,6 +251,7 @@ styles.DropdownItem = {
 
 styles.Button = {
   default: {
+    margin: 0,
     marginLeft: `.5rem`,
   },
   mobile: {

--- a/src/theme/styles/navigation.js
+++ b/src/theme/styles/navigation.js
@@ -251,7 +251,6 @@ styles.DropdownItem = {
 
 styles.Button = {
   default: {
-    margin: 0,
     marginLeft: `.5rem`,
   },
   mobile: {


### PR DESCRIPTION
Zeroes padding and margin of each `<li>` in `Navigation` so that navigation buttons are aligned even in cases when some normalizer is used together with this componentFor example, this is how Cloud nav would look on the current version without this fix:
<img width="439" alt="Screen Shot 2020-03-26 at 11 50 58 AM" src="https://user-images.githubusercontent.com/4366711/77685227-5d385700-6f58-11ea-8612-5c441498c612.png">
 