### PR TITLE
chore: fix a11y issues in some stories

### DIFF
--- a/__tests__/__snapshots__/icons.test.js.snap
+++ b/__tests__/__snapshots__/icons.test.js.snap
@@ -16,7 +16,7 @@ exports[`icons <BitbucketIcon /> renders unchanged 1`] = `
     width="24px"
   >
     <g
-      clip-path="url(#BitbucketIcon__clip)"
+      clip-path="url(#BitbucketIcon__clip--noid)"
     >
       <path
         d="M2.64036 2.8875C2.5481 2.8863 2.45669 2.90556 2.37256 2.94393C2.28843 2.9823 2.21362 3.03885 2.15337 3.10961C2.09312 3.18037 2.0489 3.26363 2.02381 3.35353C1.99873 3.44344 1.99338 3.53782 2.00815 3.63004L4.69189 20.1258C4.72533 20.3276 4.82794 20.5111 4.98172 20.644C5.13549 20.7768 5.33058 20.8506 5.53273 20.8523H18.4077C18.5592 20.8543 18.7064 20.8011 18.8225 20.7024C18.9385 20.6037 19.0157 20.4661 19.0399 20.3146L21.7237 3.63324C21.7384 3.54102 21.7331 3.44664 21.708 3.35673C21.6829 3.26683 21.6387 3.18357 21.5784 3.11281C21.5182 3.04205 21.4434 2.9855 21.3592 2.94713C21.2751 2.90876 21.1837 2.8895 21.0914 2.8907L2.64036 2.8875ZM13.9411 14.8096H9.83177L8.71908 8.92378H14.9369L13.9411 14.8096Z"
@@ -24,13 +24,13 @@ exports[`icons <BitbucketIcon /> renders unchanged 1`] = `
       />
       <path
         d="M20.8702 8.92383H14.9369L13.9411 14.8097H9.83178L4.97955 20.6411C5.13335 20.7758 5.32943 20.8506 5.53274 20.8523H18.4109C18.5624 20.8543 18.7096 20.8011 18.8257 20.7024C18.9417 20.6037 19.0189 20.4661 19.0431 20.3147L20.8702 8.92383Z"
-        fill="url(#BitbucketIcon__gradient)"
+        fill="url(#BitbucketIcon__gradient--noid)"
       />
     </g>
     <defs>
       <lineargradient
         gradientUnits="userSpaceOnUse"
-        id="BitbucketIcon__gradient"
+        id="BitbucketIcon__gradient--noid"
         x1="22.2421"
         x2="12.3445"
         y1="10.5721"
@@ -46,7 +46,7 @@ exports[`icons <BitbucketIcon /> renders unchanged 1`] = `
         />
       </lineargradient>
       <clippath
-        id="BitbucketIcon__clip"
+        id="BitbucketIcon__clip--noid"
       >
         <rect
           fill="white"
@@ -371,7 +371,7 @@ exports[`icons <EllipsisIcon /> renders unchanged 1`] = `
   >
     <filter
       height="100%"
-      id="EllipsisIcon__filter"
+      id="EllipsisIcon__filter--noid"
       width="100%"
       x="0"
       y="0"
@@ -387,7 +387,7 @@ exports[`icons <EllipsisIcon /> renders unchanged 1`] = `
       cx="12"
       cy="12"
       r="10"
-      style="filter: url(#EllipsisIcon__filter);"
+      style="filter: url(#EllipsisIcon__filter--noid);"
     />
     <circle
       cx="6.5"
@@ -660,7 +660,7 @@ exports[`icons <InProgressIcon /> renders unchanged 1`] = `
   >
     <mask
       height="20"
-      id="InProgressIcon__mask--0"
+      id="InProgressIcon__mask0--noid"
       mask-type="alpha"
       maskUnits="userSpaceOnUse"
       width="20"
@@ -669,7 +669,7 @@ exports[`icons <InProgressIcon /> renders unchanged 1`] = `
     >
       <mask
         height="10"
-        id="InProgressIcon__mask--1"
+        id="InProgressIcon__mask1--noid"
         maskUnits="userSpaceOnUse"
         width="20"
         x="2"
@@ -681,7 +681,7 @@ exports[`icons <InProgressIcon /> renders unchanged 1`] = `
         />
       </mask>
       <g
-        mask="url(#InProgressIcon__mask--1)"
+        mask="url(#InProgressIcon__mask1--noid"
       >
         <path
           clip-rule="evenodd"
