### PR TITLE
Unpin gatsby peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@emotion/core": "^10.0.14",
     "@emotion/styled": "^10.0.14",
     "formik": "^2.0.8",
-    "gatsby": "2.6.0",
+    "gatsby": "^2.6.0",
     "prop-types": "^15.6.1",
     "react": "16.8.1",
     "react-dom": "16.8.1",


### PR DESCRIPTION
Pinning the peer dependency version of Gatsby is leading to users complaining about mismatched peer deps now that `gatsby-interface` is installed with every `gatsby` install: https://github.com/gatsbyjs/gatsby/issues/24653

I might be missing the reasoning behind it, so feel free to suggest a better solution, but this PR adds a caret to the peer dep which will resolve this issue.