### PR TITLE
chore: Use `border` instead of `boxShadow` for badge; add `tone.lighter`

### DIFF
--- a/src/components/Badge/Badge.helpers.tsx
+++ b/src/components/Badge/Badge.helpers.tsx
@@ -7,8 +7,8 @@ const variants: Record<BadgeVariant, GetVariantStylesFn> = {
   STATUS: tone => {
     return theme => [
       {
-        boxShadow: `0 0 1px 0 ${theme.tones[tone].light} inset`,
         background: theme.tones[tone].superLight,
+        border: `1px solid ${theme.tones[tone].light}`,
         color: theme.tones[tone].darker,
       },
       (tone === "WARNING" || tone === "SUCCESS") && {

--- a/src/components/Badge/Badge.helpers.tsx
+++ b/src/components/Badge/Badge.helpers.tsx
@@ -8,7 +8,7 @@ const variants: Record<BadgeVariant, GetVariantStylesFn> = {
     return theme => [
       {
         background: theme.tones[tone].superLight,
-        border: `1px solid ${theme.tones[tone].light}`,
+        border: `1px solid ${theme.tones[tone].lighter}`,
         color: theme.tones[tone].darker,
       },
       (tone === "WARNING" || tone === "SUCCESS") && {

--- a/src/components/PlanIndicator/PlanIndicator.tsx
+++ b/src/components/PlanIndicator/PlanIndicator.tsx
@@ -14,21 +14,25 @@ const baseCss: ThemeCss = _theme => ({
 })
 
 const planTypeFreeCss: ThemeCss = theme => ({
+  borderColor: theme.colors.orange[10],
   backgroundColor: theme.colors.orange[10],
   color: theme.colors.orange[90],
 })
 
 const planTypeProfessionalCss: ThemeCss = theme => ({
+  borderColor: theme.colors.blue[10],
   backgroundColor: theme.colors.blue[10],
   color: theme.colors.blue[90],
 })
 
 const planTypeBusinessCss: ThemeCss = theme => ({
+  borderColor: theme.colors.purple[10],
   backgroundColor: theme.colors.purple[10],
   color: theme.colors.purple[70],
 })
 
 const planTypeEnterpriseCss: ThemeCss = theme => ({
+  borderColor: theme.colors.purple[80],
   backgroundColor: theme.colors.purple[80],
   color: theme.colors.white,
 })

--- a/src/theme/tones.ts
+++ b/src/theme/tones.ts
@@ -3,6 +3,7 @@ import { AtomTone } from "./types"
 
 export type ToneColors = {
   superLight: string
+  lighter: string
   light: string
   medium: string
   dark: string
@@ -13,6 +14,7 @@ export type ToneColors = {
 const tones: Record<AtomTone, ToneColors> = {
   BRAND: {
     superLight: colors.purple[5],
+    lighter: colors.purple[10],
     light: colors.purple[20],
     medium: colors.purple[40],
     dark: colors.purple[60],
@@ -21,6 +23,7 @@ const tones: Record<AtomTone, ToneColors> = {
   },
   SUCCESS: {
     superLight: colors.green[5],
+    lighter: colors.green[10],
     light: colors.green[20],
     medium: colors.green[50],
     dark: colors.green[60],
@@ -29,6 +32,7 @@ const tones: Record<AtomTone, ToneColors> = {
   },
   DANGER: {
     superLight: colors.red[5],
+    lighter: colors.red[10],
     light: colors.red[20],
     medium: colors.red[50],
     dark: colors.red[70],
@@ -37,6 +41,7 @@ const tones: Record<AtomTone, ToneColors> = {
   },
   NEUTRAL: {
     superLight: colors.grey[5],
+    lighter: colors.grey[10],
     light: colors.grey[20],
     medium: colors.grey[40],
     dark: colors.grey[50],
@@ -45,6 +50,7 @@ const tones: Record<AtomTone, ToneColors> = {
   },
   WARNING: {
     superLight: colors.orange[5],
+    lighter: colors.orange[10],
     light: colors.orange[30],
     medium: colors.orange[50],
     dark: colors.orange[60],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21834/80265382-aedb1b00-8697-11ea-852e-00010eb3bf54.png)

- chore: use `border` instead of `boxShadow` for `<Badge>`
  - `minHeight` and `box-sizing: border-box` got our back
  - let's stick to one strategy for displaying a border for now
  - makes borders slightly more prominent
- chore: introduce `tone.lighter` and use it as `border` color for `<Badge>`
  - tone.light is only used for Badge.STATUS and button.SECONDARY borders
  - for button.SECONDARY, we want slightly darker borders
  - nicely fills the gap between `superLight` and `light` (as opposed to `dark`, `darker`, `superDark`)