@@ -692,7 +692,7 @@ exports[`icons <InProgressIcon /> renders unchanged 1`] = `
       </g>
       <mask
         height="20"
-        id="InProgressIcon__mask--2"
+        id="InProgressIcon__mask2--noid"
         maskUnits="userSpaceOnUse"
         width="20"
         x="2"
@@ -706,23 +706,23 @@ exports[`icons <InProgressIcon /> renders unchanged 1`] = `
         />
       </mask>
       <g
-        mask="url(#InProgressIcon__mask--2)"
+        mask="url(#InProgressIcon__mask2--noid"
       >
         <path
           d="M12 2.00003C6.47714 2.00003 2 6.47718 2 12L22 12C22 6.47718 17.5228 2.00003 12 2.00003Z"
-          fill="url(#InProgressIcon__linear)"
+          fill="url(#InProgressIcon__gradient--noid)"
         />
       </g>
     </mask>
     <g
-      mask="url(#InProgressIcon__mask--0)"
+      mask="url(#InProgressIcon__mask0--noid"
     >
       <circle
         cx="12"
         cy="12"
         fill="currentColor"
         r="9.99998"
-        style="filter: url(#InProgressIcon__filter);"
+        style="filter: url(#InProgressIcon__filter--noid);"
       />
     </g>
     <circle
@@ -734,7 +734,7 @@ exports[`icons <InProgressIcon /> renders unchanged 1`] = `
     <defs>
       <lineargradient
         gradientUnits="userSpaceOnUse"
-        id="InProgressIcon__linear"
+        id="InProgressIcon__gradient--noid"
         x1="5.74999"
         x2="18.25"
         y1="12"
@@ -750,7 +750,7 @@ exports[`icons <InProgressIcon /> renders unchanged 1`] = `
       </lineargradient>
       <filter
         height="100%"
-        id="InProgressIcon__filter"
+        id="InProgressIcon__filter--noid"
         width="100%"
         x="0"
         y="0"
@@ -1025,7 +1025,7 @@ exports[`icons <SkullIcon /> renders unchanged 1`] = `
     />
     <mask
       fill="white"
-      id="path-9-inside-1"
+      id="SkullIcon__mask--noid"
     >
       <path
         clip-rule="evenodd"
@@ -1036,7 +1036,7 @@ exports[`icons <SkullIcon /> renders unchanged 1`] = `
     <path
       d="M17.3333 17.7724L16.6668 15.8867L15.3333 16.358V17.7724H17.3333ZM6.66667 17.7724H8.66667V16.358L7.33316 15.8867L6.66667 17.7724ZM22 10C22 4.47715 17.5228 0 12 0V4C15.3137 4 18 6.68629 18 10H22ZM22 14V10H18V14H22ZM17.9998 19.6581C20.3275 18.8354 22 16.6156 22 14H18C18 14.8677 17.4463 15.6112 16.6668 15.8867L17.9998 19.6581ZM15.3333 17.7724V18H19.3333V17.7724H15.3333ZM15.3333 18C15.3333 19.1046 14.4379 20 13.3333 20V24C16.647 24 19.3333 21.3137 19.3333 18H15.3333ZM13.3333 20H10.6667V24H13.3333V20ZM10.6667 20C9.5621 20 8.66667 19.1046 8.66667 18H4.66667C4.66667 21.3137 7.35296 24 10.6667 24V20ZM8.66667 18V17.7724H4.66667V18H8.66667ZM2 14C2 16.6156 3.67249 18.8354 6.00017 19.6581L7.33316 15.8867C6.55367 15.6112 6 14.8677 6 14H2ZM2 10V14H6V10H2ZM12 0C6.47715 0 2 4.47715 2 10H6C6 6.68629 8.68629 4 12 4V0Z"
       fill="currentColor"
-      mask="url(#path-9-inside-1)"
+      mask="url(#SkullIcon__mask--noid)"
     />
     <path
       d="M12 13L13.299 15.25H10.701L12 13Z"

--- a/src/components/ThemeProvider/ThemeProvider.stories.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.stories.tsx
@@ -1,7 +1,5 @@
 /** @jsx jsx */
 import { jsx, Interpolation } from "@emotion/core"
-import { storiesOf } from "@storybook/react"
-import { StoryUtils } from "../../utils/storybook"
 import { css } from "@emotion/core"
 import { Theme, getTheme } from "../../theme"
 import { useTheme, ThemeProvider } from "."
