### PR TITLE
fix: various TypeScript fixes

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -68,7 +68,7 @@ const headerCss: ThemeCss = theme => ({
   lineHeight: 1,
 })
 
-export type CardHeaderProps = Omit<CardSectionProps, "as"> & {
+export type CardHeaderProps = Omit<CardSectionProps, "as" | "title"> & {
   as?: "header" | "div"
   title: React.ReactNode
   titleAs?: HeadingProps["as"]

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -170,7 +170,7 @@ export type ComboboxPopoverProps = PropsWithAs<
 >
 
 export const ComboboxPopover = React.forwardRef<
-  HTMLInputElement,
+  HTMLDivElement,
   ComboboxPopoverProps
 >(function ComboboxPopover(props, ref) {
   return (

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -162,12 +162,8 @@ export const ComboboxInput = React.forwardRef<
   )
 })
 
-export type ComboboxPopoverProps = PropsWithAs<
-  "div",
-  ReachComboboxPopoverProps &
-    Partial<PopoverProps> &
-    React.RefAttributes<HTMLDivElement>
->
+export type ComboboxPopoverProps = ReachComboboxPopoverProps &
+  Partial<PopoverProps>
 
 export const ComboboxPopover = React.forwardRef<
   HTMLDivElement,

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../utils/storybook"
 import { DropdownMenuSize } from "./DropdownMenu"
 import { Notification } from "../Notification"
+import { Link } from "gatsby"
 
 export default {
   title: `DropdownMenu`,
@@ -181,15 +182,28 @@ export const MenuLinks = () => {
         <DropdownMenuButton>{text("label", "Actions")}</DropdownMenuButton>
         <DropdownMenuItems>
           {["Ashalmawia", "Addadshashanammu", "Ularradallaku"].map(item => (
-            <DropdownMenuLink
-              href={`https://www.google.com/search?q=${item}`}
-              target="_blank"
-              rel="noreferrer noopener"
-              key={item}
-              onSelect={() => action("Select")(item)}
-            >
-              {item}
-            </DropdownMenuLink>
+            <React.Fragment>
+              <DropdownMenuLink
+                href={`https://www.google.com/search?q=${item}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                key={item}
+                as={"a"}
+                onSelect={() => action("Select")(item)}
+              >
+                {item} {`(as "<a>")`}
+              </DropdownMenuLink>
+              <DropdownMenuLink
+                to={`https://www.google.com/search?q=${item}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                key={item}
+                as={Link}
+                onSelect={() => action("Select")(item)}
+              >
+                {item} {`(as "<Link>")`}
+              </DropdownMenuLink>
+            </React.Fragment>
           ))}
         </DropdownMenuItems>
       </DropdownMenu>

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -18,6 +18,7 @@ import {
   MenuLinkProps,
   useMenuButtonContext,
 } from "@reach/menu-button"
+import { forwardRefWithAs } from "@reach/utils"
 import { MdKeyboardArrowDown } from "react-icons/md"
 import {
   dropdownCss,
@@ -97,17 +98,13 @@ export const DropdownMenuItem: React.FC<DropdownMenuItemProps> = props => (
   <MenuItem {...props} css={menuItemCss} />
 )
 
-export type DropdownMenuLinkProps = import("@reach/utils").PropsWithAs<
-  "a",
-  MenuLinkProps
->
+export type DropdownMenuLinkProps = MenuLinkProps
 
-export const DropdownMenuLink = React.forwardRef<
-  HTMLAnchorElement,
-  DropdownMenuLinkProps
->(function DropdownMenuLink(props, ref) {
-  return <MenuLink ref={ref} {...props} css={menuItemCss} />
-})
+export const DropdownMenuLink = forwardRefWithAs<DropdownMenuLinkProps, "a">(
+  function DropdownMenuLink(props, ref) {
+    return <MenuLink ref={ref} {...props} css={menuItemCss} />
+  }
+)
 
 export type DropdownMenuPopoverProps = MenuPopoverProps
 


### PR DESCRIPTION
Fixes several TypeScript errors that might occur when using Gatsby Interface:
* Using a React element as `title` for `CardHeader` would result in an error, since the prop type from `CardHeaderProps` conflicts with the type for `title` attribute on `<div>`/`<header>` elements. 
* `ComboboxPopover` had incorrect type specified for its `ref` — it was `HTMLInputElement` instead of `HTMLDivElement`.
* `DropdownMenuLink` would not accept any `as` prop other than `"a"`; I had to use ReachUI's utility helper `forwardRefWithAs` in order to fix this.