### PR TITLE
chore: Remove `SidebarNav variant="FULL"`

### DIFF
--- a/src/components/SidebarNav/SidebarNav.stories.tsx
+++ b/src/components/SidebarNav/SidebarNav.stories.tsx
@@ -10,19 +10,8 @@ import {
   SkullIcon,
   GeneralIcon,
 } from "../icons"
-import {
-  SidebarNav,
-  SidebarNavOption,
-  SidebarNavProps,
-  SidebarNavVariant,
-} from "./"
-import {
-  radioKnobOptions,
-  withVariationsContainer,
-} from "../../utils/storybook"
-import { radios, text } from "@storybook/addon-knobs"
-
-const SIDEBAR_NAV_VARIANTS: SidebarNavVariant[] = [`DEFAULT`, `FULL`]
+import { SidebarNav, SidebarNavOption, SidebarNavProps } from "./"
+import { text } from "@storybook/addon-knobs"
 
 export default {
   title: `SidebarNav`,
@@ -41,12 +30,7 @@ export const Basic = () => <SidebarNavExample />
 
 export const Sandbox = () => (
   <SidebarNavExample
-    variant={radios(
-      "variant",
-      radioKnobOptions(SIDEBAR_NAV_VARIANTS),
-      `DEFAULT`
-    )}
-    aria-label={text("accessible label", "Sandbox navigation")}
+    aria-label={text("Accessible label", "Sandbox navigation")}
   />
 )
 
@@ -54,18 +38,6 @@ Sandbox.story = {
   parameters: {
     chromatic: { disable: true },
   },
-}
-
-export const Variants = () =>
-  SIDEBAR_NAV_VARIANTS.map(variant => (
-    <React.Fragment key={variant}>
-      <h3>{variant}:</h3>
-      <SidebarNavExample key={variant} variant={variant} />
-    </React.Fragment>
-  ))
-
-Variants.story = {
-  decorators: [withVariationsContainer],
 }
 
 const SidebarNavExample = (props: Partial<SidebarNavProps>) => {

--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -42,7 +42,7 @@ export default function SidebarNav({ options, ...rest }: SidebarNavProps) {
 
 type SidebarNavListProps = JSX.IntrinsicElements["ul"]
 
-function SidebarNavList({ ...rest }: SidebarNavListProps) {
+function SidebarNavList(props: SidebarNavListProps) {
   return (
     <ul
       css={[
@@ -52,7 +52,7 @@ function SidebarNavList({ ...rest }: SidebarNavListProps) {
           padding: 0,
         },
       ]}
-      {...rest}
+      {...props}
     />
   )
 }

--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -16,18 +16,11 @@ export type SidebarNavOption = SidebarNavItem & {
   subItems?: SidebarNavItem[]
 }
 
-export type SidebarNavVariant = `DEFAULT` | `FULL`
-
 export type SidebarNavProps = JSX.IntrinsicElements["nav"] & {
   options?: SidebarNavOption[]
-  variant?: SidebarNavVariant
 }
 
-export default function SidebarNav({
-  options,
-  variant,
-  ...rest
-}: SidebarNavProps) {
+export default function SidebarNav({ options, ...rest }: SidebarNavProps) {
   return (
     <nav
       aria-label="sidebar navigation"
@@ -37,7 +30,7 @@ export default function SidebarNav({
       {...rest}
     >
       {options && (
-        <SidebarNavList variant={variant}>
+        <SidebarNavList>
           {options.map(option => {
             return <SidebarNavListItem key={option.to} {...option} />
           })}
@@ -47,11 +40,9 @@ export default function SidebarNav({
   )
 }
 
-type SidebarNavListProps = JSX.IntrinsicElements["ul"] & {
-  variant?: SidebarNavVariant
-}
+type SidebarNavListProps = JSX.IntrinsicElements["ul"]
 
-function SidebarNavList({ variant = `DEFAULT`, ...rest }: SidebarNavListProps) {
+function SidebarNavList({ ...rest }: SidebarNavListProps) {
   return (
     <ul
       css={[
@@ -60,7 +51,6 @@ function SidebarNavList({ variant = `DEFAULT`, ...rest }: SidebarNavListProps) {
           margin: 0,
           padding: 0,
         },
-        variant === `FULL` && { maxWidth: `8rem` },
       ]}
       {...rest}
     />

--- a/src/components/SidebarNav/index.ts
+++ b/src/components/SidebarNav/index.ts
@@ -1,12 +1,10 @@
 import {
   SidebarNavProps as SidebarNavPropsDefinition,
-  SidebarNavVariant as SidebarNavVariantDefinition,
   SidebarNavOption as SidebarNavOptionDefinition,
   SidebarNavItem as SidebarNavItemDefinition,
 } from "./SidebarNav"
 
 export type SidebarNavProps = SidebarNavPropsDefinition
-export type SidebarNavVariant = SidebarNavVariantDefinition
 export type SidebarNavOption = SidebarNavOptionDefinition
 export type SidebarNavItem = SidebarNavItemDefinition
 


### PR DESCRIPTION
…and thus all variants of the component:

- Not used in Gatsby Cloud.
- `maxWidth: 8rem` that the `FULL` variant sets on `SidebarNavList` could be set on its parent `SidebarNav` via Emotion's `css` prop or `styled` (at `10rem`, taking `SidebarNav`s `padding-left` into account).
- Remove `Variants` story, knob in `Sandbox` story.

Fixes #326