### PR TITLE
feat(BuildLogs): Display docsUrl and errorUrl for errors

### DIFF
--- a/src/components/BuildLogs/BuildLogsList.stories.tsx
+++ b/src/components/BuildLogs/BuildLogsList.stories.tsx
@@ -232,11 +232,39 @@ const ALL_INCLUSIVE = [
     code: "85901",
     type: "GRAPHQL",
     filePath: "/usr/src/app/www/src/templates/blog-post.js",
+    location: {
+      start: {
+        line: 13,
+        column: 5,
+      },
+    },
+    errorUrl:
+      "https://www.github.com/julienp-test-org/gatsby-starter-blog/blob/local-dev/src/pages/index3.js#L13",
     docsUrl: "https://gatsby.dev/issue-how-to",
     context: {
       sourceMessage:
         'Variable "$slug" is never used in operation "BlogPostBySlug".\n\nGraphQL request:2:24\n1 |\n2 |   query BlogPostBySlug($slug: String!) {\n  |                        ^\n3 |     site {',
     },
+    level: StructuredLogLevel.Error,
+    __typename: "StructuredLog",
+    activity: null,
+  },
+
+  {
+    id: "93e9769c-24a8-401c-865a-ca3ab1696057",
+    message: 'Building static HTML failed for path "/index3/"',
+    code: "95313",
+    type: "PLUGIN",
+    filePath: "src/pages/index3.js",
+    location: {
+      start: {
+        line: 13,
+        column: 5,
+      },
+    },
+    docsUrl: "https://gatsby.dev/issue-how-to",
+    context: null,
+    errorUrl: `https://www.github.com/julienp-test-org/gatsby-starter-blog/blob/local-dev/src/pages/index3.js#L13`,
     level: StructuredLogLevel.Error,
     __typename: "StructuredLog",
     activity: null,

--- a/src/components/BuildLogs/BuildLogsList.tsx
+++ b/src/components/BuildLogs/BuildLogsList.tsx
@@ -37,6 +37,9 @@ export function BuildLogsList({
                   message={logItem.message}
                   context={logItem.context}
                   filePath={logItem.filePath}
+                  location={logItem.location}
+                  docsUrl={logItem.docsUrl}
+                  errorUrl={logItem.errorUrl}
                 />
               )}
             </li>

--- a/src/components/BuildLogs/BuildStandardLogEntry.tsx
+++ b/src/components/BuildLogs/BuildStandardLogEntry.tsx
@@ -24,14 +24,23 @@ const messageCss: ThemeCss = theme => ({
 
 export type BuildStandardLogEntryProps = Pick<
   BuildLogItem,
-  "level" | "message" | "context" | "filePath"
+  | "level"
+  | "message"
+  | "context"
+  | "filePath"
+  | "docsUrl"
+  | "location"
+  | "errorUrl"
 > & {}
 
 export function BuildStandardLogEntry({
   level,
   message,
   context,
+  location,
   filePath,
+  docsUrl,
+  errorUrl,
 }: BuildStandardLogEntryProps) {
   const displayMessage =
     context && context.stageLabel
@@ -46,6 +55,10 @@ export function BuildStandardLogEntry({
       <FormattedLogMessage
         message={displayMessage}
         level={level}
+        location={location}
+        filePath={filePath}
+        docsUrl={docsUrl}
+        errorUrl={errorUrl}
         css={messageCss}
       />
     </BuildLogEntrySkeleton>

--- a/src/components/BuildLogs/FormattedLogMessage.tsx
+++ b/src/components/BuildLogs/FormattedLogMessage.tsx
@@ -3,10 +3,12 @@ import { jsx } from "@emotion/core"
 import { BuildLogItem, StructuredLogLevel } from "./types"
 import { ThemeCss, Theme } from "../../theme"
 import { FormattedMessage } from "./FormattedMessage"
+import { Link } from "../Link"
+import { Text } from "../Text"
 
 export type FormattedLogMessageProps = Pick<
   BuildLogItem,
-  "level" | "message"
+  "level" | "message" | "docsUrl" | "location" | "filePath" | "errorUrl"
 > & {
   className?: string
 }
@@ -14,11 +16,28 @@ export type FormattedLogMessageProps = Pick<
 export function FormattedLogMessage({
   level,
   message,
+  docsUrl,
+  location,
+  filePath,
+  errorUrl,
   className,
 }: FormattedLogMessageProps) {
   return (
     <div css={getMessageCss(level)} className={className}>
       <FormattedMessage rawMessage={message || ""} />
+      {docsUrl && (
+        <Text>
+          For more details see <Link href={docsUrl}>{docsUrl}</Link>
+        </Text>
+      )}
+      {location && location.start && errorUrl && (
+        <Text>
+          The error occured in{" "}
+          <Link href={errorUrl}>
+            {filePath}@{location.start.line},{location.start.column}
+          </Link>
+        </Text>
+      )}
     </div>
   )
 }
@@ -34,6 +53,25 @@ function getMessageCss(level: StructuredLogLevel | null | undefined): ThemeCss {
     }
 
     return {
+      div: {
+        // The first div > p is the title of the message.
+        p: {
+          "&:first-of-type": {
+            color: getLogLevelColor(level)(theme),
+            fontSize: theme.fontSizes[1],
+            marginBottom: theme.space[3],
+          },
+        },
+        // If we only have a single p in a single div, we don't want the margin.
+        "&:only-child": {
+          p: {
+            "&:only-child": {
+              marginBottom: 0,
+            },
+          },
+        },
+      },
+
       whiteSpace: `pre-wrap`,
       display: `block`,
 
@@ -82,15 +120,11 @@ function getMessageCss(level: StructuredLogLevel | null | undefined): ThemeCss {
 
       p: [
         spaceMixin,
+
         {
           color: theme.colors.grey[50],
           fontSize: theme.fontSizes[0],
           lineHeight: theme.lineHeights.loose,
-
-          "&:first-of-type": {
-            color: getLogLevelColor(level)(theme),
-            fontSize: theme.fontSizes[1],
-          },
 
           a: {
             textDecoration: `none`,

--- a/src/components/BuildLogs/FormattedMessage.tsx
+++ b/src/components/BuildLogs/FormattedMessage.tsx
@@ -36,14 +36,16 @@ export const FormattedMessage = ({ rawMessage }: FormattedMessageProps) => {
   const stringPartsByLines = rawMessage.split("\n")
   const message = formatCodeBlocks(stringPartsByLines)
 
-  // Markdown formatter treats strings without line break as spans, we need to wrap them in a <p></p>
-  // to make it act as a line title
+  // Markdown formatter treats strings without line break as spans, we need to wrap them in a
+  // <div><p></p></div> to keep the same structure as a multi line message.
   const isOneLine = stringPartsByLines.length === 1
   if (isOneLine) {
     return (
-      <p>
-        <Markdown>{message}</Markdown>
-      </p>
+      <div>
+        <p>
+          <Markdown>{message}</Markdown>
+        </p>
+      </div>
     )
   }
 

--- a/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
+++ b/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
@@ -9,11 +9,13 @@ describe("utils", () => {
     expect(render(<FormattedMessage rawMessage={message} />).container)
       .toMatchInlineSnapshot(`
       <div>
-        <p>
-          <span>
-            The GraphQL query in the non-page component "/usr/src/app/www/cloud/gatsbyjs.com/src/templates/get-started/index.js" will not be run.
-          </span>
-        </p>
+        <div>
+          <p>
+            <span>
+              The GraphQL query in the non-page component "/usr/src/app/www/cloud/gatsbyjs.com/src/templates/get-started/index.js" will not be run.
+            </span>
+          </p>
+        </div>
       </div>
     `)
   })

--- a/src/components/BuildLogs/types.ts
+++ b/src/components/BuildLogs/types.ts
@@ -24,6 +24,11 @@ export enum StructuredLogLevel {
   Error = "ERROR",
 }
 
+export type Location = {
+  line: number
+  column: number
+}
+
 export type BuildLogItem = {
   id: string
   message?: string | null
@@ -31,6 +36,9 @@ export type BuildLogItem = {
   activity?: BuildActivity | null
   filePath?: string | null
   context?: { [k: string]: string } | null
+  docsUrl?: string | null
+  errorUrl?: string | null
+  location?: { start?: Location | null; end?: Location | null } | null
 }
 
 export type BuildActivity = {


### PR DESCRIPTION
Show more information on errors when it's available:

<img width="524" alt="Screenshot 2020-10-01 at 10 24 09" src="https://user-images.githubusercontent.com/387068/94785679-44f63880-03d0-11eb-91f2-73bc4d548743.png">