@@ -10,127 +8,130 @@ const textCss: Interpolation = {
   textTransform: `uppercase`,
 }
 
-storiesOf(`Theme/ThemeProvider`, module)
-  .addParameters({
-    options: {
-      showPanel: true,
-    },
-  })
-  .add(`accessing theme in a css prop`, () => {
-    function TestComponent() {
-      return (
-        <StoryUtils.Container>
-          <StoryUtils.Stack>
-            <div
-              css={(theme: Theme) =>
-                css(textCss, {
-                  backgroundColor: theme.colors.gatsby,
-                  color: theme.colors.white,
-                  padding: theme.space[5],
-                })
-              }
-            >
-              Lorem ipsum
-            </div>
-          </StoryUtils.Stack>
-        </StoryUtils.Container>
-      )
-    }
+export default {
+  title: `Theme/ThemeProvider`,
+  component: ThemeProvider,
+}
+
+export const CssProp = () => {
+  function TestComponent() {
+    return (
+      <div
+        css={(theme: Theme) =>
+          css(textCss, {
+            backgroundColor: theme.colors.gatsby,
+            color: theme.colors.white,
+            padding: theme.space[5],
+          })
+        }
+      >
+        Lorem ipsum
+      </div>
+    )
+  }
+
+  return (
+    <ThemeProvider>
+      <TestComponent />
+    </ThemeProvider>
+  )
+}
+
+CssProp.story = {
+  name: `Accessing theme in a css prop`,
+}
+
+export const UseTheme = () => {
+  function TestComponent() {
+    const theme = useTheme()
 
     return (
-      <ThemeProvider>
-        <TestComponent />
-      </ThemeProvider>
+      <div
+        style={{
+          backgroundColor: theme.colors.green[80],
+          color: theme.colors.white,
+          padding: theme.space[5],
+        }}
+      >
+        Lorem ipsum
+      </div>
     )
-  })
-  .add(`useTheme`, () => {
-    function TestComponent() {
-      const theme = useTheme()
-      return (
-        <StoryUtils.Container>
-          <StoryUtils.Stack>
-            <div
-              style={{
-                backgroundColor: theme.colors.green[80],
-                color: theme.colors.white,
-                padding: theme.space[5],
-              }}
-            >
-              Lorem ipsum
-            </div>
-          </StoryUtils.Stack>
-        </StoryUtils.Container>
-      )
-    }
+  }
 
+  return (
+    <ThemeProvider>
+      <TestComponent />
+    </ThemeProvider>
+  )
+}
+
+UseTheme.story = {
+  name: `useTheme`,
+}
+
+export const CustomThemeObject = () => {
+  function TestComponent() {
     return (
-      <ThemeProvider>
-        <TestComponent />
-      </ThemeProvider>
+      <div
+        css={(theme: Theme) =>
+          css(textCss, {
+            backgroundColor: theme.colors.gatsby,
+            color: theme.colors.white,
+            padding: theme.space[5],
+          })
+        }
+      >
+        Lorem ipsum
+      </div>
     )
-  })
-  .add("ThemeProvider custom theme prop of type Theme", () => {
-    function TestComponent() {
-      return (
-        <StoryUtils.Container>
-          <StoryUtils.Stack>
-            <div
-              css={(theme: Theme) =>
-                css(textCss, {
-                  backgroundColor: theme.colors.gatsby,
-                  color: theme.colors.white,
-                  padding: theme.space[5],
-                })
-              }
-            >
-              Lorem ipsum
-            </div>
-          </StoryUtils.Stack>
-        </StoryUtils.Container>
-      )
-    }
+  }
 
-    const defaultTheme = getTheme()
-    const otherTheme = {
-      ...defaultTheme,
-      colors: { ...defaultTheme.colors, gatsby: "red" },
-    }
+  const defaultTheme = getTheme()
+  const otherTheme = {
+    ...defaultTheme,
+    colors: { ...defaultTheme.colors, gatsby: "#b22222" },
+  }
 
+  return (
+    <ThemeProvider theme={otherTheme}>
+      <TestComponent />
+    </ThemeProvider>
+  )
+}
+
+CustomThemeObject.story = {
+  name: `Custom theme object`,
+}
+
+export const CustomThemeFunction = () => {
+  function TestComponent() {
     return (
-      <ThemeProvider theme={otherTheme}>
-        <TestComponent />
-      </ThemeProvider>
+      <div
+        css={(theme: Theme) =>
+          css(textCss, {
+            backgroundColor: theme.colors.gatsby,
+            color: theme.colors.white,
+            padding: theme.space[5],
+          })
+        }
+      >
+        Lorem ipsum
+      </div>
     )
-  })
-  .add("ThemeProvider custom theme prop of type function", () => {
-    function TestComponent() {
-      return (
-        <StoryUtils.Container>
-          <StoryUtils.Stack>
-            <div
-              css={(theme: Theme) =>
-                css(textCss, {
-                  backgroundColor: theme.colors.gatsby,
-                  color: theme.colors.white,
-                  padding: theme.space[5],
-                })
-              }
-            >
-              Lorem ipsum
-            </div>
-          </StoryUtils.Stack>
-        </StoryUtils.Container>
-      )
-    }
+  }
 
-    const getNewTheme = (defaultTheme: Theme) => ({
-      ...defaultTheme,
-      colors: { ...defaultTheme.colors, gatsby: "yellow" },
-    })
-
-    return (
-      <ThemeProvider theme={getNewTheme}>
-        <TestComponent />
-      </ThemeProvider>
-    )
+  const getNewTheme = (defaultTheme: Theme) => ({
+    ...defaultTheme,
+    colors: { ...defaultTheme.colors, gatsby: "#483d8b" },
   })
+
+  return (
+    <ThemeProvider theme={getNewTheme}>
+      <TestComponent />
+    </ThemeProvider>
+  )
+}
+
+CustomThemeFunction.story = {
+  name: `Custom theme function`,
+}

--- a/src/components/icons/BitbucketIcon.tsx
+++ b/src/components/icons/BitbucketIcon.tsx
@@ -3,21 +3,23 @@ import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 
 export default function BitbucketIcon(props: IconProps) {
+  const clipId = `BitbucketIcon__clip--${props.id || "noid"}`
+  const gradientId = `BitbucketIcon__gradient--${props.id || "noid"}`
   return (
     <IconSkeleton {...props} iconName="BitbucketIcon" fill="none" stroke="none">
-      <g clipPath="url(#BitbucketIcon__clip)">
+      <g clipPath={`url(#${clipId})`}>
         <path
           d="M2.64036 2.8875C2.5481 2.8863 2.45669 2.90556 2.37256 2.94393C2.28843 2.9823 2.21362 3.03885 2.15337 3.10961C2.09312 3.18037 2.0489 3.26363 2.02381 3.35353C1.99873 3.44344 1.99338 3.53782 2.00815 3.63004L4.69189 20.1258C4.72533 20.3276 4.82794 20.5111 4.98172 20.644C5.13549 20.7768 5.33058 20.8506 5.53273 20.8523H18.4077C18.5592 20.8543 18.7064 20.8011 18.8225 20.7024C18.9385 20.6037 19.0157 20.4661 19.0399 20.3146L21.7237 3.63324C21.7384 3.54102 21.7331 3.44664 21.708 3.35673C21.6829 3.26683 21.6387 3.18357 21.5784 3.11281C21.5182 3.04205 21.4434 2.9855 21.3592 2.94713C21.2751 2.90876 21.1837 2.8895 21.0914 2.8907L2.64036 2.8875ZM13.9411 14.8096H9.83177L8.71908 8.92378H14.9369L13.9411 14.8096Z"
           fill="#2684FF"
         />
         <path
           d="M20.8702 8.92383H14.9369L13.9411 14.8097H9.83178L4.97955 20.6411C5.13335 20.7758 5.32943 20.8506 5.53274 20.8523H18.4109C18.5624 20.8543 18.7096 20.8011 18.8257 20.7024C18.9417 20.6037 19.0189 20.4661 19.0431 20.3147L20.8702 8.92383Z"
-          fill="url(#BitbucketIcon__gradient)"
+          fill={`url(#${gradientId})`}
         />
       </g>
       <defs>
         <linearGradient
-          id="BitbucketIcon__gradient"
+          id={gradientId}
           x1="22.2421"
           y1="10.5721"
           x2="12.3445"
@@ -27,7 +29,7 @@ export default function BitbucketIcon(props: IconProps) {
           <stop offset="0.18" stopColor="#0052CC" />
           <stop offset="1" stopColor="#2684FF" />
         </linearGradient>
-        <clipPath id="BitbucketIcon__clip">
+        <clipPath id={clipId}>
           <rect
             width="20"
             height="18"

--- a/src/components/icons/EllipsisIcon.tsx
+++ b/src/components/icons/EllipsisIcon.tsx
@@ -3,19 +3,15 @@ import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 
 export default function EllipsisIcon(props: IconProps) {
+  const filterId = `EllipsisIcon__filter--${props.id || "noid"}`
   return (
     <IconSkeleton {...props} iconName="EllipsisIcon" applyColorToStroke={false}>
-      <filter id="EllipsisIcon__filter" x="0" y="0" width="100%" height="100%">
+      <filter id={filterId} x="0" y="0" width="100%" height="100%">
         <feComponentTransfer>
           <feFuncA type="linear" slope="0.1"></feFuncA>
         </feComponentTransfer>
       </filter>
-      <circle
-        cx="12"
-        cy="12"
-        r="10"
-        style={{ filter: `url(#EllipsisIcon__filter)` }}
-      />
+      <circle cx="12" cy="12" r="10" style={{ filter: `url(#${filterId})` }} />
       <circle cx="6.5" cy="12" r="2" />
       <circle cx="12" cy="12" r="2" />
       <circle cx="17.5" cy="12" r="2" />

--- a/src/components/icons/InProgressIcon.tsx
+++ b/src/components/icons/InProgressIcon.tsx
@@ -3,6 +3,11 @@ import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 
 export default function InProgressIcon(props: IconProps) {
+  const mask0Id = `InProgressIcon__mask0--${props.id || "noid"}`
+  const mask1Id = `InProgressIcon__mask1--${props.id || "noid"}`
+  const mask2Id = `InProgressIcon__mask2--${props.id || "noid"}`
+  const filterId = `InProgressIcon__filter--${props.id || "noid"}`
+  const gradientId = `InProgressIcon__gradient--${props.id || "noid"}`
   return (
     <IconSkeleton
       {...props}
@@ -10,7 +15,7 @@ export default function InProgressIcon(props: IconProps) {
       applyColorToStroke={false}
     >
       <mask
-        id="InProgressIcon__mask--0"
+        id={mask0Id}
         mask-type="alpha"
         maskUnits="userSpaceOnUse"
         x="2"
@@ -19,7 +24,7 @@ export default function InProgressIcon(props: IconProps) {
         height="20"
       >
         <mask
-          id="InProgressIcon__mask--1"
+          id={mask1Id}
           maskUnits="userSpaceOnUse"
           x="2"
           y="12"
@@ -31,7 +36,7 @@ export default function InProgressIcon(props: IconProps) {
             fill="#232129"
           />
         </mask>
-        <g mask="url(#InProgressIcon__mask--1)">
+        <g mask={`url(#${mask1Id}`}>
           <path
             fillRule="evenodd"
             clipRule="evenodd"
@@ -40,7 +45,7 @@ export default function InProgressIcon(props: IconProps) {
           />
         </g>
         <mask
-          id="InProgressIcon__mask--2"
+          id={mask2Id}
           maskUnits="userSpaceOnUse"
           x="2"
           y="2"
@@ -54,26 +59,26 @@ export default function InProgressIcon(props: IconProps) {
             fill="#2DE3DA"
           />
         </mask>
-        <g mask="url(#InProgressIcon__mask--2)">
+        <g mask={`url(#${mask2Id}`}>
           <path
             d="M12 2.00003C6.47714 2.00003 2 6.47718 2 12L22 12C22 6.47718 17.5228 2.00003 12 2.00003Z"
-            fill="url(#InProgressIcon__linear)"
+            fill={`url(#${gradientId})`}
           />
         </g>
       </mask>
-      <g mask="url(#InProgressIcon__mask--0)">
+      <g mask={`url(#${mask0Id}`}>
         <circle
           cx="12"
           cy="12"
           r="9.99998"
           fill="currentColor"
-          style={{ filter: `url(#InProgressIcon__filter)` }}
+          style={{ filter: `url(#${filterId})` }}
         />
       </g>
       <circle cx="12" cy="12" r="4" fill="currentColor" />
       <defs>
         <linearGradient
-          id="InProgressIcon__linear"
+          id={gradientId}
           x1="5.74999"
           y1="12"
           x2="18.25"
@@ -83,13 +88,7 @@ export default function InProgressIcon(props: IconProps) {
           <stop stopColor="#663399" stopOpacity="0" />
           <stop offset="1" />
         </linearGradient>
-        <filter
-          id="InProgressIcon__filter"
-          x="0"
-          y="0"
-          width="100%"
-          height="100%"
-        >
+        <filter id={filterId} x="0" y="0" width="100%" height="100%">
           <feComponentTransfer>
             <feFuncA type="linear" slope="0.3"></feFuncA>
           </feComponentTransfer>

--- a/src/components/icons/SkullIcon.tsx
+++ b/src/components/icons/SkullIcon.tsx
@@ -3,6 +3,7 @@ import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 
 export default function SkullIcon(props: IconProps) {
+  const maskId = `SkullIcon__mask--${props.id || "noid"}`
   return (
     <IconSkeleton {...props} stroke="none" iconName="SkullIcon">
       <path
@@ -21,7 +22,7 @@ export default function SkullIcon(props: IconProps) {
         strokeWidth="1.5"
         stroke="currentColor"
       />
-      <mask id="path-9-inside-1" fill="white">
+      <mask id={maskId} fill="white">
         <path
           fillRule="evenodd"
           clipRule="evenodd"
@@ -31,7 +32,7 @@ export default function SkullIcon(props: IconProps) {
       <path
         d="M17.3333 17.7724L16.6668 15.8867L15.3333 16.358V17.7724H17.3333ZM6.66667 17.7724H8.66667V16.358L7.33316 15.8867L6.66667 17.7724ZM22 10C22 4.47715 17.5228 0 12 0V4C15.3137 4 18 6.68629 18 10H22ZM22 14V10H18V14H22ZM17.9998 19.6581C20.3275 18.8354 22 16.6156 22 14H18C18 14.8677 17.4463 15.6112 16.6668 15.8867L17.9998 19.6581ZM15.3333 17.7724V18H19.3333V17.7724H15.3333ZM15.3333 18C15.3333 19.1046 14.4379 20 13.3333 20V24C16.647 24 19.3333 21.3137 19.3333 18H15.3333ZM13.3333 20H10.6667V24H13.3333V20ZM10.6667 20C9.5621 20 8.66667 19.1046 8.66667 18H4.66667C4.66667 21.3137 7.35296 24 10.6667 24V20ZM8.66667 18V17.7724H4.66667V18H8.66667ZM2 14C2 16.6156 3.67249 18.8354 6.00017 19.6581L7.33316 15.8867C6.55367 15.6112 6 14.8677 6 14H2ZM2 10V14H6V10H2ZM12 0C6.47715 0 2 4.47715 2 10H6C6 6.68629 8.68629 4 12 4V0Z"
         fill="currentColor"
-        mask="url(#path-9-inside-1)"
+        mask={`url(#${maskId})`}
       />
       <path
         d="M12 13L13.299 15.25H10.701L12 13Z"

--- a/src/components/icons/icons.stories.tsx
+++ b/src/components/icons/icons.stories.tsx
@@ -80,6 +80,7 @@ function ThemeColorCase({
       <Component
         css={theme => ({ color: getColor(theme.colors) })}
         height="3em"
+        id={`customColor-${colorLabel}`}
       />
     </StoryCase>
   )
@@ -159,13 +160,13 @@ sortedIconComponentNames.forEach(componentName => {
           <h2>Size:</h2>
           {sizes.map(size => (
             <StoryCase info={size} key={size}>
-              <Component size={size} />
+              <Component size={size} id={`size-${size}`} />
             </StoryCase>
           ))}
           <h2>Custom size:</h2>
           {customSizes.map(size => (
             <StoryCase info={<CustomSizeInfo size={size} />} key={size}>
-              <Component height={size} width={size} />
+              <Component height={size} width={size} id={`customSize-${size}`} />
             </StoryCase>
           ))}
           <h2>Theme color:</h2>
@@ -185,12 +186,16 @@ sortedIconComponentNames.forEach(componentName => {
               info={<span style={{ color: colorCase }}>{colorCase}</span>}
               key={colorCase}
             >
-              <Component color={colorCase} height="3em" />
+              <Component
+                color={colorCase}
+                height="3em"
+                id={`customColor-${colorCase}`}
+              />
             </StoryCase>
           ))}
           <h2>Inline</h2>
           <p>
-            Lorem ipsum <Component height="1em" /> foo bar
+            Lorem ipsum <Component height="1em" id="inline" /> foo bar
           </p>
         </div>
       )


### PR DESCRIPTION
Fixes some a11y issues detected by axe in icons and `ThemeProvider` stories, also rewrites stories for the latter in CSF format.  