### PR TITLE
feat: Make `<Button>` transitions snappier, use theme tokens

### DIFF
--- a/src/components/CopyButton/__tests__/__snapshots__/CopyButton.test.tsx.snap
+++ b/src/components/CopyButton/__tests__/__snapshots__/CopyButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<CopyButton> renders unchanged 1`] = `
 <div>
   <button
-    class="css-1spz73u-baseCss"
+    class="css-f0zj64-baseCss"
     title="Copy to clipboard"
     type="button"
   >

--- a/src/theme/styles/button.ts
+++ b/src/theme/styles/button.ts
@@ -46,7 +46,7 @@ function getButtonBaseCss(textVariant?: ButtonTextVariant): ThemeCss {
     fontFamily:
       textVariant === "BRAND" ? theme.fonts.heading : theme.fonts.body,
     justifyContent: `center`,
-    transition: `background ${theme.transitions.speed.slow}, border ${theme.transitions.speed.slow}, color ${theme.transitions.speed.slow}`,
+    transition: `background ${theme.transitions.speed.default}, border ${theme.transitions.speed.default}, color ${theme.transitions.speed.default}`,
     lineHeight: theme.lineHeights.solid,
     textDecoration: `none`,
 

--- a/src/theme/styles/button.ts
+++ b/src/theme/styles/button.ts
@@ -46,7 +46,7 @@ function getButtonBaseCss(textVariant?: ButtonTextVariant): ThemeCss {
     fontFamily:
       textVariant === "BRAND" ? theme.fonts.heading : theme.fonts.body,
     justifyContent: `center`,
-    transition: `background 0.5s, border 0.5s, color 0.5s`,
+    transition: `background ${theme.transitions.speed.slow}, border ${theme.transitions.speed.slow}, color ${theme.transitions.speed.slow}`,
     lineHeight: theme.lineHeights.solid,
     textDecoration: `none`,
 


### PR DESCRIPTION
- use `transition` tokens for transition durations
- make transitions snappier: change transition duration from `500ms` to `250ms`

Fixes #304