### PR TITLE
Animated InProgressIcon

### DIFF
--- a/__tests__/__snapshots__/icons.test.js.snap
+++ b/__tests__/__snapshots__/icons.test.js.snap
@@ -830,6 +830,7 @@ exports[`icons <InProgressIcon /> renders unchanged 1`] = `
 <div>
   <svg
     aria-hidden="true"
+    class="css-1hopcnb-InProgressIcon"
     data-testid="icon-InProgressIcon"
     fill="currentColor"
     fill-rule="evenodd"

--- a/src/components/icons/InProgressIcon.tsx
+++ b/src/components/icons/InProgressIcon.tsx
@@ -1,6 +1,21 @@
-import React from "react"
+/** @jsx jsx */
+import { jsx } from "@emotion/core"
+import { keyframes } from "@emotion/core"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
+import { ThemeCss } from "../../theme"
+
+const rotating = keyframes`
+  100% {
+    transform: rotate(360deg);
+  }
+`
+
+const animatedCss: ThemeCss = _theme => ({
+  animation: `${rotating} 1s infinite`,
+  animationTimingFunction: `linear`,
+  transform: `rotate(0)`,
+})
 
 export default function InProgressIcon(props: IconProps) {
   const mask0Id = `InProgressIcon__mask0--${props.id || "noid"}`
@@ -8,11 +23,13 @@ export default function InProgressIcon(props: IconProps) {
   const mask2Id = `InProgressIcon__mask2--${props.id || "noid"}`
   const filterId = `InProgressIcon__filter--${props.id || "noid"}`
   const gradientId = `InProgressIcon__gradient--${props.id || "noid"}`
+
   return (
     <IconSkeleton
       {...props}
       iconName="InProgressIcon"
       applyColorToStroke={false}
+      css={animatedCss}
     >
       <mask
         id={mask0Id}

--- a/src/components/icons/icons.stories.tsx
+++ b/src/components/icons/icons.stories.tsx
@@ -9,6 +9,7 @@ import * as icons from "./icons"
 import { IconSize, IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"
 import { Theme, ThemeCss } from "../../theme"
+import { disableAnimationsDecorator } from "../../utils/storybook"
 
 const sizes: IconSize[] = [
   `inherit`,
@@ -113,6 +114,7 @@ const sortedIconComponentNames = Object.keys(icons)
 
 storiesOf(`Icons`, module)
   .addDecorator(withKnobs)
+  .addDecorator(disableAnimationsDecorator)
   .addParameters({
     componentSubtitle:
       "Icons provide visual context, communicate meaning, and enhance usability.",
@@ -145,6 +147,7 @@ storiesOf(`Icons`, module)
 
 sortedIconComponentNames.forEach(componentName => {
   storiesOf(`Icons/Single icons`, module)
+    .addDecorator(disableAnimationsDecorator)
     .addParameters({
       layout: `padded`,
       options: {


### PR DESCRIPTION
Makes `InProgressIcon` animated similar to what we do in Gatsby Cloud for build status icon. 

Like most other icons, this one can be colored by applying some `color` CSS, e.g.
```typescript
import { InProgressIcon, ThemeCss } from "gatsby-interface"

const purpleIconCss: ThemeCss = theme => ({
  color: theme.colors.gatsby,
})

function PurpleInProgressIcon() {
  return <InProgressIcon css={purpleIconCss} />
}
```

### Preview
https://5f2b05a6b9c58d00084532bb--gatsby-interface.netlify.app/?path=/story/icons-single-icons--inprogressicon