### PR TITLE
feat: support 'size' prop for some form elements

### DIFF
--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -10,8 +10,13 @@ import {
 } from "./"
 import { Theme } from "../../theme"
 import { ComboboxOptionProps } from "./Combobox"
-import { boolean, text } from "@storybook/addon-knobs"
-import { isA11yTest } from "../../utils/storybook"
+import { boolean, text, radios } from "@storybook/addon-knobs"
+import {
+  isA11yTest,
+  radioKnobOptions,
+  withVariationsContainer,
+} from "../../utils/storybook"
+import { InputSize, StyledLabel } from "../form"
 
 export default {
   title: `Combobox`,
@@ -57,6 +62,8 @@ const options: ComboboxOptionProps[] = [
   },
 ]
 
+const SIZES: InputSize[] = [`S`, `M`, `L`]
+
 export const Basic = () => {
   return (
     <div css={{ minHeight: `100vh` }}>
@@ -88,6 +95,7 @@ export const Sandbox = () => {
           hasError={boolean(`hasError`, false)}
           showToggleButton={boolean(`showToggleButton`, false)}
           toggleButtonAriaLabel={text("toggleButtonAriaLabel", "Show options")}
+          size={radios("size", radioKnobOptions(SIZES), "M")}
         />
         <ComboboxPopover>
           <ComboboxList aria-labelledby="demo">
@@ -277,4 +285,35 @@ export const WithControlledInput = () => {
       </div>
     </div>
   )
+}
+
+export const Sizes = () =>
+  SIZES.map(size => (
+    <div key={size}>
+      <StyledLabel
+        htmlFor={`input__size--${size}`}
+        id={`label__size--${size}`}
+        labelSize={size}
+      >
+        Label size: "{size}"
+      </StyledLabel>
+      <Combobox>
+        <ComboboxInput
+          aria-labelledby={`label__size--${size}`}
+          id={`input__size--${size}`}
+          size={size}
+        />
+        <ComboboxPopover>
+          <ComboboxList aria-labelledby={`label__size--${size}`}>
+            {options.map(({ value }) => {
+              return <ComboboxOption key={value} value={value} />
+            })}
+          </ComboboxList>
+        </ComboboxPopover>
+      </Combobox>
+    </div>
+  ))
+
+Sizes.story = {
+  decorators: [withVariationsContainer],
 }

--- a/src/components/Combobox/Combobox.styles.tsx
+++ b/src/components/Combobox/Combobox.styles.tsx
@@ -1,5 +1,5 @@
-import { getInputStyles } from "../form/components/FormField.helpers"
 import { ThemeCss } from "../../theme"
+import { baseInputCss, InputSize, getInputSizeCss } from "../form"
 
 export const comboboxCss: ThemeCss = () => ({
   position: `relative`,
@@ -27,10 +27,11 @@ export const searchIconCss: ThemeCss = theme => ({
   zIndex: 2,
 })
 
-export const inputCss: (hasError?: boolean) => ThemeCss = (
-  hasError = false
+export const inputCss: (size?: InputSize) => ThemeCss = (
+  size = "M"
 ) => theme => [
-  getInputStyles(theme, hasError),
+  baseInputCss(theme),
+  getInputSizeCss(size)(theme),
   {
     // offset padding based on search icon spacing and size
     paddingLeft: `calc(${theme.fontSizes[3]} + 2 * ${theme.space[3]})`,

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -36,6 +36,7 @@ import { warn } from "../../utils/maintenance/warn"
 import { RequireProp } from "../../utils/types"
 import { DisableReachStyleCheck } from "../../utils/helpers/DisableReachStyleCheck"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"
+import { InputSize } from "../form"
 
 type ComboboxCustomContextValue = {
   listRef: React.RefObject<HTMLUListElement>
@@ -71,6 +72,7 @@ export type ComboboxInputProps = PropsWithAs<
     hasError?: boolean
     showToggleButton?: boolean
     toggleButtonAriaLabel?: string
+    size?: InputSize
   }
 >
 
@@ -83,6 +85,7 @@ export const ComboboxInput = React.forwardRef<
     hasError,
     showToggleButton,
     toggleButtonAriaLabel = "Show options",
+    size,
     ...delegated
   },
   ref
@@ -140,10 +143,11 @@ export const ComboboxInput = React.forwardRef<
         selectOnClick
         onKeyDown={onKeyDown}
         css={theme => [
-          inputCss(hasError)(theme),
+          inputCss(size)(theme),
           showSelectedOptionLabel && inputWithSelectedValueCss(theme),
           showToggleButton && inputWithToggleButtonCss(theme),
         ]}
+        aria-invalid={hasError}
         {...delegated}
       />
       {!!selectedOptionLabel && (

--- a/src/components/form/components/InputFieldBlock.tsx
+++ b/src/components/form/components/InputFieldBlock.tsx
@@ -31,7 +31,7 @@ export const InputFieldBlock = React.forwardRef<
       error={error}
       hint={hint}
       required={required}
-      labelSize={labelSize}
+      labelSize={labelSize === undefined ? rest.size : labelSize}
       validationMode={validationMode}
       layout={layout}
       className={className}

--- a/src/components/form/components/styled-primitives/StyledInput.tsx
+++ b/src/components/form/components/styled-primitives/StyledInput.tsx
@@ -2,20 +2,30 @@
 import { jsx } from "@emotion/core"
 import React from "react"
 import { ThemeCss } from "../../../../theme"
-import { baseInputCss } from "../../styles"
+import { baseInputCss, InputSize, getInputSizeCss } from "../../styles"
 
-export type StyledInputProps = React.ComponentPropsWithRef<"input">
+export type StyledInputProps = Omit<
+  React.ComponentPropsWithRef<"input">,
+  "size"
+> & {
+  size?: InputSize
+}
 
-export const StyledInput = React.forwardRef<
-  HTMLInputElement,
-  React.ComponentPropsWithRef<"input">
->(function InputFieldControl(props, ref) {
-  const placeholder =
-    props.placeholder && props.disabled
-      ? `The field is disabled`
-      : props.placeholder
+export const StyledInput = React.forwardRef<HTMLInputElement, StyledInputProps>(
+  function InputFieldControl({ size = `M`, ...props }, ref) {
+    const placeholder =
+      props.placeholder && props.disabled
+        ? `The field is disabled`
+        : props.placeholder
 
-  const baseCss: ThemeCss = theme => [baseInputCss(theme), { width: `auto` }]
+    const baseCss: ThemeCss = theme => [
+      baseInputCss(theme),
+      getInputSizeCss(size)(theme),
+      { width: `auto` },
+    ]
 
-  return <input ref={ref} css={baseCss} {...props} placeholder={placeholder} />
-})
+    return (
+      <input ref={ref} css={baseCss} {...props} placeholder={placeholder} />
+    )
+  }
+)

--- a/src/components/form/components/styled-primitives/StyledSelect.tsx
+++ b/src/components/form/components/styled-primitives/StyledSelect.tsx
@@ -2,23 +2,28 @@
 import { jsx } from "@emotion/core"
 import React from "react"
 import { ThemeCss } from "../../../../theme"
-import { baseInputCss } from "../../styles"
+import { baseInputCss, InputSize, getInputSizeCss } from "../../styles"
 
 export type StyledSelectOption = {
   value: string
   label: string
 }
 
-export type StyledSelectProps = React.ComponentPropsWithRef<"select"> & {
+export type StyledSelectProps = Omit<
+  React.ComponentPropsWithRef<"select">,
+  "size"
+> & {
   options: StyledSelectOption[]
+  size?: InputSize
 }
 
 export const StyledSelect = React.forwardRef<
   HTMLSelectElement,
   StyledSelectProps
->(function SelectFieldControl({ options, ...rest }, ref) {
+>(function SelectFieldControl({ options, size = "M", ...rest }, ref) {
   const baseCss: ThemeCss = theme => [
     baseInputCss(theme),
+    getInputSizeCss(size)(theme),
     {
       padding: `0 ${theme.space[3]}`,
       backgroundImage: `url("data:image/svg+xml,%3Csvg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 24 24' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z'%3E%3C/path%3E%3C/svg%3E")`,

--- a/src/components/form/components/styled-primitives/StyledTextArea.tsx
+++ b/src/components/form/components/styled-primitives/StyledTextArea.tsx
@@ -2,14 +2,19 @@
 import { jsx } from "@emotion/core"
 import React from "react"
 import { ThemeCss } from "../../../../theme"
-import { baseInputCss } from "../../styles"
+import { baseInputCss, InputSize, getInputSizeCss } from "../../styles"
 
-export type StyledTextAreaProps = React.ComponentPropsWithRef<"textarea">
+export type StyledTextAreaProps = Omit<
+  React.ComponentPropsWithRef<"textarea">,
+  "size"
+> & {
+  size?: InputSize
+}
 
 export const StyledTextArea = React.forwardRef<
   HTMLTextAreaElement,
   StyledTextAreaProps
->(function StyledTextArea(props, ref) {
+>(function StyledTextArea({ size = `M`, ...props }, ref) {
   const placeholder =
     props.placeholder && props.disabled
       ? `The field is disabled`
@@ -17,6 +22,7 @@ export const StyledTextArea = React.forwardRef<
 
   const baseCss: ThemeCss = theme => [
     baseInputCss(theme),
+    getInputSizeCss(size)(theme),
     {
       display: `block`,
       minHeight: `4.85em`,

--- a/src/components/form/stories/InputFieldBlock.stories.tsx
+++ b/src/components/form/stories/InputFieldBlock.stories.tsx
@@ -4,11 +4,16 @@ import { action } from "@storybook/addon-actions"
 import { InputFieldBlock, FormFieldBlockLayout } from ".."
 import { FormFieldLabelSize } from "../components/FormField.helpers"
 import { getFieldBlockSandboxProps } from "./stories.utils"
-import { text } from "@storybook/addon-knobs"
-import { withVariationsContainer } from "../../../utils/storybook"
+import { text, radios } from "@storybook/addon-knobs"
+import {
+  withVariationsContainer,
+  radioKnobOptions,
+} from "../../../utils/storybook"
 import InputFieldBlockDocs from "./InputFieldBlock.mdx"
+import { InputSize } from "../styles"
 
 const LABEL_SIZES: FormFieldLabelSize[] = [`L`, `M`, `S`]
+const SIZES: InputSize[] = [`S`, `M`, `L`]
 
 export default {
   title: `Form/Styled Blocks/InputFieldBlock`,
@@ -38,6 +43,7 @@ export const Sandbox = () => {
     <InputFieldBlock
       id="sandbox"
       placeholder={placeholder}
+      size={radios("size", radioKnobOptions(SIZES), "M")}
       {...getFieldBlockSandboxProps()}
     />
   )
@@ -74,11 +80,26 @@ export const WithErrorAndHint = () => (
   />
 )
 
+export const Sizes = () =>
+  SIZES.map(size => (
+    <InputFieldBlock
+      key={size}
+      id={`InputFieldBlock__size--${size}`}
+      label={`Size: "${size}"`}
+      size={size}
+      defaultValue="Default value"
+    />
+  ))
+
+Sizes.story = {
+  decorators: [withVariationsContainer],
+}
+
 export const LabelSizes = () =>
   LABEL_SIZES.map(labelSize => (
     <InputFieldBlock
       key={labelSize}
-      id={labelSize}
+      id={`InputFieldBlock__labelSize--${labelSize}`}
       label={`Label size: "${labelSize}"`}
       labelSize={labelSize}
     />

--- a/src/components/form/stories/SelectFieldBlock.stories.tsx
+++ b/src/components/form/stories/SelectFieldBlock.stories.tsx
@@ -2,15 +2,19 @@
 import { jsx } from "@emotion/core"
 
 import { action } from "@storybook/addon-actions"
-import { SelectFieldBlock, FormFieldBlockLayout } from ".."
+import { SelectFieldBlock, FormFieldBlockLayout, InputSize } from ".."
 import { FormFieldLabelSize } from "../components/FormField.helpers"
 import { getFieldBlockSandboxProps } from "./stories.utils"
-import { text } from "@storybook/addon-knobs"
+import { text, radios } from "@storybook/addon-knobs"
 import { getGroupFieldStoryOptions } from "../../form-skeletons/stories/storyUtils"
-import { withVariationsContainer } from "../../../utils/storybook"
+import {
+  withVariationsContainer,
+  radioKnobOptions,
+} from "../../../utils/storybook"
 import SelectFieldBlockDocs from "./SelectFieldBlock.mdx"
 
 const LABEL_SIZES: FormFieldLabelSize[] = [`L`, `M`, `S`]
+const SIZES: InputSize[] = [`S`, `M`, `L`]
 
 const options = getGroupFieldStoryOptions()
 
@@ -43,6 +47,7 @@ export const Sandbox = () => {
     <SelectFieldBlock
       id="SelectFieldBlock"
       placeholder={placeholder}
+      size={radios("size", radioKnobOptions(SIZES), "M")}
       {...getFieldBlockSandboxProps()}
       options={options}
     />
@@ -101,11 +106,26 @@ export const WithErrorAndHint = () => (
   />
 )
 
+export const Sizes = () =>
+  SIZES.map(size => (
+    <SelectFieldBlock
+      key={size}
+      id={`SelectFieldBlock__size--${size}`}
+      label={`Size: "${size}"`}
+      size={size}
+      options={options}
+    />
+  ))
+
+Sizes.story = {
+  decorators: [withVariationsContainer],
+}
+
 export const LabelSizes = () =>
   LABEL_SIZES.map(labelSize => (
     <SelectFieldBlock
       key={labelSize}
-      id={`SelectFieldBlock__size--${labelSize}`}
+      id={`SelectFieldBlock__labelSize--${labelSize}`}
       label={`Label size: "${labelSize}"`}
       labelSize={labelSize}
       options={options}

--- a/src/components/form/stories/TextAreaFieldBlock.stories.tsx
+++ b/src/components/form/stories/TextAreaFieldBlock.stories.tsx
@@ -2,14 +2,18 @@
 import { jsx } from "@emotion/core"
 
 import { action } from "@storybook/addon-actions"
-import { TextAreaFieldBlock, FormFieldBlockLayout } from ".."
+import { TextAreaFieldBlock, FormFieldBlockLayout, InputSize } from ".."
 import { FormFieldLabelSize } from "../components/FormField.helpers"
 import { getFieldBlockSandboxProps } from "./stories.utils"
-import { text } from "@storybook/addon-knobs"
-import { withVariationsContainer } from "../../../utils/storybook"
+import { text, radios } from "@storybook/addon-knobs"
+import {
+  withVariationsContainer,
+  radioKnobOptions,
+} from "../../../utils/storybook"
 import TextAreaFieldBlockDocs from "./TextAreaFieldBlock.mdx"
 
 const LABEL_SIZES: FormFieldLabelSize[] = [`L`, `M`, `S`]
+const SIZES: InputSize[] = [`S`, `M`, `L`]
 
 export default {
   title: `Form/Styled Blocks/TextAreaFieldBlock`,
@@ -39,6 +43,7 @@ export const Sandbox = () => {
     <TextAreaFieldBlock
       id="TextAreaFieldBlock"
       placeholder={placeholder}
+      size={radios("size", radioKnobOptions(SIZES), "M")}
       {...getFieldBlockSandboxProps()}
     />
   )
@@ -83,11 +88,26 @@ export const WithErrorAndHint = () => (
   />
 )
 
+export const Sizes = () =>
+  SIZES.map(size => (
+    <TextAreaFieldBlock
+      key={size}
+      id={`TextAreaFieldBlock__size--${size}`}
+      label={`Size: "${size}"`}
+      size={size}
+      defaultValue="Default value"
+    />
+  ))
+
+Sizes.story = {
+  decorators: [withVariationsContainer],
+}
+
 export const LabelSizes = () =>
   LABEL_SIZES.map(labelSize => (
     <TextAreaFieldBlock
       key={labelSize}
-      id={`TextAreaFieldBlock__size--${labelSize}`}
+      id={`TextAreaFieldBlock__labelSize--${labelSize}`}
       label={`Label size: "${labelSize}"`}
       labelSize={labelSize}
     />

--- a/src/components/form/styles/index.ts
+++ b/src/components/form/styles/index.ts
@@ -57,7 +57,6 @@ export const baseInputCss: ThemeCss = theme => [
     color: theme.colors.grey[90],
     fontFamily: theme.fonts.system,
     fontSize: theme.fontSizes[2],
-    height: `2.25rem`,
     padding: `0 ${theme.space[3]}`,
     position: `relative`,
     width: `100%`,
@@ -80,6 +79,27 @@ export const baseInputCss: ThemeCss = theme => [
     ),
   },
 ]
+
+export type InputSize = "S" | `M` | "L"
+
+export function getInputSizeCss(size: InputSize) {
+  return inputSizeCss[size]
+}
+
+const inputSizeCss: Record<InputSize, ThemeCss> = {
+  S: theme => ({
+    minHeight: theme.space[8],
+    fontSize: theme.fontSizes[1],
+  }),
+  M: theme => ({
+    minHeight: `calc(${theme.space[8]} + ${theme.space[2]})`,
+    fontSize: theme.fontSizes[2],
+  }),
+  L: theme => ({
+    minHeight: theme.space[10],
+    fontSize: theme.fontSizes[3],
+  }),
+}
 
 export function getOptionLabelCss(
   optionControlSize = "0px",


### PR DESCRIPTION
POC for supporting different sizes for some of the form elements.

This PR adds support for a new `size` prop to the following components:
* `StyledInput` (and `InputFieldBlock`)
* `StyledSelect` (and `SelectFieldBlock`)
* `StyledTextArea` (and `TextAreaFieldBlock`)
* `ComboboxInput`

The supported values mirror those of `labelSize`: `S`, `M` and `L`. In terms of height and font size those correspond to `ButtonSize` of `M`, `L` and `XL` respectively (supporting an equivalent to button's `S` size doesn't seem viable to me, as the font size is going to be too small in that case). 

### Open questions:
* Could we omit current `labelSize` altogether and use `size` instead, coupling label and control sizes? For now I have made `labelSize` fall back to `size` if no value has been passed.
* What about other form components, such as single checkbox field or checkbox group or radio button? Should we support different sizes for those and how should they look? This can be done in a separate PR.

### Images
#### Input
<img width="294" alt="Screen Shot 2020-08-11 at 1 16 31 PM" src="https://user-images.githubusercontent.com/4366711/89944652-04025480-dbd5-11ea-967f-9354b3ebd9a6.png">

#### Select
<img width="262" alt="Screen Shot 2020-08-11 at 1 16 37 PM" src="https://user-images.githubusercontent.com/4366711/89944671-09f83580-dbd5-11ea-9b94-a6e16077f38f.png">

#### Text area
<img width="274" alt="Screen Shot 2020-08-11 at 1 16 49 PM" src="https://user-images.githubusercontent.com/4366711/89944686-11b7da00-dbd5-11ea-9521-5c9827268f35.png">

#### Combobox input
<img width="296" alt="Screen Shot 2020-08-11 at 1 15 45 PM" src="https://user-images.githubusercontent.com/4366711/89944695-17152480-dbd5-11ea-8de5-3859d00af824.png">
