### PR TITLE
fix(buttons): Adjust button sizes to match the design

### DIFF
--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -22,13 +22,13 @@ const baseCss: ThemeCss = _theme => ({
 
 const iconSizeStyles: Record<ButtonSize, ThemeCss> = {
   S: theme => ({
-    fontSize: theme.fontSizes[4],
+    fontSize: theme.fontSizes[2],
   }),
   M: theme => ({
-    fontSize: theme.fontSizes[5],
+    fontSize: theme.fontSizes[4],
   }),
   L: theme => ({
-    fontSize: theme.fontSizes[6],
+    fontSize: theme.fontSizes[5],
   }),
   XL: theme => ({
     fontSize: theme.fontSizes[7],

--- a/src/theme/styles/button.ts
+++ b/src/theme/styles/button.ts
@@ -131,8 +131,8 @@ function getButtonSizeCss(
       return {
         fontSize:
           textVariant === "BRAND" ? theme.fontSizes[1] : theme.fontSizes[0],
-        minHeight: `calc(${theme.space[2]} * 7)`,
-        minWidth: `calc(${theme.space[2]} * 7)`,
+        minHeight: theme.space[7],
+        minWidth: theme.space[7],
         padding: `${theme.space[2]} ${theme.space[3]}`,
       }
     }
@@ -140,8 +140,8 @@ function getButtonSizeCss(
       return {
         fontSize:
           textVariant === "BRAND" ? theme.fontSizes[2] : theme.fontSizes[1],
-        minHeight: `calc(${theme.space[2]} * 9)`,
-        minWidth: `calc(${theme.space[2]} * 9)`,
+        minHeight: theme.space[8],
+        minWidth: theme.space[8],
         padding: `${theme.space[2]} ${theme.space[4]}`,
       }
     }
@@ -149,15 +149,15 @@ function getButtonSizeCss(
       return {
         fontSize:
           textVariant === "BRAND" ? theme.fontSizes[3] : theme.fontSizes[2],
-        minHeight: theme.space[9],
-        minWidth: theme.space[9],
+        minHeight: `calc(${theme.space[8]} + ${theme.space[2]})`,
+        minWidth: `calc(${theme.space[8]} + ${theme.space[2]})`,
         padding: `${theme.space[2]} ${theme.space[5]}`,
       }
     }
     if (size === `XL`) {
       return {
         fontSize:
-          textVariant === "BRAND" ? theme.fontSizes[5] : theme.fontSizes[4],
+          textVariant === "BRAND" ? theme.fontSizes[5] : theme.fontSizes[3],
         minHeight: theme.space[10],
         minWidth: theme.space[10],
         padding: `${theme.space[3]} ${theme.space[6]}`,


### PR DESCRIPTION
Makes button sizes the same as the ones in Figma.

**IMPORTANT** ~needs review for the changes in other components (see Chromatic CI checks) and potentially trying this out in Gatsby Cloud before merging.~ Seems to be OK, with env vars form being the only thing in Gatsby Cloud that needs updating.

### Images
![www chromatic com_snapshot_appId=5d4c6885a869c600201d3c8b id=5f3189ded9ed440022c1fe16](https://user-images.githubusercontent.com/4366711/89814705-66395780-daf8-11ea-842a-76d7362645ee.png)

### Preview
https://deploy-preview-375--gatsby-interface.netlify.app/?path=/story/button-anchorbutton-linkbutton--sizes