### PR TITLE
Color contrast tweaks for several PlanIndicator variants

### DIFF
--- a/src/components/PlanIndicator/PlanIndicator.tsx
+++ b/src/components/PlanIndicator/PlanIndicator.tsx
@@ -16,7 +16,7 @@ const baseCss: ThemeCss = _theme => ({
 const planTypeFreeCss: ThemeCss = theme => ({
   borderColor: theme.colors.orange[10],
   backgroundColor: theme.colors.orange[10],
-  color: theme.colors.orange[90],
+  color: theme.colors.red[70],
 })
 
 const planTypeProfessionalCss: ThemeCss = theme => ({
@@ -40,7 +40,7 @@ const planTypeEnterpriseCss: ThemeCss = theme => ({
 const planTypeTrialingCss: ThemeCss = theme => ({
   borderColor: theme.colors.green[10],
   backgroundColor: theme.colors.green[10],
-  color: theme.colors.green[70],
+  color: theme.colors.green[90],
 })
 
 const planTypeCss: Record<PlanIndicatorPlanType, ThemeCss> = {


### PR DESCRIPTION
The existing color contrast for the "Free" and "Professional Trial" variants of PlanIndicator don't have sufficient contrast. To remedy that, I've changed the text colors for both.

Note that the "Free" plan was only the darkest/highest contrast orange value available, which I why I switched to a red value. To me it still seems complementary. Thoughts, @fk ?

![CleanShot 2020-06-22 at 15 52 55@2x](https://user-images.githubusercontent.com/3461087/85334590-21eaed00-b4a1-11ea-98a6-4828a5f36c62.png)
