### PR TITLE
feat(Modal): changes default size for ModalPanel

### DIFF
--- a/src/components/Modal/ModalPanel.tsx
+++ b/src/components/Modal/ModalPanel.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { keyframes } from "@emotion/core"
 import { ModalContent, ModalContentProps } from "./ModalContent"
 import { ThemeCss } from "../../theme"
+import { warn } from "../../utils/maintenance/warn"
 
 const buildTranslation = (position: ModalPanelPosition) => keyframes`
   0% {
@@ -27,33 +28,56 @@ const baseCss: ThemeCss = theme => ({
   animationTimingFunction: `ease`,
 })
 
+const DEFAULT_MAX_WIDTH = `432px`
+
+const sizesStyles: Record<PanelSize, ThemeCss> = {
+  DEFAULT: _theme => ({
+    maxWidth: `100%`,
+    [`@media (min-width: ${DEFAULT_MAX_WIDTH})`]: {
+      maxWidth: DEFAULT_MAX_WIDTH,
+    },
+  }),
+}
+
 export type PanelPosition = "left" | "right"
 export type ModalPanelPosition = "left" | "right"
+export type PanelSize = "DEFAULT"
 
 export type ModalPanelProps = Omit<ModalContentProps, "ref"> & {
   position?: ModalPanelPosition
+  size?: PanelSize
+  // DEPRECATED, ONLY USE "size" INSTEAD
   maxWidth?: string
 }
 
 export const ModalPanel: React.FC<ModalPanelProps> = ({
-  maxWidth = `50vw`,
+  maxWidth,
   position = `right`,
+  size = `DEFAULT`,
   ...props
-}) => (
-  <ModalContent
-    css={theme => [
-      baseCss(theme),
-      { maxWidth },
-      position === `right`
-        ? {
-            right: 0,
-            animationName: translateRight,
-          }
-        : {
-            left: 0,
-            animationName: translateLeft,
-          },
-    ]}
-    {...props}
-  />
-)
+}) => {
+  if (maxWidth) {
+    warn(
+      `"maxWidth" prop has been deprecated in favour of "size" (set to "DEFAULT" if not passed)`
+    )
+  }
+
+  return (
+    <ModalContent
+      css={theme => [
+        baseCss(theme),
+        maxWidth ? { maxWidth } : sizesStyles[size](theme),
+        position === `right`
+          ? {
+              right: 0,
+              animationName: translateRight,
+            }
+          : {
+              left: 0,
+              animationName: translateLeft,
+            },
+      ]}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
Changes default size for `ModalPanel` to 432px or 100% if screen width is less than that value. I don't think we've been using `maxWidth` anywhere in Cloud, but to be safe I've decided to keep it for now and add a deprecation message.

I have not changed the purple color of the overlay since its shared between normal modals and panels, will take care of that in a different PR later.

Preview available in [Chromatic](https://5d4c6885a869c600201d3c8b-pwghngfmjx.chromatic.com/?path=/story/modal-styledpanel--usage-example).