### PR TITLE
chore: fix tiny ui issue with font sizes story [ci skip]

### DIFF
--- a/src/theme/utils/TextShowCase.tsx
+++ b/src/theme/utils/TextShowCase.tsx
@@ -30,8 +30,8 @@ export function TextShowCaseItem({
   const rawValueElements = []
 
   for (let i = 0; i < rawValues.length; i++) {
-    rawValueElements.push(<code>{rawValues}</code>)
-    if (i === rawValues.length - 1 && i !== 0) {
+    rawValueElements.push(<code>{rawValues[i]}</code>)
+    if (i < rawValues.length - 1) {
       rawValueElements.push(", ")
     }
   }


### PR DESCRIPTION
Fixes this display for raw values in "Font SIzes" story:
<img width="485" alt="Screen Shot 2020-09-30 at 10 59 09 AM" src="https://user-images.githubusercontent.com/4366711/94722306-f97a5680-030b-11eb-944a-202f1e1b43d0.png">

Fixed:
<img width="485" alt="Screen Shot 2020-09-30 at 10 59 38 AM" src="https://user-images.githubusercontent.com/4366711/94722345-0ac36300-030c-11eb-8236-c82cf9ab47be.png">
