### PR TITLE
Form updates for radio button block and connected single input blocks

### DIFF
--- a/src/components/form-skeletons/components/CheckboxGroupFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/CheckboxGroupFieldSkeleton.tsx
@@ -46,7 +46,7 @@ export function CheckboxGroupFieldSkeletonError(
 
 export type CheckboxGroupFieldSkeletonOptionProps = Omit<
   FormGroupFieldSkeletonOptionProps,
-  "type" | "ref"
+  "type" | "ref" | "children"
 >
 
 export const CheckboxGroupFieldSkeletonOption = React.forwardRef<

--- a/src/components/form-skeletons/components/RadioButtonFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/RadioButtonFieldSkeleton.tsx
@@ -44,7 +44,7 @@ export function RadioButtonFieldSkeletonError(
 
 export type RadioButtonFieldSkeletonOptionProps = Omit<
   FormGroupFieldSkeletonOptionProps,
-  "type" | "ref"
+  "type" | "ref" | "children"
 >
 
 export const RadioButtonFieldSkeletonOption = React.forwardRef<

--- a/src/components/form/components/CheckboxConnectedField.tsx
+++ b/src/components/form/components/CheckboxConnectedField.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
+import React from "react"
 import { CheckboxFieldBlock } from "./CheckboxFieldBlock"
 import { CheckboxFieldBlockProps } from "./CheckboxFieldBlock"
 import { useConnectedField } from "../hooks/useConnectedField"
@@ -10,10 +11,11 @@ export type CheckboxConnectedFieldProps = {
   label?: React.ReactNode
 } & Omit<CheckboxFieldBlockProps, "id" | "label">
 
-export const CheckboxConnectedField: React.FC<
+export const CheckboxConnectedField = React.forwardRef<
+  HTMLInputElement,
   CheckboxConnectedFieldProps
-> = props => {
+>(function CheckboxConnectedField(props, ref) {
   const [connectedProps] = useConnectedField(props.name)
 
-  return <CheckboxFieldBlock {...connectedProps} {...props} />
-}
+  return <CheckboxFieldBlock ref={ref} {...connectedProps} {...props} />
+})

--- a/src/components/form/components/InputConnectedField.tsx
+++ b/src/components/form/components/InputConnectedField.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
+import React from "react"
 import { InputFieldBlock } from "./InputFieldBlock"
 import { InputFieldBlockProps } from "./InputFieldBlock"
 import { useConnectedField } from "../hooks/useConnectedField"
@@ -10,10 +11,11 @@ export type InputConnectedFieldProps = {
   label?: React.ReactNode
 } & Omit<InputFieldBlockProps, "id" | "label">
 
-export const InputConnectedField: React.FC<
+export const InputConnectedField = React.forwardRef<
+  HTMLInputElement,
   InputConnectedFieldProps
-> = props => {
+>(function InputConnectedField(props, ref) {
   const [connectedProps] = useConnectedField(props.name)
 
-  return <InputFieldBlock {...connectedProps} {...props} />
-}
+  return <InputFieldBlock ref={ref} {...connectedProps} {...props} />
+})

--- a/src/components/form/components/InputFieldBlock.tsx
+++ b/src/components/form/components/InputFieldBlock.tsx
@@ -18,7 +18,7 @@ export type InputFieldBlockProps = WithFormFieldBlock<InputFieldControlProps>
 export const InputFieldBlock = React.forwardRef<
   HTMLInputElement,
   InputFieldBlockProps
->((props, ref) => {
+>(function InputFieldBlock(props, ref) {
   const {
     id,
     label,

--- a/src/components/form/components/RadioButtonField.tsx
+++ b/src/components/form/components/RadioButtonField.tsx
@@ -110,9 +110,10 @@ const getFrameStyles: ThemeCss = theme => ({
 
 export type RadioButtonFieldOptionLabelProps = RadioButtonFieldSkeletonOptionLabelProps &
   FormGroupFieldOptionLabelProps
-export const RadioButtonFieldOptionLabel: React.FC<
-  RadioButtonFieldOptionLabelProps
-> = ({ size, ...rest }) => {
+export const RadioButtonFieldOptionLabel: React.FC<RadioButtonFieldOptionLabelProps> = ({
+  size,
+  ...rest
+}) => {
   const { hasError } = useFormFieldSkeleton()
   const { css, ...styledProps } = useStyledGroupFieldOptionLabel({ size })
   const { variant } = useFormGroupField()
@@ -163,9 +164,7 @@ export type RadioButtonFieldOptionFrameProps = Pick<
   "className" | "style"
 >
 
-export const RadioButtonFieldOptionFrame: React.FC<
-  RadioButtonFieldOptionFrameProps
-> = props => {
+export const RadioButtonFieldOptionFrame: React.FC<RadioButtonFieldOptionFrameProps> = props => {
   const { variant } = useFormGroupField()
 
   return (
@@ -225,4 +224,23 @@ export function RadioButtonFieldOptionWrapper(
   props: RadioButtonFieldOptionWrapperProps
 ) {
   return <FormGroupFieldOptionWrapper {...props} />
+}
+
+export type RadioButtonFieldOptionItemProps = RadioButtonFieldOptionProps & {
+  label: React.ReactNode
+}
+
+export function RadioButtonFieldOptionItem({
+  label,
+  value,
+  ...rest
+}: RadioButtonFieldOptionItemProps) {
+  return (
+    <RadioButtonFieldOptionWrapper>
+      <RadioButtonFieldOption value={value} {...rest} />
+      <RadioButtonFieldOptionLabel optionValue={value}>
+        {label}
+      </RadioButtonFieldOptionLabel>
+    </RadioButtonFieldOptionWrapper>
+  )
 }

--- a/src/components/form/components/RadioButtonFieldBlock.tsx
+++ b/src/components/form/components/RadioButtonFieldBlock.tsx
@@ -11,10 +11,16 @@ import {
   RadioButtonFieldOptionItemProps,
 } from "./RadioButtonField"
 import { WithFormFieldBlock } from "./FormField"
+import { RadioButtonFieldSkeletonOptionProps } from "../../form-skeletons"
+
+export type RadioButtonFieldBlockOption = {
+  label: React.ReactNode
+  value: string
+} & Partial<Omit<RadioButtonFieldSkeletonOptionProps, "label" | "value">>
 
 export type RadioButtonFieldBlockProps = WithFormFieldBlock<
   {
-    options: { label: string; value: any }[]
+    options: RadioButtonFieldBlockOption[]
   } & RadioButtonFieldOptionItemProps
 >
 
@@ -29,7 +35,6 @@ export const RadioButtonFieldBlock = (props: RadioButtonFieldBlockProps) => {
     validationMode,
     value: fieldValue,
     options,
-    children,
     ...rest
   } = props
 
@@ -44,16 +49,16 @@ export const RadioButtonFieldBlock = (props: RadioButtonFieldBlockProps) => {
         {label}
       </RadioButtonFieldLabel>
       <RadioButtonFieldOptions>
-        {children ||
-          options.map(({ label, value }) => (
-            <RadioButtonFieldOptionItem
-              key={value}
-              value={value}
-              checked={value === fieldValue}
-              label={label}
-              {...rest}
-            />
-          ))}
+        {options.map(({ value, label, ...restOption }) => (
+          <RadioButtonFieldOptionItem
+            key={value}
+            value={value}
+            checked={value === fieldValue}
+            label={label}
+            {...rest}
+            {...restOption}
+          />
+        ))}
       </RadioButtonFieldOptions>
       <RadioButtonFieldHint>{hint}</RadioButtonFieldHint>
       <RadioButtonFieldError validationMode={validationMode}>

--- a/src/components/form/components/RadioButtonFieldBlock.tsx
+++ b/src/components/form/components/RadioButtonFieldBlock.tsx
@@ -5,19 +5,17 @@ import {
   RadioButtonField,
   RadioButtonFieldLabel,
   RadioButtonFieldOptions,
-  RadioButtonFieldOptionWrapper,
-  RadioButtonFieldOption,
-  RadioButtonFieldOptionLabel,
   RadioButtonFieldHint,
   RadioButtonFieldError,
-  RadioButtonFieldOptionProps,
+  RadioButtonFieldOptionItem,
+  RadioButtonFieldOptionItemProps,
 } from "./RadioButtonField"
 import { WithFormFieldBlock } from "./FormField"
 
 export type RadioButtonFieldBlockProps = WithFormFieldBlock<
   {
     options: { label: string; value: any }[]
-  } & RadioButtonFieldOptionProps
+  } & RadioButtonFieldOptionItemProps
 >
 
 export const RadioButtonFieldBlock = (props: RadioButtonFieldBlockProps) => {
@@ -31,6 +29,7 @@ export const RadioButtonFieldBlock = (props: RadioButtonFieldBlockProps) => {
     validationMode,
     value: fieldValue,
     options,
+    children,
     ...rest
   } = props
 
@@ -45,18 +44,16 @@ export const RadioButtonFieldBlock = (props: RadioButtonFieldBlockProps) => {
         {label}
       </RadioButtonFieldLabel>
       <RadioButtonFieldOptions>
-        {options.map(({ label, value }) => (
-          <RadioButtonFieldOptionWrapper key={value}>
-            <RadioButtonFieldOption
+        {children ||
+          options.map(({ label, value }) => (
+            <RadioButtonFieldOptionItem
+              key={value}
               value={value}
               checked={value === fieldValue}
+              label={label}
               {...rest}
             />
-            <RadioButtonFieldOptionLabel optionValue={value}>
-              {label}
-            </RadioButtonFieldOptionLabel>
-          </RadioButtonFieldOptionWrapper>
-        ))}
+          ))}
       </RadioButtonFieldOptions>
       <RadioButtonFieldHint>{hint}</RadioButtonFieldHint>
       <RadioButtonFieldError validationMode={validationMode}>

--- a/src/components/form/components/SelectConnectedField.tsx
+++ b/src/components/form/components/SelectConnectedField.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
+import React from "react"
 import { SelectFieldBlock } from "./SelectFieldBlock"
 import { SelectFieldBlockProps } from "./SelectFieldBlock"
 import { useConnectedField } from "../hooks/useConnectedField"
@@ -10,10 +11,11 @@ export type SelectConnectedFieldProps = {
   label?: React.ReactNode
 } & Omit<SelectFieldBlockProps, "id" | "label">
 
-export const SelectConnectedField: React.FC<
+export const SelectConnectedField = React.forwardRef<
+  HTMLSelectElement,
   SelectConnectedFieldProps
-> = props => {
+>(function SelectConnectedField(props, ref) {
   const [connectedProps] = useConnectedField(props.name)
 
-  return <SelectFieldBlock {...connectedProps} {...props} />
-}
+  return <SelectFieldBlock ref={ref} {...connectedProps} {...props} />
+})

--- a/src/components/form/components/TextAreaConnectedField.tsx
+++ b/src/components/form/components/TextAreaConnectedField.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
+import React from "react"
 import { TextAreaFieldBlock } from "./TextAreaFieldBlock"
 import { TextAreaFieldBlockProps } from "./TextAreaFieldBlock"
 import { useConnectedField } from "../hooks/useConnectedField"
@@ -10,10 +11,11 @@ export type TextAreaConnectedFieldProps = {
   label?: React.ReactNode
 } & Omit<TextAreaFieldBlockProps, "id" | "label">
 
-export const TextAreaConnectedField: React.FC<
+export const TextAreaConnectedField = React.forwardRef<
+  HTMLTextAreaElement,
   TextAreaConnectedFieldProps
-> = props => {
+>(function TextAreaConnectedField(props, ref) {
   const [connectedProps] = useConnectedField(props.name)
 
-  return <TextAreaFieldBlock {...connectedProps} {...props} />
-}
+  return <TextAreaFieldBlock ref={ref} {...connectedProps} {...props} />
+})

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -23,3 +23,5 @@ export * from "./components/CheckboxGroupConnectedField"
 export * from "./components/RadioButtonField"
 export * from "./components/RadioButtonFieldBlock"
 export * from "./components/RadioButtonConnectedField"
+
+export { useConnectedField } from "./hooks/useConnectedField"


### PR DESCRIPTION
* Adds a `RadioButtonFieldOptionItem` component that can be used for custom option render in `RadioButtonFieldBlock` or `RadioButtonConnectedField`
* Allow to pass most of `<input>` props in `options` array for `RadioButtonFieldBlock` or `RadioButtonConnectedField`.
* Allows to pass `ref` prop to `CheckboxConnectedField`, `InputConnectedField`, `SelectConnectedField` and `TextAreaFieldBlock` components. This can be used in cases such as setting focus on mount.
* Exposes `useConnectedField` hook