### PR TITLE
chore: Realign `SidebarNav` subitems to save horizontal space

### DIFF
--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -153,8 +153,12 @@ function SidebarNavListItem({
               key={subItem.to}
               css={(theme: Theme) => [
                 {
-                  padding: `${theme.space[3]} ${theme.space[5]}`,
+                  paddingTop: theme.space[3],
+                  paddingRight: theme.space[5],
+                  paddingBottom: theme.space[3],
+                  paddingLeft: theme.space[6],
                   marginBottom: `0`,
+                  marginLeft: `calc(-${theme.space[6]} - 1px)`,
                   borderLeft: `1px solid ${theme.colors.grey[30]}`,
                 },
                 subItem.active && {

--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -156,9 +156,9 @@ function SidebarNavListItem({
                   paddingTop: theme.space[3],
                   paddingRight: theme.space[5],
                   paddingBottom: theme.space[3],
-                  paddingLeft: theme.space[6],
+                  paddingLeft: `calc(${theme.space[6]} + 1px)`,
                   marginBottom: `0`,
-                  marginLeft: `calc(-${theme.space[6]} - 1px)`,
+                  marginLeft: `calc(-${theme.space[6]} - 2px)`,
                   borderLeft: `1px solid ${theme.colors.grey[30]}`,
                 },
                 subItem.active && {


### PR DESCRIPTION
Saves a bit of horizontal space, and (subjectively ;)) feels better — before/after:

![image](https://user-images.githubusercontent.com/21834/80849435-6a132f00-8c17-11ea-9c55-3d9cb6a069ee.png)
