### PR TITLE
chore: do not stop CI jobs on failed Chromatic test

### DIFF
--- a/scripts/run-chromatic.js
+++ b/scripts/run-chromatic.js
@@ -18,7 +18,7 @@ const runCommand = command => {
 const branch = process.env.CIRCLE_BRANCH
 
 if (branch !== `master`) {
-  runCommand(`yarn chromatic`)
+  runCommand(`yarn chromatic --exit-zero-on-changes`)
 } else {
   // We know any changes that make it to master *must* have been approved
   runCommand(`yarn chromatic --auto-accept-changes`)


### PR DESCRIPTION
This PR stops CI `is-green` check from failing if there were any visual regressions detected by Chromatic, as this doesn't make any sense when `UI Tests` and `UI review` checks are already required for merge. 