### PR TITLE
Allow `Navigation` to link to external URLs

### DIFF
--- a/src/components/BaseNavigation/BaseNavigation.tsx
+++ b/src/components/BaseNavigation/BaseNavigation.tsx
@@ -6,6 +6,7 @@ import { MdArrowForward } from "react-icons/md"
 
 import { LinkButton, LinkButtonProps } from "../LinkButton"
 import { AnchorButton, AnchorButtonProps } from "../AnchorButton"
+import { BaseAnchor } from "../BaseAnchor"
 import useOnClickOutside from "../../utils/hooks/useOnClickOutside"
 import baseStyles from "./BaseNavigation.styles"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"
@@ -26,6 +27,7 @@ export type BaseNavigationComponents = {
   List: React.ComponentType<any>
   Item: React.ComponentType<any>
   ItemLink: React.ComponentType<any>
+  ItemAnchor: React.ComponentType<any>
   Dropdown: React.ComponentType<any>
   DropdownItem: React.ComponentType<any>
   DropdownToggle: React.ComponentType<any>
@@ -72,6 +74,7 @@ export const BaseNavigation = ({
   List = BaseNavigationList,
   Item = BaseNavigationListItem,
   ItemLink = BaseNavigationItemLink,
+  ItemAnchor = BaseNavigationItemAnchor,
   Dropdown = BaseNavigationDropdown,
   DropdownItem = BaseNavigationDropdownItem,
   DropdownToggle = BaseNavigationDropdownToggle,
@@ -109,6 +112,7 @@ export const BaseNavigation = ({
       List,
       Item,
       ItemLink,
+      ItemAnchor,
       Dropdown,
       DropdownItem,
       DropdownToggle,
@@ -294,14 +298,37 @@ export type BaseNavigationItemLinkProps = Omit<GatsbyLinkProps<any>, "ref"> & {
   item: BaseNavigationItem
 }
 
+export type BaseNavigationItemAnchorProps = Omit<
+  React.HTMLProps<HTMLAnchorElement>,
+  "ref"
+> & {
+  item: BaseNavigationItem
+}
+
+export function BaseNavigationItemAnchor({
+  item,
+  ...rest
+}: BaseNavigationItemAnchorProps) {
+  return (
+    <BaseAnchor href={item.linkTo} {...rest}>
+      {/*
+        This span is needed for the styles applied in theme/styles/navigation
+      */}
+      <span>{item.name}</span>
+    </BaseAnchor>
+  )
+}
+
+BaseNavigation.ItemAnchor = BaseNavigationItemAnchor
+
 export function BaseNavigationItemLink({
   item,
   ...rest
 }: BaseNavigationItemLinkProps) {
   return (
     <Link activeClassName="nav-item-active" to={item.linkTo} {...rest}>
-      {/* 
-        This span is needed for the styles applied in theme/styles/navigation 
+      {/*
+        This span is needed for the styles applied in theme/styles/navigation
       */}
       <span>{item.name}</span>
     </Link>

--- a/src/components/BaseNavigation/BaseNavigation.tsx
+++ b/src/components/BaseNavigation/BaseNavigation.tsx
@@ -6,7 +6,7 @@ import { MdArrowForward } from "react-icons/md"
 
 import { LinkButton, LinkButtonProps } from "../LinkButton"
 import { AnchorButton, AnchorButtonProps } from "../AnchorButton"
-import { BaseAnchor } from "../BaseAnchor"
+import { BaseAnchor, BaseAnchorProps } from "../BaseAnchor"
 import useOnClickOutside from "../../utils/hooks/useOnClickOutside"
 import baseStyles from "./BaseNavigation.styles"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"
@@ -298,10 +298,7 @@ export type BaseNavigationItemLinkProps = Omit<GatsbyLinkProps<any>, "ref"> & {
   item: BaseNavigationItem
 }
 
-export type BaseNavigationItemAnchorProps = Omit<
-  React.HTMLProps<HTMLAnchorElement>,
-  "ref"
-> & {
+export type BaseNavigationItemAnchorProps = Omit<BaseAnchorProps, "ref"> & {
   item: BaseNavigationItem
 }
 

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -103,8 +103,6 @@ Navigation.ItemLink = ({ item, ...delegated }) => {
     ? BaseNavigation.ItemAnchor
     : BaseNavigation.ItemLink
 
-  console.log(Object.keys(BaseNavigation), Component)
-
   return (
     <Component
       item={item}

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -91,14 +91,23 @@ Navigation.Item = delegated => {
     />
   )
 }
-Navigation.ItemLink = delegated => {
+Navigation.ItemLink = ({ item, ...delegated }) => {
   const {
     isInverted,
     mobileNavMediaQuery,
   } = BaseNavigation.useNavigationContext()
 
+  const isExternal = getIsExternalLink(item.linkTo)
+
+  const Component = isExternal
+    ? BaseNavigation.ItemAnchor
+    : BaseNavigation.ItemLink
+
+  console.log(Object.keys(BaseNavigation), Component)
+
   return (
-    <BaseNavigation.ItemLink
+    <Component
+      item={item}
       css={{
         ...styles.ItemLink.default(isInverted),
         [mobileNavMediaQuery]: styles.ItemLink.mobile,
@@ -153,7 +162,7 @@ Navigation.DropdownItem = delegated => {
 Navigation.Button = ({ linkTo, ...delegated }) => {
   const { mobileNavMediaQuery } = BaseNavigation.useNavigationContext()
 
-  const isExternal = linkTo.match(/(^http|^mailto)/i)
+  const isExternal = getIsExternalLink(linkTo)
 
   const cssStyles = {
     ...styles.ButtonItem.default,
@@ -173,6 +182,10 @@ Navigation.Button = ({ linkTo, ...delegated }) => {
       <BaseNavigation.LinkButton linkTo={linkTo} {...delegated} />
     </li>
   )
+}
+
+const getIsExternalLink = linkTo => {
+  return linkTo.match(/(^http|^mailto)/i)
 }
 
 export default Navigation

--- a/src/components/Navigation/Navigation.stories.js
+++ b/src/components/Navigation/Navigation.stories.js
@@ -125,3 +125,11 @@ storiesOf(`Navigation`, module)
       </Navigation>
     </div>
   ))
+  .add(`with external children`, () => (
+    <Navigation
+      items={[
+        { name: `internal`, linkTo: `/test` },
+        { name: `external`, linkTo: `http://www.google.com` },
+      ]}
+    />
+  ))


### PR DESCRIPTION
In the Will It Build project, we have 1 link (API Playground) that needs to use an `<a>` tag rather than a `<Link>`, since the page is outside of the Gatsby app (links to `willit.build/api-playground`, but we're using Netlify rewrites to actually show a Graphiql playground)

I tried to follow the pattern established with @Elanhant for the `NavigationButton`; `BaseNavigation` has two separate primitives, but `Navigation` looks at the `linkTo` to determine which should be used.