### PR TITLE
fix: various Combobox fixes

### DIFF
--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -58,7 +58,7 @@ const options: ComboboxOptionProps[] = [
 
 export const Basic = () => {
   return (
-    <div>
+    <div css={{ minHeight: `100vh` }}>
       <h4 id="demo">Basic, fixed List Combobox</h4>
       <Combobox>
         <ComboboxInput

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -110,6 +110,27 @@ Sandbox.story = {
   },
 }
 
+export const WithAccessibleNameForList = () => {
+  return (
+    <div>
+      <h4 id="demo">Combobox with an explicit accessible label</h4>
+      <Combobox>
+        <ComboboxInput
+          aria-labelledby="demo"
+          ref={element => element && element.focus()}
+        />
+        <ComboboxPopover>
+          <ComboboxList aria-label="Grocery list">
+            {options.map(({ value }) => {
+              return <ComboboxOption key={value} value={value} />
+            })}
+          </ComboboxList>
+        </ComboboxPopover>
+      </Combobox>
+    </div>
+  )
+}
+
 export const WithSelect = () => {
   const [term, setTerm] = React.useState("")
 

--- a/src/components/Combobox/Combobox.styles.tsx
+++ b/src/components/Combobox/Combobox.styles.tsx
@@ -57,6 +57,7 @@ export const selectedValueCss: ThemeCss = theme => ({
   opacity: 0,
   transform: `translate3d(0.8rem, 1.1rem, 0)`,
   transition: `all ${theme.transitions.curve.default} ${theme.transitions.speed.default}`,
+  pointerEvents: `none`,
 })
 
 export const listCss: ThemeCss = () => ({

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -30,6 +30,7 @@ import {
 } from "./Combobox.styles"
 import { warn } from "../../utils/maintenance/warn"
 import { RequireProp } from "../../utils/types"
+import { DisableReachStyleCheck } from "../../utils/helpers/DisableReachStyleCheck"
 
 type ComboboxCustomContextValue = {
   listRef: React.RefObject<HTMLUListElement>
@@ -52,6 +53,7 @@ export function Combobox(props: ComboboxProps) {
 
   return (
     <ComboboxCustomContext.Provider value={{ listRef }}>
+      <DisableReachStyleCheck reachComponent="combobox" />
       <ReachCombobox openOnFocus css={comboboxCss} {...props} />
     </ComboboxCustomContext.Provider>
   )

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -28,6 +28,8 @@ import {
   selectedValueCss,
   inputWithSelectedValueCss,
 } from "./Combobox.styles"
+import { warn } from "../../utils/maintenance/warn"
+import { RequireProp } from "../../utils/types"
 
 type ComboboxCustomContextValue = {
   listRef: React.RefObject<HTMLUListElement>
@@ -145,19 +147,35 @@ export const ComboboxPopover = React.forwardRef<
   ComboboxPopoverProps
 >(function ComboboxPopover(props, ref) {
   return (
-    <ReachComboboxPopover
-      ref={ref}
-      portal={false}
-      css={popoverCss}
-      {...props}
-    />
+    <ReachComboboxPopover ref={ref} portal={true} css={popoverCss} {...props} />
   )
 })
 
-export type ComboboxListProps = PropsWithAs<"ul", ReachComboboxListProps>
+type ComboboxListBaseProps = PropsWithAs<"ul", ReachComboboxListProps>
+
+/**
+ * ComboboxList renders an element with role="listbox"
+ * which must have an accessible name (https://dequeuniversity.com/rules/axe/3.5/aria-input-field-name?application=AxeChrome)
+ * therefore we require "aria-label" or "aria-labelledby" to be passed
+ */
+export type ComboboxListProps =
+  | RequireProp<ComboboxListBaseProps, "aria-label">
+  | RequireProp<ComboboxListBaseProps, "aria-labelledby">
 
 export function ComboboxList(props: ComboboxListProps) {
   const { listRef } = useComboboxCustomContext()
+
+  if (process.env.NODE_ENV === `development`) {
+    const hasAccessibleName = Boolean(
+      props["aria-label"] || props["aria-labelledby"]
+    )
+    if (!hasAccessibleName) {
+      warn(
+        `<ComboboxList /> is missing one of the required props: "aria-label", "aria-labelledby"`
+      )
+    }
+  }
+
   return (
     <ReachComboboxList
       ref={listRef}

--- a/src/components/Combobox/__tests__/Combobox.test.tsx
+++ b/src/components/Combobox/__tests__/Combobox.test.tsx
@@ -1,0 +1,16 @@
+import { renderWithTheme as render } from "../../../utils/testing"
+import { Basic, WithAccessibleNameForList } from "../Combobox.stories"
+
+describe(`Combobox`, () => {
+  it(`allows to link the combobox list to an accessible label`, () => {
+    const { getByRole } = render(Basic())
+
+    expect(getByRole(`listbox`)).toHaveAttribute("aria-labelledby", "demo")
+  })
+
+  it(`allows to provide an explicit accessible name to the combobox list`, () => {
+    const { getByRole } = render(WithAccessibleNameForList())
+
+    expect(getByRole(`listbox`)).toHaveAttribute("aria-label", "Grocery list")
+  })
+})

--- a/src/utils/maintenance/deprecationMessages.ts
+++ b/src/utils/maintenance/deprecationMessages.ts
@@ -1,10 +1,10 @@
-import showDeprecationMessage from "./showDeprecationMessage"
+import { warn } from "./warn"
 
 export function showCustomCssDeprecationMessage(customCss: any) {
   if (customCss === undefined) {
     return
   }
-  showDeprecationMessage(
+  warn(
     `Styling components via "customCss" prop is deprecated, please use Emotion "css" prop or pass a "className"`
   )
 }

--- a/src/utils/maintenance/warn.ts
+++ b/src/utils/maintenance/warn.ts
@@ -1,7 +1,4 @@
-export default function showDeprecationMessage(
-  message: string,
-  level: `warning` | `error` = `warning`
-) {
+export function warn(message: string, level: `warning` | `error` = `warning`) {
   if (process.env.NODE_ENV === `development`) {
     if (level === `error`) {
       console.error(message)

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,3 +10,9 @@ export type PropsOf<Tag> = Tag extends keyof JSX.IntrinsicElements
   : Tag extends React.ComponentType<infer Props>
   ? Props & JSX.IntrinsicAttributes
   : never
+
+export type RequireProp<TProps, TPropName extends keyof TProps> = Omit<
+  TProps,
+  TPropName
+> &
+  Required<Pick<TProps, TPropName>>


### PR DESCRIPTION
* Allow clicks through the displayed selected value (when `selectedOptionLabel` is passed); otherwise users would not be able to reopen the popover by clicking into the input once they select an option.
* Require to explicitly pass `aria-labelledby` or `aria-label` to the `ComboboxList` component.  
* Display options popover in a portal by default