### PR TITLE
chore: add an util to list prop variations in a sandbox

### DIFF
--- a/src/components/Notification/Notification.stories.tsx
+++ b/src/components/Notification/Notification.stories.tsx
@@ -10,7 +10,7 @@ import {
   NotificationVariant,
   NotificationTone,
 } from "."
-import { StoryUtils } from "../../utils/storybook"
+import { StoryUtils, sandboxWithPropVariations } from "../../utils/storybook"
 import { Button } from "../Button"
 import { radioKnobOptions } from "../../utils/storybook/knobs"
 import { MdSignalWifi1BarLock } from "react-icons/md"
@@ -55,22 +55,30 @@ export const Basic = () => (
   <Notification content="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
 )
 
-export const Sandbox = () => (
-  <Notification
-    content={text(
-      "content",
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    )}
-    variant={radios("variant", variantOptions, `PRIMARY`)}
-    tone={radios("tone", toneOptions, `BRAND`)}
-    contentAs={select("content element", ["div", "span"], "div")}
-    linkUrl={text("linkUrl", "")}
-    linkText={text("linkText", "")}
-    isOpened={boolean("isOpened", true)}
-    showDismissButton={boolean("show dismiss button", false)}
-    dismissButtonLabel={text("dismiss button label", "Close")}
-  />
-)
+export const Sandbox = () =>
+  sandboxWithPropVariations(
+    propVariations => (
+      <Notification
+        content={text(
+          "content",
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+        )}
+        variant={radios("variant", variantOptions, `PRIMARY`)}
+        tone={radios("tone", toneOptions, `BRAND`)}
+        contentAs={select("content element", ["div", "span"], "div")}
+        linkUrl={text("linkUrl", "")}
+        linkText={text("linkText", "")}
+        isOpened={boolean("isOpened", true)}
+        showDismissButton={boolean("show dismiss button", false)}
+        dismissButtonLabel={text("dismiss button label", "Close")}
+        {...propVariations}
+      />
+    ),
+    {
+      variant: VARIANTS,
+      tone: TONES,
+    }
+  )
 
 Sandbox.story = {
   parameters: {

--- a/src/utils/storybook/index.ts
+++ b/src/utils/storybook/index.ts
@@ -1,3 +1,4 @@
 export * from "./knobs"
 export * from "./layoutHelpers"
+export * from "./propsCombinationStory"
 export { default as StoryUtils } from "./StoryUtils"

--- a/src/utils/storybook/propsCombinationStory.tsx
+++ b/src/utils/storybook/propsCombinationStory.tsx
@@ -23,7 +23,6 @@ export function sandboxWithPropVariations<TProps>(
     possibleProps,
     possibleProps[0]
   ) as keyof PossiblePropValues<TProps>
-  console.log({ selectedProp })
   const propVariations = possiblePropValues[selectedProp]
 
   return (

--- a/src/utils/storybook/propsCombinationStory.tsx
+++ b/src/utils/storybook/propsCombinationStory.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { select } from "@storybook/addon-knobs"
+
+type PossiblePropValues<TProps> = {
+  [PropName in keyof TProps]: TProps[PropName][]
+}
+
+type PropVariation<TProps> = {
+  [PropName in keyof TProps]: TProps[PropName]
+}
+
+type SandboxWithPropVariationsStory<TProps> = (
+  propVariation: PropVariation<TProps>
+) => React.ReactNode
+
+export function sandboxWithPropVariations<TProps>(
+  story: SandboxWithPropVariationsStory<TProps>,
+  possiblePropValues: PossiblePropValues<TProps>
+) {
+  const possibleProps = Object.keys(possiblePropValues)
+  const selectedProp = select(
+    "- Show all variations for prop",
+    possibleProps,
+    possibleProps[0]
+  ) as keyof PossiblePropValues<TProps>
+  console.log({ selectedProp })
+  const propVariations = possiblePropValues[selectedProp]
+
+  return (
+    <React.Fragment>
+      {(propVariations || []).map((propValue, idx) => {
+        return (
+          <React.Fragment key={idx}>
+            {story({ [selectedProp]: propValue } as PropVariation<TProps>)}
+          </React.Fragment>
+        )
+      })}
+    </React.Fragment>
+  )
+}


### PR DESCRIPTION
Adds a new Storybook util, `sandboxWithPropVariations`, that allows to display a component with different values for a selected prop via Knobs add-on.

To use this util function, you'll have to update your "Sandbox" story. For example, if you had something like this:
```jsx
const VARIANTS: MyComponentVariant[] = ['foo', 'bar']

export const Sandbox = () => (
  <MyComponent
    children={text('children', 'Lorem ipsum')}
    variant={radios('variant', radioKnobOptions(VARIANTS), 'foo')}
  />
)
```
then you'll need to change it to this:
```jsx
const VARIANTS: MyComponentVariant[] = ['foo', 'bar']

export const Sandbox = () => sandboxWithPropVariations(propVariations => (
  <MyComponent
    children={text('children', 'Lorem ipsum')}
    variant={radios('variant', radioKnobOptions(VARIANTS), 'foo')}
    {...propVariations}
  />
), {
  variant: VARIANTS,
})
```

You can specify possible variations for multiple props and then select which of them do you want to see in Storybook Knobs add-on panel:
<img width="841" alt="Screen Shot 2020-04-08 at 10 19 55 AM" src="https://user-images.githubusercontent.com/4366711/78815147-ab9c1b80-7984-11ea-9b65-ae089a5e2b5f.png">
<img width="1680" alt="Screen Shot 2020-04-08 at 10 22 15 AM" src="https://user-images.githubusercontent.com/4366711/78815153-adfe7580-7984-11ea-8483-e5b73b8b6567.png">


