### PR TITLE
fix(EmptyState): fixes props type for EmptyStatePrimaryAction

### DIFF
--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -136,10 +136,10 @@ export function EmptyState({
   )
 }
 
-export type EmptyStatePrimaryActionProps = Omit<
-  ButtonProps | LinkButtonProps | AnchorButtonProps,
-  "variant" | "size" | "tone"
->
+export type EmptyStatePrimaryActionProps =
+  | Omit<ButtonProps, "variant" | "size" | "tone">
+  | Omit<LinkButtonProps, "variant" | "size" | "tone">
+  | Omit<AnchorButtonProps, "variant" | "size" | "tone">
 
 export function EmptyStatePrimaryAction(props: EmptyStatePrimaryActionProps) {
   const sharedProps: ButtonStyleProps = {


### PR DESCRIPTION
Fixes TypeScript error when trying to use `EmptyStatePrimaryAction` as a Gatsby Link by passing `to` prop.