### PR TITLE
feat(Button): support new prop, width

### DIFF
--- a/src/components/AnchorButton/AnchorButton.tsx
+++ b/src/components/AnchorButton/AnchorButton.tsx
@@ -18,6 +18,7 @@ export const AnchorButton = React.forwardRef<
     leftIcon,
     rightIcon,
     textVariant,
+    width,
     ...rest
   } = props
 
@@ -31,6 +32,7 @@ export const AnchorButton = React.forwardRef<
         leftIcon,
         rightIcon,
         textVariant,
+        width,
       })}
       {...rest}
       ref={ref}

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -13,6 +13,7 @@ import {
   ButtonTone,
   ButtonSize,
   ButtonTextVariant,
+  ButtonWidth,
 } from "../../theme/styles/button"
 import {
   withVariationsContainer,
@@ -84,6 +85,7 @@ export const Sandbox = () => {
     radioKnobOptions(TEXT_VARIANTS),
     "DEFAULT"
   )
+  const width = radios("width", radioKnobOptions(WIDTHS), "AUTO")
   const icon = radios(
     "icon",
     { left: `left`, right: "right", none: `none` },
@@ -103,6 +105,7 @@ export const Sandbox = () => {
         tone={tone}
         size={size}
         textVariant={textVariant}
+        width={width}
         leftIcon={leftIcon}
         rightIcon={rightIcon}
         disabled={disabled}
@@ -117,6 +120,7 @@ export const Sandbox = () => {
         tone={tone}
         size={size}
         textVariant={textVariant}
+        width={width}
         leftIcon={leftIcon}
         rightIcon={rightIcon}
       >
@@ -128,6 +132,7 @@ export const Sandbox = () => {
         tone={tone}
         size={size}
         textVariant={textVariant}
+        width={width}
         leftIcon={leftIcon}
         rightIcon={rightIcon}
       >
@@ -220,6 +225,33 @@ export const TextVariants = () =>
   ))
 
 TextVariants.story = {
+  decorators: [withVariationsContainer],
+}
+
+const WIDTHS: ButtonWidth[] = [`AUTO`, `FIT_CONTAINER`]
+
+export const Widths = () =>
+  WIDTHS.map(width => (
+    <div
+      key={width}
+      css={theme => ({
+        display: `grid`,
+        gridGap: theme.space[5],
+        maxWidth: `300px`,
+      })}
+    >
+      <StoryPropVariant propName="width" propValue={width} />
+      <Button width={width}>Button</Button>{" "}
+      <AnchorButton href="#" width={width}>
+        AnchorButton
+      </AnchorButton>{" "}
+      <LinkButton to="/" width={width}>
+        LinkButton
+      </LinkButton>
+    </div>
+  ))
+
+Widths.story = {
   decorators: [withVariationsContainer],
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,6 +10,7 @@ import {
   ButtonTone,
   ButtonSize,
   ButtonTextVariant,
+  ButtonWidth,
 } from "../../theme/styles/button"
 import { Theme } from "../../theme"
 
@@ -20,6 +21,7 @@ export type ButtonStyleProps = {
   leftIcon?: React.ReactNode
   rightIcon?: React.ReactNode
   textVariant?: ButtonTextVariant
+  width?: ButtonWidth
 }
 
 export type ButtonProps = BaseButtonProps & ButtonStyleProps
@@ -33,6 +35,7 @@ export function getButtonStyles({
   leftIcon,
   rightIcon,
   textVariant = `DEFAULT`,
+  width,
 }: {
   children: React.ReactNode
   loading?: boolean
@@ -49,6 +52,7 @@ export function getButtonStyles({
       leftIcon,
       rightIcon,
       textVariant,
+      width,
     }),
     children:
       leftIcon || rightIcon ? (
@@ -75,6 +79,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       leftIcon,
       rightIcon,
       textVariant,
+      width,
       ...rest
     } = props
 
@@ -89,6 +94,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           leftIcon,
           rightIcon,
           textVariant,
+          width,
         })}
         loading={loading}
         LoadingIcon={LoadingIcon}

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -15,6 +15,7 @@ export function LinkButton<TState>(props: LinkButtonProps<TState>) {
     leftIcon,
     rightIcon,
     textVariant,
+    width,
     ...rest
   } = props
 
@@ -28,6 +29,7 @@ export function LinkButton<TState>(props: LinkButtonProps<TState>) {
         leftIcon,
         rightIcon,
         textVariant,
+        width,
       })}
       {...rest}
     />

--- a/src/theme/styles/button.ts
+++ b/src/theme/styles/button.ts
@@ -5,6 +5,7 @@ export type ButtonSize = "XL" | "L" | "M" | "S"
 export type ButtonTone = "BRAND" | "SUCCESS" | "DANGER" | "NEUTRAL"
 export type ButtonVariant = "PRIMARY" | "SECONDARY" | "GHOST"
 export type ButtonTextVariant = "DEFAULT" | "BRAND"
+export type ButtonWidth = "AUTO" | "FIT_CONTAINER"
 
 export function getButtonCss({
   size = `L`,
@@ -14,6 +15,7 @@ export function getButtonCss({
   rightIcon,
   loading,
   textVariant = `DEFAULT`,
+  width = `AUTO`,
 }: {
   size?: ButtonSize
   tone?: ButtonTone
@@ -22,6 +24,7 @@ export function getButtonCss({
   rightIcon?: React.ReactNode
   loading?: boolean
   textVariant?: ButtonTextVariant
+  width?: ButtonWidth
 }): InterpolationWithTheme<Theme> {
   return (theme: Theme) => [
     getButtonBaseCss(textVariant)(theme),
@@ -32,6 +35,7 @@ export function getButtonCss({
     getButtonLoadingCss({ loading })(theme),
     getButtonVariantCss(variant, tone)(theme),
     getButtonSizeCss(size, textVariant)(theme),
+    getButtonWidthCss(width)(theme),
   ]
 }
 
@@ -199,4 +203,10 @@ function getButtonVariantCss(
     }
     return {}
   }
+}
+
+function getButtonWidthCss(buttonWidth?: ButtonWidth): ThemeCss {
+  return _theme => ({
+    width: buttonWidth === `FIT_CONTAINER` ? `100%` : undefined,
+  })
 }


### PR DESCRIPTION
Adds a new prop, `width`, to `Button`, `LinkButton` and `AnchorButton` to support "Full width" variant defined in the design. 
Allowed values are:
* `AUTO` — default value, button's width fits its content
* `FIT_CONTAINER` — makes the button take all available width

**NOTE:** I chose `FIT_CONTAINER` instead of `FULL_WIDTH` as IMO it is more appropriate for the actual behaviour; however, I am not too attached to it and can change if needed. 

### Images
<img width="261" alt="Screen Shot 2020-07-24 at 6 38 12 PM" src="https://user-images.githubusercontent.com/4366711/88446207-d5b30580-cddc-11ea-9de9-475707c90dd0.png">
