### PR TITLE
chore: add deprecation notice to *FieldSkeleton and *Field components

### DIFF
--- a/src/components/form-skeletons/components/CheckboxFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/CheckboxFieldSkeleton.tsx
@@ -12,9 +12,11 @@ import {
 } from "./FormFieldSkeleton"
 import { getFinalAriaDescribedBy } from "../utils"
 import { OmitControlProps } from "../sharedTypes"
+import { showFormSkeletonDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type CheckboxFieldSkeletonProps = FormFieldSkeletonProps
 export function CheckboxFieldSkeleton(props: CheckboxFieldSkeletonProps) {
+  showFormSkeletonDeprecatedMessage("CheckboxFieldSkeleton")
   return <FormFieldSkeleton {...props} />
 }
 

--- a/src/components/form-skeletons/components/CheckboxGroupFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/CheckboxGroupFieldSkeleton.tsx
@@ -15,11 +15,13 @@ import {
   FormGroupFieldSkeletonOptionLabel,
   FormGroupFieldSkeletonOptionLabelProps,
 } from "./FormGroupFieldSkeleton"
+import { showFormSkeletonDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type CheckboxGroupFieldSkeletonProps = FormGroupFieldSkeletonProps
 export function CheckboxGroupFieldSkeleton(
   props: CheckboxGroupFieldSkeletonProps
 ) {
+  showFormSkeletonDeprecatedMessage("CheckboxGroupFieldSkeleton", true)
   return <FormGroupFieldSkeleton {...props} />
 }
 

--- a/src/components/form-skeletons/components/FormFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/FormFieldSkeleton.tsx
@@ -3,6 +3,7 @@ import { jsx } from "@emotion/core"
 import React from "react"
 import { getHintId, getErrorId, getErrorAriaLiveAttribute } from "../utils"
 import { ErrorValidationMode } from "../types"
+import { showFormSkeletonDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type FormFieldSkeletonContextValue = {
   id: string
@@ -121,6 +122,7 @@ export const FormFieldSkeletonError: React.FC<FormFieldSkeletonErrorProps> = ({
 }
 
 export function FormFieldSkeleton(props: FormFieldSkeletonProps) {
+  showFormSkeletonDeprecatedMessage("FormFieldSkeleton")
   return <FormFieldSkeletonProvider {...props} />
 }
 

--- a/src/components/form-skeletons/components/FormGroupFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/FormGroupFieldSkeleton.tsx
@@ -7,6 +7,7 @@ import {
 } from "./FormFieldSkeleton"
 import { getFinalAriaDescribedBy } from "../utils"
 import { OmitControlProps } from "../sharedTypes"
+import { showFormSkeletonDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type FormGroupFieldSkeletonProps = FormFieldSkeletonProps &
   Pick<JSX.IntrinsicElements["div"], "className" | "style">
@@ -19,6 +20,7 @@ export function FormGroupFieldSkeleton({
   className,
   style,
 }: FormGroupFieldSkeletonProps) {
+  showFormSkeletonDeprecatedMessage("FormGroupFieldSkeleton", true)
   return (
     <FormFieldSkeleton id={id} hasError={hasError} hasHint={hasHint}>
       <div

--- a/src/components/form-skeletons/components/InputFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/InputFieldSkeleton.tsx
@@ -12,9 +12,11 @@ import {
 } from "./FormFieldSkeleton"
 import { getFinalAriaDescribedBy } from "../utils"
 import { OmitControlProps } from "../sharedTypes"
+import { showFormSkeletonDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type InputFieldSkeletonProps = FormFieldSkeletonProps
 export function InputFieldSkeleton(props: InputFieldSkeletonProps) {
+  showFormSkeletonDeprecatedMessage("InputFieldSkeleton")
   return <FormFieldSkeleton {...props} />
 }
 

--- a/src/components/form-skeletons/components/RadioButtonFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/RadioButtonFieldSkeleton.tsx
@@ -15,9 +15,11 @@ import {
   FormGroupFieldSkeletonOptionLabel,
   FormGroupFieldSkeletonOptionLabelProps,
 } from "./FormGroupFieldSkeleton"
+import { showFormSkeletonDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type RadioButtonFieldSkeletonProps = FormGroupFieldSkeletonProps
 export function RadioButtonFieldSkeleton(props: RadioButtonFieldSkeletonProps) {
+  showFormSkeletonDeprecatedMessage("RadioButtonFieldSkeleton", true)
   return <FormGroupFieldSkeleton {...props} />
 }
 

--- a/src/components/form-skeletons/components/SelectFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/SelectFieldSkeleton.tsx
@@ -12,9 +12,11 @@ import {
 } from "./FormFieldSkeleton"
 import { getFinalAriaDescribedBy } from "../utils"
 import { OmitControlProps } from "../sharedTypes"
+import { showFormSkeletonDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type SelectFieldSkeletonProps = FormFieldSkeletonProps
 export function SelectFieldSkeleton(props: FormFieldSkeletonProps) {
+  showFormSkeletonDeprecatedMessage("SelectFieldSkeleton")
   return <FormFieldSkeleton {...props} />
 }
 

--- a/src/components/form-skeletons/components/TextAreaFieldSkeleton.tsx
+++ b/src/components/form-skeletons/components/TextAreaFieldSkeleton.tsx
@@ -12,9 +12,11 @@ import {
 } from "./FormFieldSkeleton"
 import { getFinalAriaDescribedBy } from "../utils"
 import { OmitControlProps } from "../sharedTypes"
+import { showFormSkeletonDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type TextAreaFieldSkeletonProps = FormFieldSkeletonProps
 export function TextAreaFieldSkeleton(props: TextAreaFieldSkeletonProps) {
+  showFormSkeletonDeprecatedMessage("TextAreaFieldSkeleton")
   return <FormFieldSkeleton {...props} />
 }
 

--- a/src/components/form/components/CheckboxField.tsx
+++ b/src/components/form/components/CheckboxField.tsx
@@ -23,9 +23,11 @@ import {
   CheckboxFieldSkeletonLabelProps,
 } from "../../form-skeletons/components/CheckboxFieldSkeleton"
 import { Theme, ThemeCss, getTheme } from "../../../theme"
+import { showFormFieldDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type CheckboxFieldProps = CheckboxFieldSkeletonProps
 export function CheckboxField(props: CheckboxFieldProps) {
+  showFormFieldDeprecatedMessage("CheckboxField")
   return <CheckboxFieldSkeleton {...props}></CheckboxFieldSkeleton>
 }
 

--- a/src/components/form/components/CheckboxGroupField.tsx
+++ b/src/components/form/components/CheckboxGroupField.tsx
@@ -34,6 +34,7 @@ import { Theme } from "../../../theme"
 import { INPUT_WIDTH, INPUT_VERTICAL_OFFSET_CALC } from "./FormGroupField"
 import { WithStyledFieldLabel } from "./FormField"
 import { styledCheckboxCss } from "./CheckboxField"
+import { showFormFieldDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type CheckboxGroupFieldProps = Omit<
   WithFormGroupField<CheckboxGroupFieldSkeletonProps>,
@@ -43,6 +44,7 @@ export function CheckboxGroupField({
   optionsDirection,
   ...rest
 }: CheckboxGroupFieldProps) {
+  showFormFieldDeprecatedMessage("CheckboxGroupField", true)
   return (
     <FormGroupFieldProvider optionsDirection={optionsDirection}>
       <CheckboxGroupFieldSkeleton css={formGroupFieldCss} {...rest} />

--- a/src/components/form/components/InputField.tsx
+++ b/src/components/form/components/InputField.tsx
@@ -23,9 +23,11 @@ import {
   InputFieldSkeletonLabelProps,
 } from "../../form-skeletons/components/InputFieldSkeleton"
 import { Theme } from "../../../theme"
+import { showFormFieldDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type InputFieldProps = InputFieldSkeletonProps
 export function InputField(props: InputFieldProps) {
+  showFormFieldDeprecatedMessage("InputField")
   return <InputFieldSkeleton {...props}></InputFieldSkeleton>
 }
 

--- a/src/components/form/components/RadioButtonField.tsx
+++ b/src/components/form/components/RadioButtonField.tsx
@@ -36,6 +36,7 @@ import { Theme, ThemeCss, getTheme } from "../../../theme"
 
 import { INPUT_WIDTH, INPUT_VERTICAL_OFFSET_CALC } from "./FormGroupField"
 import { WithStyledFieldLabel } from "./FormField"
+import { showFormFieldDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type RadioButtonFieldVariant = "default" | "framed"
 
@@ -47,6 +48,7 @@ export function RadioButtonField({
   optionsDirection,
   ...rest
 }: RadioButtonFieldProps) {
+  showFormFieldDeprecatedMessage("RadioButtonField", true)
   return (
     <FormGroupFieldProvider optionsDirection={optionsDirection}>
       <RadioButtonFieldSkeleton

--- a/src/components/form/components/SelectField.tsx
+++ b/src/components/form/components/SelectField.tsx
@@ -23,9 +23,11 @@ import {
   SelectFieldSkeletonLabelProps,
 } from "../../form-skeletons/components/SelectFieldSkeleton"
 import { Theme } from "../../../theme"
+import { showFormFieldDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type SelectFieldProps = SelectFieldSkeletonProps
 export function SelectField(props: SelectFieldProps) {
+  showFormFieldDeprecatedMessage("SelectField")
   return <SelectFieldSkeleton {...props}></SelectFieldSkeleton>
 }
 

--- a/src/components/form/components/TextAreaField.tsx
+++ b/src/components/form/components/TextAreaField.tsx
@@ -23,9 +23,11 @@ import {
   TextAreaFieldSkeletonLabelProps,
 } from "../../form-skeletons/components/TextAreaFieldSkeleton"
 import { Theme } from "../../../theme"
+import { showFormFieldDeprecatedMessage } from "../../../utils/maintenance/deprecationMessages"
 
 export type TextAreaFieldProps = TextAreaFieldSkeletonProps
 export function TextAreaField(props: TextAreaFieldProps) {
+  showFormFieldDeprecatedMessage("TextAreaField")
   return <TextAreaFieldSkeleton {...props}></TextAreaFieldSkeleton>
 }
 

--- a/src/utils/maintenance/deprecationMessages.ts
+++ b/src/utils/maintenance/deprecationMessages.ts
@@ -8,3 +8,34 @@ export function showCustomCssDeprecationMessage(customCss: any) {
     `Styling components via "customCss" prop is deprecated, please use Emotion "css" prop or pass a "className"`
   )
 }
+
+export function showFormSkeletonDeprecatedMessage(
+  componentName: string,
+  isGroupSkeleton = false
+) {
+  warn(
+    `<${componentName}> and its subcomponents should be considered deprecated and replaced with "${
+      isGroupSkeleton ? `useAriaFormGroupField` : `useAriaFormField`
+    }"`
+  )
+}
+
+export function showFormFieldDeprecatedMessage(
+  componentName: string,
+  isGroupField = false
+) {
+  warn(
+    `
+<${componentName}> and its subcomponents should be considered deprecated and replaced with one of the following:
+  - <${componentName}Block> (or <${componentName.substring(
+      0,
+      componentName.indexOf("Field")
+    )}ConnectedField> in Formik forms)
+  - "${
+    isGroupField ? `useAriaFormGroupField` : `useAriaFormField`
+  }" hook and a combination of styled form elements, such as <StyledInput>, <${
+      isGroupField ? `FormLegend` : `StyledLabel`
+    }>, <FormError>
+`.trim()
+  )
+}


### PR DESCRIPTION
Now when #340 is merged, we can start deprecating `*FieldSkeleton` and `*Field` components (e.g. `InputFieldSkeleton` and `InputField`) — they can be replaced with the new hooks and styled form elements.
<img width="485" alt="Screen Shot 2020-06-29 at 6 20 19 PM" src="https://user-images.githubusercontent.com/4366711/86072545-a35cf500-ba36-11ea-9fd5-20cced6fa3a3.png">
By the way, the only deprecated components used in Cloud codebase are `RadioButtonFieldSkeleton` (which gave us those a11y warnings about not using `<fieldset>`), `InputField` (which I have already replaced in an outstanding PR) and `RadioButtonField`. Their total usage number is about 10, and they shouldn't be to difficult to replace with the `*FieldBlock` counterparts or `useAriaFormField`/`useAriaFormGroupField` hooks. 