### PR TITLE
fix(Avatar): start a new z-index stack for AvatarsGroup

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,110 +1,129 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import { storiesOf } from "@storybook/react"
+import React from "react"
 import { text, color, boolean, number, radios } from "@storybook/addon-knobs"
-
-import { StoryUtils } from "../../utils/storybook"
-import README from "./README.md"
 import Avatar from "./Avatar"
 import AvatarsGroup from "./AvatarsGroup"
 import { AvatarSize } from "./index"
+import { radioKnobOptions } from "../../utils/storybook"
+
+export default {
+  title: `Avatar`,
+  component: Avatar,
+  parameters: {
+    componentSubtitle:
+      "Avatars can represent a user or a brand, plugin, theme, or starter (with a logo or branded graphic). Usually used to represent user, they can also display user initials or a default icon as a fallback.",
+    design: {
+      type: "figma",
+      url:
+        "https://www.figma.com/file/E9BxE7udN0PmULGRCevSsGtK/Avatars?node-id=257%3A0",
+    },
+  },
+}
 
 const IMG_URL_1 = `https://picsum.photos/id/1005/200/200`
 const IMG_URL_2 = `https://picsum.photos/id/1025/200/200`
+const SIZES: AvatarSize[] = [`XS`, `S`, `M`, `L`, `XL`, `XXL`]
 
-storiesOf(`Avatar`, module)
-  .addParameters({
-    componentSubtitle:
-      "Avatars can represent a user or a brand, plugin, theme, or starter (with a logo or branded graphic). Usually used to represent user, they can also display user initials or a default icon as a fallback.",
-    options: {
-      showPanel: true,
-    },
-    readme: {
-      sidebar: README,
-    },
-  })
-  .add(`Avatar`, () => {
-    const bordered = boolean("Show border?", false)
-    const borderColor = color("borderColor", "#000")
-    return (
-      <StoryUtils.Container>
-        <div>
-          <Avatar
-            src={IMG_URL_1}
-            label={text("label", "John Doe")}
-            borderColor={bordered ? borderColor : null}
-            size={radios(
-              "size",
-              {
-                xsmall: "XS",
-                small: "S",
-                medium: "M",
-                large: "L",
-                xlarge: "XL",
-                xxlarge: "XXL",
-              },
-              "M"
-            )}
-          />
-        </div>
-      </StoryUtils.Container>
-    )
-  })
-  .add(`Avatar fallback text fit`, () => {
-    const sizes: AvatarSize[] = ["XS", "S", "M", "L", "XL", "XXL"]
-    return (
-      <StoryUtils.Container>
-        <div>
-          {sizes.map(size => (
-            <Avatar
-              key={size}
-              src=""
-              label={`Avatar of size ${size}`}
-              fallback={text("fallback text", "A")}
-              size={size}
-            />
-          ))}
-        </div>
-      </StoryUtils.Container>
-    )
-  })
-  .add(`AvatarsGroup`, () => {
-    const borderColor = color("borderColor", "#fff")
-    return (
-      <StoryUtils.Container>
-        <div>
-          <AvatarsGroup
-            avatars={[
-              {
-                src: IMG_URL_1,
-                label: `John Doe`,
-              },
-              { src: ``, label: `John Doe`, fallback: "JD" },
-              {
-                src: IMG_URL_2,
-                label: `Jane Doe`,
-              },
-            ]}
-            borderColor={borderColor}
-            size={radios(
-              "size",
-              {
-                xsmall: "XS",
-                small: "S",
-                medium: "M",
-                large: "L",
-                xlarge: "XL",
-                xxlarge: "XXL",
-              },
-              "M"
-            )}
-            omittedAvatarsCount={number("omittedAvatarsCount", 1)}
-            omittedAvatarsLabel={text(
-              "omittedAvatarsLabel",
-              "More users not displayed"
-            )}
-          />
-        </div>
-      </StoryUtils.Container>
-    )
-  })
+export const Basic = () => <Avatar src={IMG_URL_1} label="A nice userpic" />
+
+export const Sandbox = () => {
+  const bordered = boolean("Show border?", false)
+  const borderColor = color("borderColor", "#000")
+  return (
+    <Avatar
+      src={text("src", IMG_URL_1)}
+      label={text("label", "John Doe")}
+      fallback={text("fallback text", "JD")}
+      borderColor={bordered ? borderColor : null}
+      size={radios("size", radioKnobOptions(SIZES), "M")}
+    />
+  )
+}
+
+Sandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}
+
+export const Sizes = () => (
+  <React.Fragment>
+    <div>
+      {SIZES.map(size => (
+        <Avatar
+          key={size}
+          src={IMG_URL_1}
+          label={`Avatar of size ${size}`}
+          size={size}
+          css={{ verticalAlign: `bottom ` }}
+        />
+      ))}
+    </div>
+    <div>
+      {SIZES.map(size => (
+        <Avatar
+          key={size}
+          src=""
+          label={`Avatar of size ${size}`}
+          fallback={size}
+          size={size}
+          css={{ verticalAlign: `bottom ` }}
+        />
+      ))}
+    </div>
+  </React.Fragment>
+)
+
+export const AvatarsGroupStory = () => (
+  <AvatarsGroup
+    avatars={[
+      {
+        src: IMG_URL_1,
+        label: `John Doe`,
+      },
+      { src: ``, label: `John Doe`, fallback: "JD" },
+      {
+        src: IMG_URL_2,
+        label: `Jane Doe`,
+      },
+    ]}
+    omittedAvatarsCount={3}
+    omittedAvatarsLabel="3 more users not shown"
+  />
+)
+
+AvatarsGroupStory.story = {
+  name: `AvatarsGroup`,
+}
+
+export const AvatarsGroupSandbox = () => {
+  return (
+    <AvatarsGroup
+      avatars={[
+        {
+          src: IMG_URL_1,
+          label: `John Doe`,
+        },
+        { src: ``, label: `John Doe`, fallback: "JD" },
+        {
+          src: IMG_URL_2,
+          label: `Jane Doe`,
+        },
+      ]}
+      borderColor={color("borderColor", "#fff")}
+      size={radios("size", radioKnobOptions(SIZES), "M")}
+      omittedAvatarsCount={number("omittedAvatarsCount", 1)}
+      omittedAvatarsLabel={text(
+        "omittedAvatarsLabel",
+        "More users not displayed"
+      )}
+    />
+  )
+}
+
+AvatarsGroupSandbox.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+}

