### PR TITLE
Expose hexToRGB and hexToRGBA helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,3 +52,5 @@ export { default as space } from "./theme/space"
 export { default as shadows } from "./theme/shadows"
 export { default as zIndices } from "./theme/zIndices"
 export { default as transition } from "./theme/transition"
+
+export { hexToRGB, hexToRGBA } from "./utils/helpers/hexToRgb"


### PR DESCRIPTION
# Purpose

Addresses [`ch4851`](https://app.clubhouse.io/gatsbyjs/story/4851/hextorgba-helpers-should-be-exposed-by-gatsby-interface).