### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+####
+# This file is used to automatically add PR reviewers.
+#
+####
+# Ref https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# Each line is a file pattern followed by one or more owners.
+# Order is important; the last matching pattern takes the most precedence.
+####
+
+* @gatsby-inc/cloud-frontend
+
+/src/ @gatsby-inc/cloud-frontend @fk


### PR DESCRIPTION
As the title says, this PR adds a CODEOWNERS file to automatically assign reviewers to new PRs — should help to avoid having open PRs in an unreviewed limbo.

Open questions:
* @fk are you ok with being marked as one of the owners of `src` folder? 
* do we need to explicitly mark me as a codeowner? It might have a benefit of letting people know who in particular to go to if they have any questions?