### PR TITLE
Use 'import * as React'

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react"
+import * as React from "react"
 import { Global, css } from "@emotion/core"
 import { addDecorator } from "@storybook/react"
 import { withKnobs } from "@storybook/addon-knobs"
@@ -42,7 +42,7 @@ addDecorator(withKnobs)
 addDecorator(withTheme)
 
 const withGlobal = storyFn => (
-  <Fragment>
+  <React.Fragment>
     <Global
       styles={css`
         *,
@@ -71,7 +71,7 @@ const withGlobal = storyFn => (
       `}
     />
     {storyFn()}
-  </Fragment>
+  </React.Fragment>
 )
 
 addDecorator(withGlobal)

--- a/__tests__/icons.test.js
+++ b/__tests__/icons.test.js
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { renderWithTheme } from "../src/utils/testing"
 import * as icons from "../src/components/icons/icons"
 

--- a/scripts/scaffold-component/component-template.ejs
+++ b/scripts/scaffold-component/component-template.ejs
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from 'react'
+import * as React from 'react'
 import { ThemeCss, Theme } from "../../theme"
 
 const baseCss: ThemeCss = theme => ({

--- a/scripts/scaffold-icon/icon-template.ejs
+++ b/scripts/scaffold-icon/icon-template.ejs
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import IconSkeleton from './IconSkeleton'
 import { IconProps } from "./types"
 

--- a/src/assets/NetlifyLogo.js
+++ b/src/assets/NetlifyLogo.js
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 
 export default ({ width = 102, height = 28 }) => (
   <svg

--- a/src/components/AnchorButton/AnchorButton.tsx
+++ b/src/components/AnchorButton/AnchorButton.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { BaseAnchor, BaseAnchorProps } from "../BaseAnchor"
 import { ButtonStyleProps, getButtonStyles } from "../Button/Button"
 

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { text, color, boolean, number, radios } from "@storybook/addon-knobs"
 import Avatar from "./Avatar"
 import AvatarsGroup from "./AvatarsGroup"

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React from "react"
+import * as React from "react"
 import { jsx } from "@emotion/core"
 import { css } from "@emotion/core"
 import AvatarSkeleton from "./AvatarSkeleton"

--- a/src/components/BaseAnchor/BaseAnchor.tsx
+++ b/src/components/BaseAnchor/BaseAnchor.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import secureTargetBlankLink from "../../utils/helpers/secureTargetBlankLink"
 
 export type BaseAnchorProps = Omit<JSX.IntrinsicElements["a"], "ref">

--- a/src/components/BaseButton/BaseButton.tsx
+++ b/src/components/BaseButton/BaseButton.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { PropsOf } from "../../utils/types"
 
 export type BaseButtonProps = Omit<JSX.IntrinsicElements["button"], "ref"> & {

--- a/src/components/BaseHeading/BaseHeading.tsx
+++ b/src/components/BaseHeading/BaseHeading.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { PropsOf } from "../../utils/types"
 
 type AllowedAs = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "span"

--- a/src/components/BaseLink/BaseLink.tsx
+++ b/src/components/BaseLink/BaseLink.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { Link, GatsbyLinkProps } from "gatsby"
 
 export type BaseLinkProps<TState> = Omit<GatsbyLinkProps<TState>, "ref">

--- a/src/components/BaseNavigation/BaseNavigation.stories.tsx
+++ b/src/components/BaseNavigation/BaseNavigation.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx, Global } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { DecoratorFn } from "@storybook/react"
 import { text, boolean } from "@storybook/addon-knobs"
 

--- a/src/components/BaseNavigation/BaseNavigation.tsx
+++ b/src/components/BaseNavigation/BaseNavigation.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Link, GatsbyLinkProps } from "gatsby"
 import { MdArrowForward } from "react-icons/md"
 

--- a/src/components/BaseText/BaseText.tsx
+++ b/src/components/BaseText/BaseText.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { PropsOf } from "../../utils/types"
 
 type AllowedAs = "p" | "span"

--- a/src/components/BuildLogs/BuildActivityEntry.tsx
+++ b/src/components/BuildLogs/BuildActivityEntry.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import {
   BuildLogItem,
   BuildActivity,

--- a/src/components/BuildLogs/BuildLogEntrySkeleton.tsx
+++ b/src/components/BuildLogs/BuildLogEntrySkeleton.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../theme"
 
 const baseCss: ThemeCss = theme => ({

--- a/src/components/BuildLogs/BuildLogsList.stories.tsx
+++ b/src/components/BuildLogs/BuildLogsList.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { text, select, number } from "@storybook/addon-knobs"
 import { DecoratorFn } from "@storybook/react"
 

--- a/src/components/BuildLogs/FormattedMessage.tsx
+++ b/src/components/BuildLogs/FormattedMessage.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import Markdown from "markdown-to-jsx"
 
 // Check for "1 |" presence to create a code block

--- a/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
+++ b/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { render } from "@testing-library/react"
 import { FormattedMessage } from "../FormattedMessage"
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { DecoratorFn } from "@storybook/react"
 import { action } from "@storybook/addon-actions"
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { MdRefresh } from "react-icons/md"
 
 import { BaseButton, BaseButtonProps } from "../BaseButton"

--- a/src/components/Button/utils/storybook-styles.tsx
+++ b/src/components/Button/utils/storybook-styles.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 
 import { action } from "@storybook/addon-actions"
 import { MdArrowForward } from "react-icons/md"

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../theme"
 import { Heading, HeadingProps } from "../Heading"
 

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { storiesOf } from "@storybook/react"
 
 import { StoryUtils } from "../../utils/storybook"

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { css } from "@emotion/core"
 import BaseChip, { BaseChipProps } from "./BaseChip"
 

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import {
   Combobox,
   ComboboxInput,

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import {
   Combobox as ReachCombobox,
   ComboboxProps as ReachComboboxProps,

--- a/src/components/CopyButton/CopyButton.stories.tsx
+++ b/src/components/CopyButton/CopyButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { storiesOf } from "@storybook/react"
 import { text } from "@storybook/addon-knobs"
 import { StoryUtils } from "../../utils/storybook"

--- a/src/components/CopyButton/CopyButton.tsx
+++ b/src/components/CopyButton/CopyButton.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import PropTypes from "prop-types"
 import { css } from "@emotion/core"
 

--- a/src/components/CopyButton/__tests__/CopyButton.test.tsx
+++ b/src/components/CopyButton/__tests__/CopyButton.test.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { fireEvent } from "@testing-library/react"
 import { CopyButton } from "../index"
 import { renderWithTheme } from "../../../utils/testing"

--- a/src/components/DecorativeDots/DecorativeDots.stories.tsx
+++ b/src/components/DecorativeDots/DecorativeDots.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 
 import { storiesOf } from "@storybook/react"
 import { number } from "@storybook/addon-knobs"

--- a/src/components/DensityProvider/DensityProvider.tsx
+++ b/src/components/DensityProvider/DensityProvider.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 
 export type Density = `DENSE` | `DEFAULT` | `LOOSE`
 

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuItems,
   DropdownMenuButtonStyled,
 } from "./"
-import React from "react"
+import * as React from "react"
 import { radios, text } from "@storybook/addon-knobs"
 import { action } from "@storybook/addon-actions"
 import { Theme } from "../../theme"

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import {
   Menu,
   MenuProps,

--- a/src/components/EmptyState/EmptyState.stories.tsx
+++ b/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { text, radios, select } from "@storybook/addon-knobs"
 import { DecoratorFn } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss, Theme } from "../../theme"
 import { HeadingProps, Heading } from "../Heading"
 import { Text } from "../Text"

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../theme"
 import { ButtonStyleProps, getButtonStyles } from "../Button"
 import { BaseButton, BaseButtonProps } from "../BaseButton"

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { DialogOverlay } from "@reach/dialog"
 import colors from "../../theme/colors"
 import { hexToRGBA } from "../../utils/helpers/hexToRgb"

--- a/src/components/Modal/ModalCard.stories.tsx
+++ b/src/components/Modal/ModalCard.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { Modal } from "./Modal"
 import { text } from "@storybook/addon-knobs"
 import { ModalCard } from "./"

--- a/src/components/Modal/ModalCard.tsx
+++ b/src/components/Modal/ModalCard.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { keyframes } from "@emotion/core"
 import { ModalContent, ModalContentProps } from "./ModalContent"
 import { ThemeCss } from "../../theme"

--- a/src/components/Modal/ModalFullScreen.stories.tsx
+++ b/src/components/Modal/ModalFullScreen.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { Modal } from "./Modal"
 import { text } from "@storybook/addon-knobs"
 import { ModalFullScreen } from "./"

--- a/src/components/Modal/ModalFullScreen.tsx
+++ b/src/components/Modal/ModalFullScreen.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { keyframes } from "@emotion/core"
 import { ModalContent, ModalContentProps } from "./ModalContent"
 import { ThemeCss } from "../../theme"

--- a/src/components/Modal/ModalPanel.stories.tsx
+++ b/src/components/Modal/ModalPanel.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { Modal } from "./Modal"
 import { text, radios } from "@storybook/addon-knobs"
 import { ModalPanel, ModalPanelPosition } from "./"

--- a/src/components/Modal/ModalPanel.tsx
+++ b/src/components/Modal/ModalPanel.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { keyframes } from "@emotion/core"
 import { ModalContent, ModalContentProps } from "./ModalContent"
 import { ThemeCss } from "../../theme"

--- a/src/components/Modal/StyledModal.stories.tsx
+++ b/src/components/Modal/StyledModal.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Global } from "@emotion/core"
 import { DecoratorFn } from "@storybook/react"
 import { text, radios } from "@storybook/addon-knobs"

--- a/src/components/Modal/StyledModal.tsx
+++ b/src/components/Modal/StyledModal.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { MdClose } from "react-icons/md"
 import { Heading } from "../Heading"
 import {

--- a/src/components/Modal/StyledPanel.stories.tsx
+++ b/src/components/Modal/StyledPanel.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Global } from "@emotion/core"
 import { DecoratorFn } from "@storybook/react"
 import { text } from "@storybook/addon-knobs"

--- a/src/components/Modal/StyledPanel.tsx
+++ b/src/components/Modal/StyledPanel.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Heading } from "../Heading"
 import {
   StyledModalCloseButton,

--- a/src/components/Navigation/Navigation.stories.tsx
+++ b/src/components/Navigation/Navigation.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx, Global } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { boolean, text } from "@storybook/addon-knobs"
 import { Navigation, NavigationItemOptions } from "."
 

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ClassNames } from "@emotion/core"
 import {
   BaseNavigation,

--- a/src/components/Notification/Notification.stories.tsx
+++ b/src/components/Notification/Notification.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { DecoratorFn } from "@storybook/react"
 import { radios, text, select, boolean } from "@storybook/addon-knobs"
 import { useTransition, animated } from "react-spring"

--- a/src/components/NumberBadge/NumberBadge.tsx
+++ b/src/components/NumberBadge/NumberBadge.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss, Theme } from "../../theme"
 
 const baseCss: ThemeCss = theme => ({

--- a/src/components/Portal/Portal.stories.tsx
+++ b/src/components/Portal/Portal.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { storiesOf } from "@storybook/react"
 import Portal from "./"
 import README from "./README.md"

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { number } from "@storybook/addon-knobs"
 import { ProgressBar } from "./ProgressBar"
 import { Theme } from "../../theme"

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Theme } from "../../theme"
 import { CSSObject } from "@emotion/core"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"

--- a/src/components/RawLogs/RawLogs.stories.tsx
+++ b/src/components/RawLogs/RawLogs.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { RawLogs, RawLogItem } from "."
 import { Text } from "../Text"
 

--- a/src/components/RawLogs/RawLogs.tsx
+++ b/src/components/RawLogs/RawLogs.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import format from "date-fns/format"
 import { ThemeCss } from "../../theme"
 

--- a/src/components/SidebarNav/SidebarNav.stories.tsx
+++ b/src/components/SidebarNav/SidebarNav.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { DecoratorFn } from "@storybook/react"
 import { withDesign } from "storybook-addon-designs"
 import {

--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Link } from "gatsby"
 import { Theme, ThemeCss } from "../../theme"
 

--- a/src/components/SkipNav/SkipNav.stories.tsx
+++ b/src/components/SkipNav/SkipNav.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { SkipNavTarget, SkipNavTrigger } from "."
 import { Button } from "../Button"
 import { Link } from "../Link"

--- a/src/components/SkipNav/SkipNav.tsx
+++ b/src/components/SkipNav/SkipNav.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../theme"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"
 

--- a/src/components/Spacer/Spacer.stories.tsx
+++ b/src/components/Spacer/Spacer.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { radios, select } from "@storybook/addon-knobs"
 import {
   radioKnobOptions,

--- a/src/components/SplitButton/SplitButton.stories.tsx
+++ b/src/components/SplitButton/SplitButton.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { text, radios, boolean } from "@storybook/addon-knobs"
 import {
   radioKnobOptions,

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../theme"
 import { ButtonVariant } from "../../theme/styles/button"
 import {

--- a/src/components/StepIndicator/StepIndicator.tsx
+++ b/src/components/StepIndicator/StepIndicator.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss, Theme } from "../../theme"
 
 const baseCss: ThemeCss = theme => ({

--- a/src/components/StepIndicator/StepIndicatorStep.tsx
+++ b/src/components/StepIndicator/StepIndicatorStep.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Link as GatsbyLink, GatsbyLinkProps } from "gatsby"
 import { Theme } from "../../theme"
 import {

--- a/src/components/StickyObserver/StickyObserver.stories.tsx
+++ b/src/components/StickyObserver/StickyObserver.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { text, radios } from "@storybook/addon-knobs"
 import { radioKnobOptions } from "../../utils/storybook/knobs"
 import {

--- a/src/components/StickyObserver/StickyObserver.tsx
+++ b/src/components/StickyObserver/StickyObserver.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Theme } from "../../theme"
 
 export type LipShadowPosition = `top` | `bottom`

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import {
   Tabs as ReachTabs,
   TabsProps as ReachTabsProps,

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { ThemeProvider as ThemeUiProvider, useThemeUI } from "theme-ui"
 import { getTheme, Theme } from "../../theme"
 

--- a/src/components/Toast/MessageWithLink.tsx
+++ b/src/components/Toast/MessageWithLink.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React from "react"
+import * as React from "react"
 import { css, jsx } from "@emotion/core"
 import { Link } from "../Link"
 

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { storiesOf } from "@storybook/react"
 import { StoryUtils } from "../../utils/storybook"
 import { Button } from "../Button"

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React from "react"
+import * as React from "react"
 import Alert from "@reach/alert"
 import { keyframes, css, jsx } from "@emotion/core"
 import { MdDone, MdClose, MdWarning } from "react-icons/md"

--- a/src/components/Toast/ToastContext.tsx
+++ b/src/components/Toast/ToastContext.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { ToastTone } from "./types"
 
 export interface ToastOptions {

--- a/src/components/Toast/ToastProvider.tsx
+++ b/src/components/Toast/ToastProvider.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Toast } from "./Toast"
 import { ToastContext } from "./ToastContext"
 import { useToastActions } from "./hooks"

--- a/src/components/Toast/__tests__/Toast.js
+++ b/src/components/Toast/__tests__/Toast.js
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { fireEvent, act } from "@testing-library/react"
 import {
   ToastProvider,

--- a/src/components/Toast/__tests__/__snapshots__/Toast.js.snap
+++ b/src/components/Toast/__tests__/__snapshots__/Toast.js.snap
@@ -3,12 +3,12 @@
 exports[`Toast renders unchanged 1`] = `
 <div>
   <div
-    class="css-6pdnk1-toastCss-Toast-Toast"
+    class="css-vwg7j5-toastCss-Toast-Toast"
     data-reach-alert="true"
     data-testid="toast"
   >
     <span
-      class="css-3wzd5o-statusCss-Toast-Toast"
+      class="css-1x71pa8-statusCss-Toast-Toast"
     >
       <svg
         fill="currentColor"
@@ -50,12 +50,12 @@ exports[`Toast renders unchanged 1`] = `
     </button>
   </div>
   <div
-    class="css-j6docj-toastCss-Toast-Toast"
+    class="css-1umw33v-toastCss-Toast-Toast"
     data-reach-alert="true"
     data-testid="toast"
   >
     <span
-      class="css-18fmh0q-statusCss-Toast-Toast"
+      class="css-1ts4l6o-statusCss-Toast-Toast"
     >
       <svg
         fill="currentColor"

--- a/src/components/Toggle/ToggleCheckbox.stories.tsx
+++ b/src/components/Toggle/ToggleCheckbox.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 
 import { ToggleCheckbox, ToggleCheckboxProps } from "./"
 import {

--- a/src/components/Toggle/ToggleCheckbox.tsx
+++ b/src/components/Toggle/ToggleCheckbox.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"
 import { AtomTone } from "../../theme/types"
 import { Theme } from "../../theme"

--- a/src/components/Toggle/ToggleSwitch.stories.tsx
+++ b/src/components/Toggle/ToggleSwitch.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 
 import {
   radioKnobOptions,

--- a/src/components/Toggle/ToggleSwitch.tsx
+++ b/src/components/Toggle/ToggleSwitch.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"
 import { AtomTone } from "../../theme/types"
 import { Theme } from "../../theme"

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { DecoratorFn } from "@storybook/react"
 import { text, radios } from "@storybook/addon-knobs"
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { useTooltip } from "@reach/tooltip"
 import { useTransition, animated } from "react-spring"
 

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { TooltipPopup, TooltipParams } from "@reach/tooltip"
 import { TooltipPosition } from "./types"
 import TooltipPointer, { TooltipPointerProps } from "./TooltipPointer"

--- a/src/components/Tooltip/TooltipPointer.tsx
+++ b/src/components/Tooltip/TooltipPointer.tsx
@@ -2,7 +2,7 @@
  * This component is based on the "Triangle pointers" example
  * from Reach UI docs: https://reacttraining.com/reach-ui/tooltip/#triangle-pointers-and-custom-styles
  */
-import React from "react"
+import * as React from "react"
 import Portal from "../Portal"
 import { TooltipPosition } from "./types"
 

--- a/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { VisuallyHidden } from "."
 
 export default {

--- a/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { visuallyHiddenCss } from "../../stylesheets/a11y"
 
 export type VisuallyHiddenProps = React.ComponentPropsWithoutRef<"span"> & {

--- a/src/components/form-skeletons/hooks/useAriaFormGroupField.tsx
+++ b/src/components/form-skeletons/hooks/useAriaFormGroupField.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { getHintId, getErrorId, getErrorAriaLiveAttribute } from "../utils"
 import { visuallyHiddenCss } from "../../../stylesheets/a11y"
 import { ErrorValidationMode } from "../types"

--- a/src/components/form/components/CheckboxConnectedField.tsx
+++ b/src/components/form/components/CheckboxConnectedField.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { CheckboxFieldBlock } from "./CheckboxFieldBlock"
 import { CheckboxFieldBlockProps } from "./CheckboxFieldBlock"
 import { useConnectedField } from "../hooks/useConnectedField"

--- a/src/components/form/components/CheckboxFieldBlock.tsx
+++ b/src/components/form/components/CheckboxFieldBlock.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 
 import { WithFormFieldBlock } from "./FormFieldBlock"
 import {

--- a/src/components/form/components/CheckboxGroupConnectedField.tsx
+++ b/src/components/form/components/CheckboxGroupConnectedField.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import {
   CheckboxGroupFieldBlock,
   CheckboxGroupFieldBlockProps,
@@ -14,9 +14,7 @@ export type CheckboxGroupConnectedFieldProps = {
   value?: string[]
 } & Omit<CheckboxGroupFieldBlockProps, "id" | "label" | "value">
 
-export const CheckboxGroupConnectedField: React.FC<
-  CheckboxGroupConnectedFieldProps
-> = props => {
+export const CheckboxGroupConnectedField: React.FC<CheckboxGroupConnectedFieldProps> = props => {
   const [connectedProps, _field, _meta, helpers] = useConnectedField<string[]>(
     props.name
   )

--- a/src/components/form/components/FormFieldBlock.tsx
+++ b/src/components/form/components/FormFieldBlock.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { FormFieldBlockLayout } from "../types"
 import {
   AriaFormFieldData,

--- a/src/components/form/components/InputConnectedField.tsx
+++ b/src/components/form/components/InputConnectedField.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { InputFieldBlock } from "./InputFieldBlock"
 import { InputFieldBlockProps } from "./InputFieldBlock"
 import { useConnectedField } from "../hooks/useConnectedField"

--- a/src/components/form/components/InputFieldBlock.tsx
+++ b/src/components/form/components/InputFieldBlock.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 
 import { FormFieldBlock, WithFormFieldBlock } from "./FormFieldBlock"
 import { StyledInput, StyledInputProps } from "./styled-primitives/StyledInput"

--- a/src/components/form/components/RadioButtonFieldBlock.tsx
+++ b/src/components/form/components/RadioButtonFieldBlock.tsx
@@ -9,7 +9,7 @@ import {
 } from "./styled-primitives/StyledRadio"
 import { OptionsContainer } from "./styled-primitives/StyledFormElements"
 import { Theme, ThemeCss } from "../../../theme"
-import React from "react"
+import * as React from "react"
 import { getOptionLabelOffsetStyles } from "../styles"
 
 const framedCss: ThemeCss = theme => ({

--- a/src/components/form/components/SelectConnectedField.tsx
+++ b/src/components/form/components/SelectConnectedField.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { SelectFieldBlock } from "./SelectFieldBlock"
 import { SelectFieldBlockProps } from "./SelectFieldBlock"
 import { useConnectedField } from "../hooks/useConnectedField"

--- a/src/components/form/components/SelectFieldBlock.tsx
+++ b/src/components/form/components/SelectFieldBlock.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 
 import { FormFieldBlock, WithFormFieldBlock } from "./FormFieldBlock"
 import {

--- a/src/components/form/components/TextAreaConnectedField.tsx
+++ b/src/components/form/components/TextAreaConnectedField.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { TextAreaFieldBlock } from "./TextAreaFieldBlock"
 import { TextAreaFieldBlockProps } from "./TextAreaFieldBlock"
 import { useConnectedField } from "../hooks/useConnectedField"

--- a/src/components/form/components/TextAreaFieldBlock.tsx
+++ b/src/components/form/components/TextAreaFieldBlock.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 
 import { FormFieldBlock, WithFormFieldBlock } from "./FormFieldBlock"
 import {

--- a/src/components/form/components/styled-primitives/StyledCheckbox.tsx
+++ b/src/components/form/components/styled-primitives/StyledCheckbox.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../../../theme"
 import { baseFormControlStyles } from "../../styles"
 import { StyledLabel, StyledLabelProps } from "./StyledFormElements"

--- a/src/components/form/components/styled-primitives/StyledFormElements.tsx
+++ b/src/components/form/components/styled-primitives/StyledFormElements.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx, keyframes } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../../../theme"
 import { MdError } from "react-icons/md"
 import { FormGroupOptionsDirection } from "../../types"

--- a/src/components/form/components/styled-primitives/StyledInput.tsx
+++ b/src/components/form/components/styled-primitives/StyledInput.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../../../theme"
 import { baseInputCss } from "../../styles"
 

--- a/src/components/form/components/styled-primitives/StyledRadio.tsx
+++ b/src/components/form/components/styled-primitives/StyledRadio.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../../../theme"
 import { baseFormControlStyles } from "../../styles"
 import { StyledLabel, StyledLabelProps } from "./StyledFormElements"

--- a/src/components/form/components/styled-primitives/StyledSelect.tsx
+++ b/src/components/form/components/styled-primitives/StyledSelect.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../../../theme"
 import { baseInputCss } from "../../styles"
 

--- a/src/components/form/components/styled-primitives/StyledTextArea.tsx
+++ b/src/components/form/components/styled-primitives/StyledTextArea.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { ThemeCss } from "../../../../theme"
 import { baseInputCss } from "../../styles"
 

--- a/src/components/form/stories/CheckboxFieldBlock.stories.tsx
+++ b/src/components/form/stories/CheckboxFieldBlock.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { action } from "@storybook/addon-actions"
 import { CheckboxFieldBlock, StyledLabelSize } from ".."
 import { getFieldBlockSandboxProps } from "./stories.utils"

--- a/src/components/form/stories/connectedFields.stories.tsx
+++ b/src/components/form/stories/connectedFields.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import {
   CheckboxConnectedField,
   CheckboxGroupConnectedField,

--- a/src/components/form/stories/stories.utils.tsx
+++ b/src/components/form/stories/stories.utils.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Story, Preview, DocsContext } from "@storybook/addon-docs/dist/blocks"
 import { text, radios, boolean } from "@storybook/addon-knobs"
 import coreClient from "@storybook/core/dist/client"

--- a/src/components/icons/BitbucketIcon.tsx
+++ b/src/components/icons/BitbucketIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/BlogIcon.tsx
+++ b/src/components/icons/BlogIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/BuildsIcon.tsx
+++ b/src/components/icons/BuildsIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/BusinessPlanIcon.tsx
+++ b/src/components/icons/BusinessPlanIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"

--- a/src/components/icons/CampaignIcon.tsx
+++ b/src/components/icons/CampaignIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/CheckCircleIcon.tsx
+++ b/src/components/icons/CheckCircleIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/CheckIcon.tsx
+++ b/src/components/icons/CheckIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/CloseCircleIcon.tsx
+++ b/src/components/icons/CloseCircleIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/CollaborationIcon.tsx
+++ b/src/components/icons/CollaborationIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"

--- a/src/components/icons/DeployIcon.tsx
+++ b/src/components/icons/DeployIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"

--- a/src/components/icons/EcommerceIcon.tsx
+++ b/src/components/icons/EcommerceIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/EllipsisIcon.tsx
+++ b/src/components/icons/EllipsisIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/EnterprisePlanIcon.tsx
+++ b/src/components/icons/EnterprisePlanIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"

--- a/src/components/icons/FeaturesIcon.tsx
+++ b/src/components/icons/FeaturesIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"

--- a/src/components/icons/FreePlanIcon.tsx
+++ b/src/components/icons/FreePlanIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"

--- a/src/components/icons/GeneralIcon.tsx
+++ b/src/components/icons/GeneralIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/GitHubIcon.tsx
+++ b/src/components/icons/GitHubIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/GitLabIcon.tsx
+++ b/src/components/icons/GitLabIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/IconSkeleton.tsx
+++ b/src/components/icons/IconSkeleton.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { IconSize, IconSkeletonProps } from "./types"
 
 export const iconHeightBySize: Record<IconSize, string> = {

--- a/src/components/icons/IntegrationsIcon.tsx
+++ b/src/components/icons/IntegrationsIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/LoginIcon.tsx
+++ b/src/components/icons/LoginIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"

--- a/src/components/icons/PortfolioIcon.tsx
+++ b/src/components/icons/PortfolioIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/ProfessionalPlanIcon.tsx
+++ b/src/components/icons/ProfessionalPlanIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"

--- a/src/components/icons/ProviderIcon.tsx
+++ b/src/components/icons/ProviderIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 import { useTheme } from "../ThemeProvider"

--- a/src/components/icons/ReportsIcon.tsx
+++ b/src/components/icons/ReportsIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/SkullIcon.tsx
+++ b/src/components/icons/SkullIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/SuccessIcon.tsx
+++ b/src/components/icons/SuccessIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import IconSkeleton from "./IconSkeleton"
 import { IconProps } from "./types"
 

--- a/src/components/icons/icons.stories.tsx
+++ b/src/components/icons/icons.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import React from "react"
+import * as React from "react"
 
 import { storiesOf } from "@storybook/react"
 import { color, select, withKnobs } from "@storybook/addon-knobs"

--- a/src/theme/theme.stories.tsx
+++ b/src/theme/theme.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx, css, keyframes } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import {
   getTheme,
   ThemeLineHeight,

--- a/src/theme/utils/storybook.tsx
+++ b/src/theme/utils/storybook.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Theme } from ".."
 import { ThemeProvider } from "../../components/ThemeProvider"
 import styled from "@emotion/styled"

--- a/src/utils/helpers/DisableReachStyleCheck.tsx
+++ b/src/utils/helpers/DisableReachStyleCheck.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 
 /**
  * To mark our components built on top of ReachUI as safe for tree-shaking, we have to apply global styles

--- a/src/utils/hooks/useOnClickOutside.ts
+++ b/src/utils/hooks/useOnClickOutside.ts
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 
 // Used to close dropdown on an outside click
 function useOnClickOutside<TElement extends Element>(

--- a/src/utils/storybook/components.tsx
+++ b/src/utils/storybook/components.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Heading } from "../../components/Heading"
 import { Theme } from "../../theme"
 

--- a/src/utils/storybook/disableAnimationsDecorator.tsx
+++ b/src/utils/storybook/disableAnimationsDecorator.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { DecoratorFn } from "@storybook/react"
 import { Global } from "@emotion/core"
 import isChromatic from "storybook-chromatic/isChromatic"

--- a/src/utils/storybook/layoutHelpers.tsx
+++ b/src/utils/storybook/layoutHelpers.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
-import React from "react"
+import * as React from "react"
 import { Theme } from "../../theme"
 
 export const borderUtilCss = (t: Theme) => ({

--- a/src/utils/storybook/propsCombinationStory.tsx
+++ b/src/utils/storybook/propsCombinationStory.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { select } from "@storybook/addon-knobs"
 
 type PossiblePropValues<TProps> = {

--- a/src/utils/testing/index.tsx
+++ b/src/utils/testing/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { ThemeProvider } from "../../components/ThemeProvider"
 import { render, RenderOptions } from "@testing-library/react"
 


### PR DESCRIPTION
Replaces `import React from "react"` with `import * as React from "react"`. This should fix issues with incomplete TypeScript types for components relying on `React.ComponentPropsWithoutRef` etc, such as `InputFieldBlock`.