### PR TITLE
chore: Use Badge instead of Chip for `StoryUtils.Default`

### DIFF
--- a/src/utils/storybook/StoryUtils.tsx
+++ b/src/utils/storybook/StoryUtils.tsx
@@ -3,7 +3,7 @@ import { jsx } from "@emotion/core"
 
 import { MdInfoOutline } from "react-icons/md"
 import colors from "../../theme/colors"
-import { Chip } from "../../components/Chip"
+import { Badge } from "../../components/Badge"
 
 type StoryUtilWrapperProps = Omit<JSX.IntrinsicElements["div"], "ref">
 
@@ -76,12 +76,15 @@ const StoryUtilsContent = ({
 )
 
 const StoryUtilsDefault = () => (
-  <Chip
-    icon={<MdInfoOutline />}
-    css={theme => ({ marginLeft: theme.space[8], verticalAlign: `middle` })}
+  <Badge
+    Icon={MdInfoOutline}
+    size="S"
+    tone="NEUTRAL"
+    textVariant="DEFAULT"
+    css={theme => ({ marginLeft: theme.space[5], verticalAlign: `middle` })}
   >
     Default
-  </Chip>
+  </Badge>
 )
 
 export default {

--- a/src/utils/storybook/StoryUtils.tsx
+++ b/src/utils/storybook/StoryUtils.tsx
@@ -81,7 +81,7 @@ const StoryUtilsDefault = () => (
     size="S"
     tone="NEUTRAL"
     textVariant="DEFAULT"
-    css={theme => ({ marginLeft: theme.space[5], verticalAlign: `middle` })}
+    css={theme => ({ marginLeft: theme.space[4], verticalAlign: `middle` })}
   >
     Default
   </Badge>


### PR DESCRIPTION
Actually like the `Chip` look-and-feel more, but this is about semantics ;) …

![image](https://user-images.githubusercontent.com/21834/80268966-0b483580-86ac-11ea-9ee9-15446e6fcbdc.png)
