### PR TITLE
fix: SSOT for `tones`

### DIFF
--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -16,7 +16,7 @@ import breakpoints, {
 } from "./breakpoints"
 import transitions, { Transitions } from "./transition"
 import { AtomTone } from "./types"
-import { ToneColors } from "./tones"
+import tones, { ToneColors } from "./tones"
 import { Interpolation, InterpolationWithTheme } from "@emotion/core"
 
 /**
@@ -31,48 +31,7 @@ const themeColors: ColorScale = colors
  */
 type ToneScale = Record<AtomTone, ToneColors>
 
-const themeTones: ToneScale = {
-  BRAND: {
-    superLight: themeColors.purple[5],
-    light: themeColors.purple[20],
-    medium: themeColors.purple[40],
-    dark: themeColors.purple[60],
-    darker: themeColors.purple[70],
-    superDark: themeColors.purple[90],
-  },
-  SUCCESS: {
-    superLight: themeColors.green[5],
-    light: themeColors.green[20],
-    medium: themeColors.green[50],
-    dark: themeColors.green[60],
-    darker: themeColors.green[70],
-    superDark: themeColors.green[80],
-  },
-  DANGER: {
-    superLight: themeColors.red[5],
-    light: themeColors.red[20],
-    medium: themeColors.red[50],
-    dark: themeColors.red[70],
-    darker: themeColors.red[80],
-    superDark: themeColors.red[90],
-  },
-  NEUTRAL: {
-    superLight: themeColors.grey[5],
-    light: themeColors.grey[20],
-    medium: themeColors.grey[40],
-    dark: themeColors.grey[50],
-    darker: themeColors.grey[60],
-    superDark: themeColors.grey[90],
-  },
-  WARNING: {
-    superLight: themeColors.orange[5],
-    light: themeColors.orange[30],
-    medium: themeColors.orange[50],
-    dark: themeColors.orange[60],
-    darker: themeColors.orange[70],
-    superDark: themeColors.yellow[90],
-  },
-}
+const themeTones: ToneScale = tones
 
 /**
  * Font families

--- a/src/theme/tones.ts
+++ b/src/theme/tones.ts
@@ -14,7 +14,7 @@ const tones: Record<AtomTone, ToneColors> = {
   BRAND: {
     superLight: colors.purple[5],
     light: colors.purple[20],
-    medium: colors.purple[50],
+    medium: colors.purple[40],
     dark: colors.purple[60],
     darker: colors.purple[70],
     superDark: colors.purple[90],
@@ -25,7 +25,7 @@ const tones: Record<AtomTone, ToneColors> = {
     medium: colors.green[50],
     dark: colors.green[60],
     darker: colors.green[70],
-    superDark: colors.green[90],
+    superDark: colors.green[80],
   },
   DANGER: {
     superLight: colors.red[5],
@@ -44,11 +44,11 @@ const tones: Record<AtomTone, ToneColors> = {
     superDark: colors.grey[90],
   },
   WARNING: {
-    superLight: colors.yellow[5],
-    light: colors.yellow[20],
-    medium: colors.yellow[40],
-    dark: colors.yellow[50],
-    darker: colors.yellow[60],
+    superLight: colors.orange[5],
+    light: colors.orange[30],
+    medium: colors.orange[50],
+    dark: colors.orange[60],
+    darker: colors.orange[70],
     superDark: colors.yellow[90],
   },
 }


### PR DESCRIPTION
Noticed today that we seem to have two places where the `TONE` scale is defined:

1. https://github.com/gatsby-inc/gatsby-interface/blob/e91f105c556752717ec5ded781c9efd64575832f/src/theme/index.ts#L34-L75
2. https://github.com/gatsby-inc/gatsby-interface/blob/e91f105c556752717ec5ded781c9efd64575832f/src/theme/tones.ts#L13-L54

The one in `theme/index` is the more recent one, with adjusted `WARNING` colors: Latter adjustments happened in

- #242 / https://github.com/gatsby-inc/gatsby-interface/pull/242/files#diff-42c090954509eda0d00c8ebb63467ec1
- #293 / https://github.com/gatsby-inc/gatsby-interface/pull/293/files#diff-42c090954509eda0d00c8ebb63467ec1

This PR consolidates the two definitions.  
(Let the TS lottery being … 😅🤞)