### PR TITLE
Setup manual pre-release action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,33 +156,34 @@ jobs:
 
 workflows:
   version: 2
-  run-branch-prerelease:
-    jobs:
-      - is-green:
-          filters:
-            branches:
-              ignore:
-                - master
-                - main
-                - dev
-      - a11y-checks:
-          requires:
-            - is-green
-          filters:
-            branches:
-              ignore:
-                - master
-                - main
-                - dev
-      - branch-prerelease:
-          requires:
-            - is-green
-          filters:
-            branches:
-              ignore:
-                - master
-                - main
-                - dev
+  # This is now replaced with a manually triggered GitHub Action — "Pre-release"
+  # run-branch-prerelease:
+  #   jobs:
+  #     - is-green:
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - main
+  #               - dev
+  #     - a11y-checks:
+  #         requires:
+  #           - is-green
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - main
+  #               - dev
+  #     - branch-prerelease:
+  #         requires:
+  #           - is-green
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - main
+  #               - dev
   run-prerelease:
     jobs:
       - is-green:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,24 @@ workflows:
   #               - master
   #               - main
   #               - dev
+  branch-check:
+    jobs:
+      - is-green:
+          filters:
+            branches:
+              ignore:
+                - master
+                - main
+                - dev
+      - a11y-checks:
+          requires:
+            - is-green
+          filters:
+            branches:
+              ignore:
+                - master
+                - main
+                - dev
   run-prerelease:
     jobs:
       - is-green:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/setup-node@master
         with:
           node-version: 12.x
+      - name: Install Yarn
+        run: curl -o- -L https://yarnpkg.com/install.sh
+      - name: Install Dependencies
+        run: yarn install
       # Runs a single command using the runners shell
       - name: Authenticate with registry
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
       # required - sets up auth in the node env
       - name: Set up Node.js
         uses: actions/setup-node@master

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # required - sets up auth in the node env
+    - name: Set up Node.js
+      uses: actions/setup-node@master
+      with:
+        node-version: 12.x
     # Runs a single command using the runners shell
     - name: Authenticate with registry
       run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/repo/.npmrc

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # required - sets up auth in the node env
-    - name: Set up Node.js
-      uses: actions/setup-node@master
-      with:
-        node-version: 12.x
-    # Runs a single command using the runners shell
-    - name: Authenticate with registry
-      run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/repo/.npmrc
-    # Runs a single command using the runners shell
-    - name: Run pre-release script
-      run: npm run release:branch
+      # required - sets up auth in the node env
+      - name: Set up Node.js
+        uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+      # Runs a single command using the runners shell
+      - name: Authenticate with registry
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+      # Runs a single command using the runners shell
+      - name: Run pre-release script
+        run: npm run release:branch

--- a/scripts/prerelease-branch.js
+++ b/scripts/prerelease-branch.js
@@ -11,18 +11,20 @@ import format from "date-fns/format"
 import addMinutes from "date-fns/addMinutes"
 import pkg from "../package.json"
 
-const branch = process.env.CIRCLE_BRANCH
-
-sh.echo(chalk.cyan(`Preparing prerelease for branch ${branch}`))
+let branch = process.env.CIRCLE_BRANCH || process.env.GITHUB_REF
 
 if (!branch) {
   sh.echo(
     chalk.red(
-      `Could not detect Git branch, process.env.CIRCLE_BRANCH is ${branch}`
+      `Could not detect Git branch:\nprocess.env.CIRCLE_BRANCH is ${process.env.CIRCLE_BRANCH}\nprocess.env.GITHUB_REF is ${process.env.GITHUB_REF}`
     )
   )
   sh.exit(1)
 }
