### PR TITLE
feat(Card): initial prototype for Card component

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,0 +1,67 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core"
+import { getGroupFieldStoryOptions, LONG_TEXT } from "../../utils/storybook"
+import { Card, CardSection, CardHeader, CardFooter, CardDivider } from "."
+import { Button } from "../Button"
+import { Notification } from "../Notification"
+import { StyledInput } from "../form/components/styled-primitives/StyledInput"
+import { Badge } from "../Badge"
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from "../Tabs"
+import { CheckboxGroupFieldBlock } from "../form"
+
+export default {
+  title: `Card`,
+  component: Card,
+  subcomponents: {
+    CardSection,
+    CardHeader,
+    CardFooter,
+    CardDivider,
+  },
+}
+
+export const Basic = () => (
+  <Card>
+    <CardHeader title="Card Title">
+      <Badge textVariant="CAPS" tone="SUCCESS">
+        New feature
+      </Badge>
+    </CardHeader>
+    <Notification content={LONG_TEXT} variant="SECONDARY" tone="WARNING" />
+    <Tabs>
+      <TabList>
+        <Tab>Tab One</Tab>
+        <Tab>Tab Two</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <CardSection>{LONG_TEXT}</CardSection>
+          <CardSection applyPaddingTop={false}>
+            <StyledInput
+              name="test"
+              placeholder="Type something..."
+              aria-label="Exampel field"
+            />
+          </CardSection>
+        </TabPanel>
+        <TabPanel>
+          <CardSection>
+            <CheckboxGroupFieldBlock
+              id="exampleCheckbox"
+              name="exampleCheckbox"
+              label="Example checkbox"
+              options={getGroupFieldStoryOptions("mid")}
+            />
+          </CardSection>
+          <CardSection applyPaddingTop={false}>{LONG_TEXT}</CardSection>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+    <CardDivider />
+    <CardSection>{LONG_TEXT}</CardSection>
+    <CardFooter>
+      <Button variant="SECONDARY">Secondary</Button>
+      <Button variant="PRIMARY">Primary</Button>
+    </CardFooter>
+  </Card>
+)

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,117 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core"
+import React from "react"
+import { ThemeCss } from "../../theme"
+import { Heading, HeadingProps } from "../Heading"
+
+const baseCss: ThemeCss = theme => theme.cardStyles.frame
+
+export type CardProps = React.ComponentPropsWithoutRef<"div"> & {
+  as?: "article" | "div"
+}
+
+export function Card({ as: Component = `article`, ...rest }: CardProps) {
+  return <Component css={baseCss} {...rest} />
+}
+
+export type CardSectionProps = React.ComponentPropsWithoutRef<"div"> & {
+  as?: `div` | `p` | `section` | `header`
+  applyPaddingTop?: boolean
+  applyPaddingBottom?: boolean
+  applyPaddingLeft?: boolean
+  applyPaddingRight?: boolean
+}
+
+export function CardSection({
+  as: Component = `div`,
+  applyPaddingTop = true,
+  applyPaddingBottom = true,
+  applyPaddingLeft = true,
+  applyPaddingRight = true,
+  ...rest
+}: CardSectionProps) {
+  const baseSectionCss: ThemeCss = theme => [
+    applyPaddingTop && {
+      paddingTop: theme.space[7],
+      [theme.mediaQueries.desktop]: {
+        paddingTop: theme.cardStyles.space.L.paddingTop,
+      },
+    },
+    applyPaddingBottom && {
+      paddingBottom: theme.space[7],
+      [theme.mediaQueries.desktop]: {
+        paddingBottom: theme.cardStyles.space.L.paddingBottom,
+      },
+    },
+    applyPaddingLeft && {
+      paddingLeft: theme.space[7],
+      [theme.mediaQueries.desktop]: {
+        paddingLeft: theme.cardStyles.space.L.paddingLeft,
+      },
+    },
+    applyPaddingRight && {
+      paddingRight: theme.space[7],
+      [theme.mediaQueries.desktop]: {
+        paddingRight: theme.cardStyles.space.L.paddingRight,
+      },
+    },
+  ]
+
+  return <Component css={baseSectionCss} {...rest} />
+}
+
+const headerCss: ThemeCss = theme => ({
+  display: `flex`,
+  alignItems: `center`,
+  justifyContent: `space-between`,
+  fontSize: theme.fontSizes[4],
+  lineHeight: 1,
+})
+
+export type CardHeaderProps = Omit<CardSectionProps, "as"> & {
+  as?: "header" | "div"
+  title: React.ReactNode
+  titleAs?: HeadingProps["as"]
+}
+
+export function CardHeader({
+  as = `header`,
+  title,
+  titleAs = `h3`,
+  children,
+  ...rest
+}: CardHeaderProps) {
+  return (
+    <CardSection as={as} css={headerCss} {...rest}>
+      <Heading as={titleAs}>{title}</Heading>
+      {children}
+    </CardSection>
+  )
+}
+
+const footerCss: ThemeCss = theme => ({
+  background: theme.colors.purple[5],
+  display: `flex`,
+  alignItems: `center`,
+  justifyContent: `space-between`,
+  borderBottomLeftRadius: theme.cardStyles.frame.borderRadius,
+  borderBottomRightRadius: theme.cardStyles.frame.borderRadius,
+})
+
+export type CardFooterProps = CardSectionProps
+
+export function CardFooter(props: CardFooterProps) {
+  return <CardSection css={footerCss} {...props} />
+}
+
+const dividerCss: ThemeCss = theme => ({
+  border: 0,
+  borderTop: `1px solid ${theme.colors.standardLine}`,
+  margin: 0,
+})
+
+export type CardDividerProps = React.ComponentPropsWithoutRef<"hr">
+
+export function CardDivider(props: CardDividerProps) {
+  return <hr css={dividerCss} {...props} />
+}

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,0 +1,1 @@
+export * from "./Card"

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -160,8 +160,20 @@ const themeTransitions = transitions
 export type CardSpaceVariant = "DEFAULT" | "L" | "M"
 
 export type CardStyles = {
-  frame: Interpolation
-  space: Record<CardSpaceVariant, Interpolation>
+  frame: {
+    background: string
+    borderRadius: string
+    boxShadow: string
+  }
+  space: Record<
+    CardSpaceVariant,
+    {
+      paddingTop: string
+      paddingBottom: string
+      paddingLeft: string
+      paddingRight: string
+    }
+  >
 }
 
 const themeCardStyles: CardStyles = {
@@ -172,13 +184,22 @@ const themeCardStyles: CardStyles = {
   },
   space: {
     DEFAULT: {
-      padding: `${space[6]} ${space[3]} ${space[5]} ${space[7]}`,
+      paddingTop: space[6],
+      paddingBottom: space[5],
+      paddingLeft: space[7],
+      paddingRight: space[3],
     },
     M: {
-      padding: `${space[5]} ${space[9]}`,
+      paddingTop: space[5],
+      paddingBottom: space[5],
+      paddingLeft: space[9],
+      paddingRight: space[9],
     },
     L: {
-      padding: `${space[7]} ${space[9]} ${space[8]}`,
+      paddingTop: space[7],
+      paddingBottom: space[8],
+      paddingLeft: space[9],
+      paddingRight: space[9],
     },
   },
 }

