### PR TITLE
Use "body" font family for <Text />

### DIFF
--- a/src/components/Text/Text.helpers.ts
+++ b/src/components/Text/Text.helpers.ts
@@ -6,7 +6,7 @@ export const baseStyle = (tone: TextTone): ThemeCss => {
     // TODO figure out a better way to do this
     // https://github.com/gatsby-inc/gatsby-interface/issues/324
     color: tone === "NEUTRAL" ? theme.tones[tone].dark : theme.tones[tone].text,
-    fontFamily: theme.fonts.system,
+    fontFamily: theme.fonts.body,
     fontWeight: `normal`,
   })
 }


### PR DESCRIPTION
The Text component hardcodes the use of the "system" font stack. This unfortunately means that to globally use a different font family we have to override it in the theme like so:

```JS
const theme = {
  ...baseTheme,
  fonts: {
    ...baseTheme.fonts,
    system: '...other fonts...'
  }
}
```

But then manually using `fontFamily: 'system'` no longer shows system fonts. That is really confusing! :confused:

Instead, this PR changes the Text component to use the "body" font stack, which is aliased to "system" by default anyway, so no behavior changes. We can then adjust that font stack without anything being confusing! :tada:

```JS
const theme = {
  ...baseTheme,
  fonts: {
    ...baseTheme.fonts,
    body: '...other fonts...'
  }
}
```