+
+branch = branch.replace("refs/heads/", "")
+
+sh.echo(chalk.cyan(`Preparing prerelease for branch ${branch}`))
 
 if (branch === `main` || branch === `dev`) {
   sh.echo(

--- a/src/components/Portal/Portal.stories.tsx
+++ b/src/components/Portal/Portal.stories.tsx
@@ -1,10 +1,29 @@
 import * as React from "react"
-import { storiesOf } from "@storybook/react"
+import { Meta } from "@storybook/react"
 import Portal from "./"
-import README from "./README.md"
-import { text } from "@storybook/addon-knobs"
 import styled from "@emotion/styled"
 import { Global, css } from "@emotion/core"
+
+export default {
+  title: `Portal`,
+  component: Portal,
+  decorators: [
+    storyFn => (
+      <div>
+        <Global
+          styles={css`
+            toast-container {
+              position: fixed;
+              right: 0;
+              bottom: 0;
+            }
+          `}
+        />
+        {storyFn()}
+      </div>
+    ),
+  ],
+} as Meta
 
 const Toast = styled.div(_props => ({
   padding: "0.5rem 1rem",
@@ -14,47 +33,26 @@ const Toast = styled.div(_props => ({
   margin: "0.2rem",
 }))
 
-storiesOf(`Portal`, module)
-  .addDecorator(storyFn => (
-    <div>
-      <Global
-        styles={css`
-          toast-container {
-            position: fixed;
-            right: 0;
-            bottom: 0;
-          }
-        `}
-      />
-      {storyFn()}
-    </div>
-  ))
-  .addParameters({
-    options: {
-      showPanel: true,
-    },
-    readme: {
-      sidebar: README,
-    },
-  })
-  .add(`Default`, () => (
+export const Basic = () => (
+  <Portal>
+    <div>This is portaled somewhere else</div>
+  </Portal>
+)
+
+export const NestedPortal = () => (
+  <Portal tag="other-node">
+    <div>This is the parent portal</div>
     <Portal>
-      <div>This is portaled somewhere else</div>
+      <div>This is the child portal</div>
     </Portal>
-  ))
-  .add(`Nesting portal`, () => (
-    <Portal tag={text(`DOM element)`, `other-node`)}>
-      <div>This is the parent portal</div>
-      <Portal>
-        <div>This is the child portal</div>
-      </Portal>
-    </Portal>
-  ))
-  .add(`Same destination portal`, () => (
+  </Portal>
+)
+
+export const SameDestination = () => (
+  <Portal tag="toast-node" target="toast-container">
+    <Toast>Parent toast</Toast>
     <Portal tag="toast-node" target="toast-container">
-      <Toast>Parent toast</Toast>
-      <Portal tag="toast-node" target="toast-container">
-        <Toast>Child toast</Toast>
-      </Portal>
+      <Toast>Child toast</Toast>
     </Portal>
-  ))
+  </Portal>
+)

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
-import { storiesOf } from "@storybook/react"
-import { StoryUtils } from "../../utils/storybook"
+import { Meta } from "@storybook/react"
 import { Button } from "../Button"
 import {
   ToastProvider,
@@ -9,81 +8,75 @@ import {
   useShowSuccessToast,
   useShowErrorAlert,
 } from "."
-import README from "./README.md"
 
-storiesOf(`Toast`, module)
-  .addParameters({
+export default {
+  title: `Toast`,
+  component: ToastProvider,
+  subcomponents: {
+    ToastConsumer,
+  },
+  parameters: {
     componentSubtitle:
       "Toasts provide brief messages about app processes at the bottom of the screen, usually to give feedback after an action has taken place.",
-    options: {
-      showPanel: true,
-    },
-    readme: {
-      sidebar: README,
-    },
-  })
-  .add(`Default`, () => {
-    function ErrorToastExample() {
-      const showErrorToast = useShowErrorToast()
+  },
+} as Meta
 
-      return (
-        <Button onClick={() => showErrorToast(`An error occured`)}>
-          Show error toast
-        </Button>
-      )
-    }
-    function ErrorAlertExample() {
-      const showErrorAlert = useShowErrorAlert()
+export const Basic = () => {
+  function ErrorToastExample() {
+    const showErrorToast = useShowErrorToast()
 
-      return (
-        <Button
-          onClick={() =>
-            showErrorAlert(`An error occured`, {
-              href: `https://google.com`,
-              linkLabel: `See details`,
-              target: `_blank`,
-            })
-          }
-        >
-          Show error alert
-        </Button>
-      )
-    }
-    function NoTimeoutExample() {
-      const showSuccessToast = useShowSuccessToast()
-
-      return (
-        <Button
-          onClick={() =>
-            showSuccessToast(`This message will stay on screen until closed`, {
-              timeout: 0,
-            })
-          }
-        >
-          Show toast without auto hide
-        </Button>
-      )
-    }
     return (
-      <StoryUtils.Container>
-        <StoryUtils.Stack>
-          <ToastProvider>
-            <ToastConsumer>
-              {({ showToast }) => (
-                <React.Fragment>
-                  <Button
-                    onClick={() => showToast(`Your action was successful`)}
-                  >
-                    Show toast
-                  </Button>
-                </React.Fragment>
-              )}
-            </ToastConsumer>
-            <NoTimeoutExample />
-            <ErrorToastExample />
-            <ErrorAlertExample />
-          </ToastProvider>
-        </StoryUtils.Stack>
-      </StoryUtils.Container>
+      <Button onClick={() => showErrorToast(`An error occured`)}>
+        Show error toast
+      </Button>
     )
-  })
+  }
+  function ErrorAlertExample() {
+    const showErrorAlert = useShowErrorAlert()
+
+    return (
+      <Button
+        onClick={() =>
+          showErrorAlert(`An error occured`, {
+            href: `https://google.com`,
+            linkLabel: `See details`,
+            target: `_blank`,
+          })
+        }
+      >
+        Show error alert
+      </Button>
+    )
+  }
+  function NoTimeoutExample() {
+    const showSuccessToast = useShowSuccessToast()
+
+    return (
+      <Button
+        onClick={() =>
+          showSuccessToast(`This message will stay on screen until closed`, {
+            timeout: 0,
+          })
+        }
+      >
+        Show toast without auto hide
+      </Button>
+    )
+  }
+  return (
+    <ToastProvider>
+      <ToastConsumer>
+        {({ showToast }) => (
+          <React.Fragment>
+            <Button onClick={() => showToast(`Your action was successful`)}>
+              Show toast
+            </Button>
+          </React.Fragment>
+        )}
+      </ToastConsumer>
+      <NoTimeoutExample />
+      <ErrorToastExample />
+      <ErrorAlertExample />
+    </ToastProvider>
+  )
+}


### PR DESCRIPTION
Replace automatic branch pre-release with a manual GitHub Action (you can find it in [Actions](https://github.com/gatsby-inc/gatsby-interface/actions)). 

To trigger a branch pre-release:
* Go to [Actions](https://github.com/gatsby-inc/gatsby-interface/actions)
* Pick "Pre-release" in the left sidebar ("Workflows"):
  <img width="1260" alt="Screen Shot 2020-10-01 at 8 00 23 PM" src="https://user-images.githubusercontent.com/4366711/94883929-cc6b9800-0420-11eb-8424-55aa8c9b6386.png">
* Click "Run workflow" button to the right, and select a branch. Click "Run workflow" button below the branch dropdown:
  <img width="1265" alt="Screen Shot 2020-10-01 at 8 03 26 PM" src="https://user-images.githubusercontent.com/4366711/94884052-36843d00-0421-11eb-8c60-21446709e4ec.png">

**NOTE:** pre-releases for `main` branch are not supported at the moment (similar to the old CircleCI job).