### PR TITLE
feat(Modal): add StyledPanelBoilerplate component

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "sideEffects": false,
   "scripts": {
     "test": "jest --env=jest-environment-jsdom-sixteen",
-    "test:a11y": "jest __tests__/AccessiblityStoryshots.test.js --testPathIgnorePatterns=[]",
+    "test:a11y": "jest __tests__/AccessiblityStoryshots.test.js --testPathIgnorePatterns=[] --env=jest-environment-jsdom-sixteen",
     "test:watch": "jest --watch --env=jest-environment-jsdom-sixteen",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/src/components/Modal/StyledPanel.stories.tsx
+++ b/src/components/Modal/StyledPanel.stories.tsx
@@ -141,18 +141,7 @@ UsageExample.story = {
 }
 
 export const Boilerplate = () => {
-  const [isOpen, setIsOpen] = React.useState<boolean>(false)
-
-  React.useEffect(() => {
-    // Open panel in Chromatic to keep track of visual regressions
-    if (!isChromatic()) {
-      return
-    }
-    const button = document.querySelector("button")
-    if (button) {
-      button.click()
-    }
-  }, [])
+  const [isOpen, setIsOpen] = React.useState<boolean>(true)
 
   return (
     <React.Fragment>
@@ -175,10 +164,10 @@ export const Boilerplate = () => {
   )
 }
 
-UsageExample.story = {
+Boilerplate.story = {
   decorators: [isChromatic() ? fullSizeDecorator : maxWidthDecorator],
 }
 
-UsageExample.parameters = {
-  chromatic: { delay: 1000 },
+Boilerplate.parameters = {
+  chromatic: { delay: 150 },
 }

--- a/src/components/Modal/StyledPanel.stories.tsx
+++ b/src/components/Modal/StyledPanel.stories.tsx
@@ -178,3 +178,7 @@ export const Boilerplate = () => {
 UsageExample.story = {
   decorators: [isChromatic() ? fullSizeDecorator : maxWidthDecorator],
 }
+
+UsageExample.parameters = {
+  chromatic: { delay: 300 },
+}

--- a/src/components/Modal/StyledPanel.stories.tsx
+++ b/src/components/Modal/StyledPanel.stories.tsx
@@ -180,5 +180,5 @@ UsageExample.story = {
 }
 
 UsageExample.parameters = {
-  chromatic: { delay: 300 },
+  chromatic: { delay: 1000 },
 }

--- a/src/components/Modal/StyledPanel.stories.tsx
+++ b/src/components/Modal/StyledPanel.stories.tsx
@@ -16,6 +16,7 @@ import {
 import { Theme } from "../../theme"
 import { Button } from "../Button"
 import { disableAnimationsDecorator } from "../../utils/storybook"
+import { StyledPanelBoilerplate } from "./StyledPanel"
 
 export default {
   title: `Modal/StyledPanel`,
@@ -131,6 +132,45 @@ export const UsageExample = () => {
           </StyledPanel>
         </ModalPanel>
       </Modal>
+    </React.Fragment>
+  )
+}
+
+UsageExample.story = {
+  decorators: [isChromatic() ? fullSizeDecorator : maxWidthDecorator],
+}
+
+export const Boilerplate = () => {
+  const [isOpen, setIsOpen] = React.useState<boolean>(false)
+
+  React.useEffect(() => {
+    // Open panel in Chromatic to keep track of visual regressions
+    if (!isChromatic()) {
+      return
+    }
+    const button = document.querySelector("button")
+    if (button) {
+      button.click()
+    }
+  }, [])
+
+  return (
+    <React.Fragment>
+      <Button onClick={() => setIsOpen(true)}>Open panel</Button>
+      <StyledPanelBoilerplate
+        aria-label="Some impressive content"
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        header="Boilerplate Header"
+        actions={
+          <React.Fragment>
+            <Button>Action 1</Button>
+            <Button>Action 2</Button>
+          </React.Fragment>
+        }
+      >
+        <StyledPanelBodySection>{LONG_TEXT}</StyledPanelBodySection>
+      </StyledPanelBoilerplate>
     </React.Fragment>
   )
 }

--- a/src/components/Modal/StyledPanel.tsx
+++ b/src/components/Modal/StyledPanel.tsx
@@ -8,6 +8,8 @@ import {
 } from "./StyledModal"
 import { ThemeCss } from "../../theme"
 import { StickyObserver } from "../StickyObserver"
+import { Modal } from "./Modal"
+import { ModalPanel } from "./ModalPanel"
 
 export type StyledPanelProps = {
   children: React.ReactNode
@@ -70,14 +72,10 @@ const bodySectionCss: ThemeCss = theme => ({
   paddingLeft: theme.space[7],
 })
 
-export type StyledPanelBodySectionProps = {
-  children: React.ReactNode
-}
+export type StyledPanelBodySectionProps = React.ComponentPropsWithoutRef<"div">
 
-export function StyledPanelBodySection({
-  children,
-}: StyledPanelBodySectionProps) {
-  return <div css={bodySectionCss}>{children}</div>
+export function StyledPanelBodySection(props: StyledPanelBodySectionProps) {
+  return <div css={bodySectionCss} {...props} />
 }
 
 const actionsContainerCss: ThemeCss = theme => ({
@@ -105,5 +103,51 @@ export function StyledPanelActions({ children }: StyledPanelActionsProps) {
     <StickyObserver lipShadowPosition="top" css={actionsContainerCss}>
       <div css={actionsCss}>{children}</div>
     </StickyObserver>
+  )
+}
+
+export type StyledPanelBoilerplateProps = {
+  isOpen?: boolean
+  "aria-label": string
+  onClose: () => void
+  header?: React.ReactNode
+  children?: React.ReactNode
+  actions?: React.ReactNode
+}
+
+export function StyledPanelBoilerplate({
+  isOpen,
+  "aria-label": ariaLabel,
+  onClose,
+  header,
+  children,
+  actions,
+}: StyledPanelBoilerplateProps) {
+  return (
+    <Modal
+      aria-label={ariaLabel}
+      isOpen={isOpen}
+      onDismiss={onClose}
+      type="neutral"
+      css={{
+        width: `100%`,
+        height: `auto`,
+        minHeight: `100%`,
+        display: `flex`,
+        flexDirection: `column`,
+      }}
+    >
+      <ModalPanel>
+        <StyledPanel>
+          {header ? (
+            <StyledPanelHeader onCloseButtonClick={onClose}>
+              {header}
+            </StyledPanelHeader>
+          ) : null}
+          {children}
+          {actions ? <StyledPanelActions>{actions}</StyledPanelActions> : null}
+        </StyledPanel>
+      </ModalPanel>
+    </Modal>
   )
 }

--- a/src/components/StickyObserver/StickyObserver.tsx
+++ b/src/components/StickyObserver/StickyObserver.tsx
@@ -147,7 +147,13 @@ export function StickyObserverSentinel(_props: StickyObserverSentinelProps) {
     }
   }, [lipShadowPosition, sentinelRef.current])
 
-  return <div ref={sentinelRef} css={{ height: `1px` }} aria-hidden />
+  return (
+    <div
+      ref={sentinelRef}
+      css={{ height: `1px`, backgroundColor: `inherit` }}
+      aria-hidden
+    />
+  )
 }
 
 export type StickyLipShadowProps = {}


### PR DESCRIPTION
Adds a shortcut for rendering panels — `StyledPanelBoilerplate` — which can be used in the new Member Management portal, and I am also trying it out for the CMS integration forms:
<details>
  <summary>Spoiler alert!</summary>

![localhost_8000_dashboard_organization_cf77a3b7-b467-49b8-bab7-c3298289a7a0_sites_import_ff556e46-2363-438e-8900-e09efa68d2f0_integrations (2)](https://user-images.githubusercontent.com/4366711/95156620-d0165c00-074b-11eb-95aa-541f9c5b68c3.png)

</details>