--- a/src/components/Avatar/AvatarsGroup.tsx
+++ b/src/components/Avatar/AvatarsGroup.tsx
@@ -1,13 +1,15 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import { css } from "@emotion/core"
 import { AvatarSize } from "./types"
 import Avatar, { AvatarProps } from "./Avatar"
 import { DEFAULT_SIZE, borderSizeValues } from "./constants"
+import { ThemeCss } from "../../theme"
 
-const groupBaseCss = css({
+const groupBaseCss: ThemeCss = _theme => ({
   display: "flex",
   alignItems: "center",
+  // Create new stacking context
+  zIndex: 1,
 })
 
 export type AvatarDescriptor = Pick<AvatarProps, "src" | "label" | "fallback">
@@ -36,13 +38,14 @@ export default function AvatarsGroup({
     borderColor,
   }
   const overlapCss = {
-    marginLeft: `-${borderSizeValues[size] * 2}px`,
+    "&:not(:first-child)": {
+      marginLeft: `-${borderSizeValues[size] * 2}px`,
+    },
   }
-  const avatarsShown = avatars.length
 
   return (
     <div css={groupBaseCss} className={className} style={style}>
-      {avatars.map(({ src, label, ...avatar }, idx) => {
+      {avatars.map(({ src, label, ...avatar }, idx, list) => {
         return (
           <Avatar
             // Using both src and label as key because src might not be unique
@@ -51,8 +54,8 @@ export default function AvatarsGroup({
             label={label}
             {...commonAvatarProps}
             {...avatar}
-            css={idx !== 0 && overlapCss}
-            style={{ zIndex: avatarsShown - idx }}
+            css={overlapCss}
+            style={{ zIndex: list.length - idx }}
           />
         )
       })}

--- a/src/components/Avatar/AvatarsGroup.tsx
+++ b/src/components/Avatar/AvatarsGroup.tsx
@@ -38,7 +38,7 @@ export default function AvatarsGroup({
     borderColor,
   }
   const overlapCss = {
-    "&:not(:first-child)": {
+    "&:not(:first-of-type)": {
       marginLeft: `-${borderSizeValues[size] * 2}px`,
     },
   }

--- a/src/components/Avatar/AvatarsGroup.tsx
+++ b/src/components/Avatar/AvatarsGroup.tsx
@@ -9,7 +9,7 @@ const groupBaseCss: ThemeCss = _theme => ({
   display: "flex",
   alignItems: "center",
   // Create new stacking context
-  zIndex: 1,
+  zIndex: 0,
 })
 
 export type AvatarDescriptor = Pick<AvatarProps, "src" | "label" | "fallback">


### PR DESCRIPTION
This should fix the overlap issue happening in Gatsby Cloud (https://github.com/gatsbyjs/gatsby/issues/26739). The reason for that issue is that we are not resetting z-index stacking context in `AvatarGroup` which results in having to adjust dropdown menu's `z-index`.

I have also updated related stories in Storybook to follow Component Story Format.