--- a/src/utils/storybook/storyData.ts
+++ b/src/utils/storybook/storyData.ts
@@ -76,3 +76,5 @@ export function getStoryOptions(size: OptionsSize = "mid") {
     }
   })
 }
+
+export const LONG_TEXT = `Lorem ipsum dolor sit amet consectetur adipisicing elit. Quo officia recusandae nisi magni, dolore laboriosam maiores suscipit perspiciatis. Perspiciatis quod ipsum corporis officia necessitatibus, doloribus fuga culpa. Unde, molestiae repellendus.`


### PR DESCRIPTION
A prototype for `Card` component. 

The biggest shift compared to how we currently implement cards is moving the responsibility for spacing from the "root" card component to a `CardSection` subcomponent. `CardComponent` can be used to apply default card space around other elements with an option to disable space on any side via passing `applyPaddingTop={false}` (or/and `applyPaddingBottom`, `applyPaddingLeft`, `applyPaddingRight`).

Available components:
* `Card` — root component, takes care of background color and border
* `CardSection`
* `CardHeader`
* `CardFooter`
* `CardDivider`

<img width="1049" alt="Screen Shot 2020-07-16 at 7 36 49 PM" src="https://user-images.githubusercontent.com/4366711/87742503-bfcd9100-c79b-11ea-88ae-bd055a888403.png">
