### PR TITLE
Adding Trialing (professional trial) as a plan

### DIFF
--- a/src/components/PlanIndicator/PlanIndicator.stories.tsx
+++ b/src/components/PlanIndicator/PlanIndicator.stories.tsx
@@ -20,6 +20,7 @@ const PLAN_TYPES: PlanIndicatorPlanType[] = [
   `PROFESSIONAL`,
   `BUSINESS`,
   `ENTERPRISE`,
+  `TRIALING`,
 ]
 
 export const Sandbox = () => (

--- a/src/components/PlanIndicator/PlanIndicator.tsx
+++ b/src/components/PlanIndicator/PlanIndicator.tsx
@@ -37,11 +37,18 @@ const planTypeEnterpriseCss: ThemeCss = theme => ({
   color: theme.colors.white,
 })
 
+const planTypeTrialingCss: ThemeCss = theme => ({
+  borderColor: theme.colors.green[10],
+  backgroundColor: theme.colors.green[10],
+  color: theme.colors.green[70],
+})
+
 const planTypeCss: Record<PlanIndicatorPlanType, ThemeCss> = {
   FREE: planTypeFreeCss,
   PROFESSIONAL: planTypeProfessionalCss,
   BUSINESS: planTypeBusinessCss,
   ENTERPRISE: planTypeEnterpriseCss,
+  TRIALING: planTypeTrialingCss,
 }
 
 const planTypeLabels: Record<PlanIndicatorPlanType, string> = {
@@ -49,13 +56,18 @@ const planTypeLabels: Record<PlanIndicatorPlanType, string> = {
   PROFESSIONAL: `Professional`,
   BUSINESS: `Business`,
   ENTERPRISE: `Enterprise`,
+  TRIALING: "Professional Trial",
 }
 
-const planTypeIcons: Record<PlanIndicatorPlanType, React.ComponentType> = {
+const planTypeIcons: Record<
+  PlanIndicatorPlanType,
+  React.ComponentType | undefined
+> = {
   FREE: FreePlanIcon,
   PROFESSIONAL: ProfessionalPlanIcon,
   BUSINESS: BusinessPlanIcon,
   ENTERPRISE: EnterprisePlanIcon,
+  TRIALING: undefined,
 }
 
 export type PlanIndicatorPlanType =
@@ -63,6 +75,7 @@ export type PlanIndicatorPlanType =
   | `PROFESSIONAL`
   | `BUSINESS`
   | `ENTERPRISE`
+  | `TRIALING`
 
 export type PlanIndicatorProps = {
   planType: PlanIndicatorPlanType

--- a/src/components/PlanIndicator/PlanIndicator.tsx
+++ b/src/components/PlanIndicator/PlanIndicator.tsx
@@ -61,13 +61,13 @@ const planTypeLabels: Record<PlanIndicatorPlanType, string> = {
 
 const planTypeIcons: Record<
   PlanIndicatorPlanType,
-  React.ComponentType | undefined
+  React.ComponentType | null
 > = {
   FREE: FreePlanIcon,
   PROFESSIONAL: ProfessionalPlanIcon,
   BUSINESS: BusinessPlanIcon,
   ENTERPRISE: EnterprisePlanIcon,
-  TRIALING: undefined,
+  TRIALING: null,
 }
 
 export type PlanIndicatorPlanType =

--- a/src/components/PlanIndicator/PlanIndicator.tsx
+++ b/src/components/PlanIndicator/PlanIndicator.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
 import { ThemeCss } from "../../theme"
-import { Badge } from "../Badge"
+import { Badge, BadgeProps } from "../Badge"
 import {
   FreePlanIcon,
   ProfessionalPlanIcon,
@@ -59,15 +59,12 @@ const planTypeLabels: Record<PlanIndicatorPlanType, string> = {
   TRIALING: "Professional Trial",
 }
 
-const planTypeIcons: Record<
-  PlanIndicatorPlanType,
-  React.ComponentType | null
-> = {
+const planTypeIcons: Record<PlanIndicatorPlanType, BadgeProps["Icon"]> = {
   FREE: FreePlanIcon,
   PROFESSIONAL: ProfessionalPlanIcon,
   BUSINESS: BusinessPlanIcon,
   ENTERPRISE: EnterprisePlanIcon,
-  TRIALING: null,
+  TRIALING: undefined,
 }
 
 export type PlanIndicatorPlanType =


### PR DESCRIPTION
We need to add the trialing / professional plan as a badge 

This badge doesn't have an icon and is in green

<img width="347" alt="Screenshot 2020-04-30 at 18 26 29" src="https://user-images.githubusercontent.com/3874873/80734883-24b80a00-8b10-11ea-98ec-49254126b2ae.png">
