### PR TITLE
chore: exclude Sandbox stories from Chromatic

### DIFF
--- a/scripts/scaffold-component/story-template.ejs
+++ b/scripts/scaffold-component/story-template.ejs
@@ -34,6 +34,12 @@ export const Sandbox = () => (
   </<%= COMPONENT_NAME %>>
 )
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+};
+
 export const Variants = () =>
   VARIANTS.map(variant => (
     <<%= COMPONENT_NAME %> key={variant} variant={variant}>

--- a/src/components/Announcement/Announcement.stories.tsx
+++ b/src/components/Announcement/Announcement.stories.tsx
@@ -26,3 +26,9 @@ export const Basic = () => (
 export const Sandbox = () => (
   <Announcement>{text("content", "Lorem ispum")}</Announcement>
 )
+
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -35,6 +35,12 @@ export const Sandbox = () => (
   </Badge>
 )
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Variants = () =>
   VARIANTS.map(variant => (
     <Badge key={variant} variant={variant}>

--- a/src/components/BaseNavigation/BaseNavigation.stories.tsx
+++ b/src/components/BaseNavigation/BaseNavigation.stories.tsx
@@ -72,6 +72,12 @@ export const Sandbox = () => {
   )
 }
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Inverted = () => <BaseNavigation items={items} isInverted />
 
 Inverted.story = {

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -106,6 +106,12 @@ export const Sandbox = () => {
   )
 }
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const WithSelect = () => {
   const [term, setTerm] = React.useState("")
 

--- a/src/components/ConcealedValue/ConcealedValue.stories.tsx
+++ b/src/components/ConcealedValue/ConcealedValue.stories.tsx
@@ -26,3 +26,9 @@ export const Sandbox = () => (
     ariaLabel={text("Label describing the value:", "Lorem ipsum")}
   />
 )
+
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -41,6 +41,12 @@ export const Sandbox = () => (
   </Heading>
 )
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Tones = () =>
   TONES.map(tone => (
     <Heading key={tone} tone={tone}>

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -30,6 +30,12 @@ export const Sandbox = () => (
   </Modal>
 )
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Dismissable = () => {
   const [isOpen, setIsOpen] = React.useState<boolean>(true)
 

--- a/src/components/Modal/ModalCard.stories.tsx
+++ b/src/components/Modal/ModalCard.stories.tsx
@@ -22,3 +22,9 @@ export const Sandbox = () => (
     <ModalCard>{text("content", "Hello world")}</ModalCard>
   </Modal>
 )
+
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}

--- a/src/components/Modal/ModalFullScreen.stories.tsx
+++ b/src/components/Modal/ModalFullScreen.stories.tsx
@@ -19,3 +19,9 @@ export const Sandbox = () => (
     <ModalFullScreen>{text("content", "Hello world")}</ModalFullScreen>
   </Modal>
 )
+
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}

--- a/src/components/Modal/ModalPanel.stories.tsx
+++ b/src/components/Modal/ModalPanel.stories.tsx
@@ -27,3 +27,9 @@ export const Sandbox = () => (
     </ModalPanel>
   </Modal>
 )
+
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}

--- a/src/components/Notification/Notification.stories.tsx
+++ b/src/components/Notification/Notification.stories.tsx
@@ -72,6 +72,12 @@ export const Sandbox = () => (
   />
 )
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Variants = () =>
   VARIANTS.map(variant => (
     <Notification

--- a/src/components/SidebarNav/SidebarNav.stories.tsx
+++ b/src/components/SidebarNav/SidebarNav.stories.tsx
@@ -40,6 +40,12 @@ export const Sandbox = () => (
   />
 )
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Variants = () =>
   SIDEBAR_NAV_VARIANTS.map(variant => (
     <React.Fragment key={variant}>

--- a/src/components/StepIndicator/StepIndicator.stories.tsx
+++ b/src/components/StepIndicator/StepIndicator.stories.tsx
@@ -70,6 +70,12 @@ export const Sandbox = () => {
   )
 }
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const WithLink = () => {
   return (
     <StepIndicator>

--- a/src/components/Toggle/ToggleCheckbox.stories.tsx
+++ b/src/components/Toggle/ToggleCheckbox.stories.tsx
@@ -51,6 +51,12 @@ export const Sandbox = () => (
   />
 )
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Tones = () =>
   TOGGLE_TONES.map(tone => (
     <ToggleCheckbox

--- a/src/components/Toggle/ToggleSwitch.stories.tsx
+++ b/src/components/Toggle/ToggleSwitch.stories.tsx
@@ -85,6 +85,12 @@ export const Sandbox = () => {
   )
 }
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Tones = () =>
   TOGGLE_TONES.map(tone => (
     <div key={tone}>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -69,6 +69,12 @@ export const Sandbox = () => (
   </Tooltip>
 )
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Positions = () =>
   POSITIONS.map(position => (
     <Tooltip key={position} label="Tooltip text" position={position}>

--- a/src/components/form/stories/InputField.stories.tsx
+++ b/src/components/form/stories/InputField.stories.tsx
@@ -71,3 +71,9 @@ export const Sandbox = () => {
     </InputField>
   )
 }
+
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}

--- a/src/components/form/stories/InputFieldBlock.stories.tsx
+++ b/src/components/form/stories/InputFieldBlock.stories.tsx
@@ -48,6 +48,12 @@ export const Sandbox = () => {
   )
 }
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Required = () => (
   <InputFieldBlock id="inputFieldBlock" label="Field label" required />
 )

--- a/src/components/form/stories/SelectField.stories.tsx
+++ b/src/components/form/stories/SelectField.stories.tsx
@@ -75,3 +75,9 @@ export const Sandbox = () => {
     </SelectField>
   )
 }
+
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}

--- a/src/components/form/stories/SelectFieldBlock.stories.tsx
+++ b/src/components/form/stories/SelectFieldBlock.stories.tsx
@@ -53,6 +53,12 @@ export const Sandbox = () => {
   )
 }
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Required = () => (
   <SelectFieldBlock
     id="SelectFieldBlock"

--- a/src/components/form/stories/TextAreaField.stories.tsx
+++ b/src/components/form/stories/TextAreaField.stories.tsx
@@ -70,3 +70,9 @@ export const Sandbox = () => {
     </TextAreaField>
   )
 }
+
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}

--- a/src/components/form/stories/TextAreaFieldBlock.stories.tsx
+++ b/src/components/form/stories/TextAreaFieldBlock.stories.tsx
@@ -48,6 +48,12 @@ export const Sandbox = () => {
   )
 }
 
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
 export const Required = () => (
   <TextAreaFieldBlock id="TextAreaFieldBlock" label="Field label" required />
 )


### PR DESCRIPTION
We don't really need to perform visual regression testing for "Sandbox" stories since those usually look the same as their "Basic" counterparts. 

This PR excludes all of the existing "Sandbox" stories from Chromatic checks and updates the `.stories.tsx` template accordingly. 