### PR TITLE
fix(BuildLogs): Handle multiple code blocks

### DIFF
--- a/src/components/BuildLogs/BuildLogsList.stories.tsx
+++ b/src/components/BuildLogs/BuildLogsList.stories.tsx
@@ -231,7 +231,31 @@ const ALL_INCLUSIVE = [
       'There was an error in your GraphQL query:\n\nVariable "$slug" is never used in operation "BlogPostBySlug".\n\nGraphQL request:2:24\n1 |\n2 |   query BlogPostBySlug($slug: String!) {\n  |                        ^\n3 |     site {',
     code: "85901",
     type: "GRAPHQL",
-    filePath: "/usr/src/app/www/src/templates/blog-post.js",
+    filePath: "templates/blog-post.js",
+    location: {
+      start: {
+        line: 13,
+        column: 5,
+      },
+    },
+    errorUrl:
+      "https://www.github.com/julienp-test-org/gatsby-starter-blog/blob/local-dev/src/pages/index3.js#L13",
+    docsUrl: "https://gatsby.dev/issue-how-to",
+    context: {
+      sourceMessage:
+        'Variable "$slug" is never used in operation "BlogPostBySlug".\n\nGraphQL request:2:24\n1 |\n2 |   query BlogPostBySlug($slug: String!) {\n  |                        ^\n3 |     site {',
+    },
+    level: StructuredLogLevel.Error,
+    __typename: "StructuredLog",
+    activity: null,
+  },
+
+  {
+    id: "32d47075-c836-4343-9d9f-dc878da94a0e",
+    message: `There was an error in your GraphQL query:\n\nVariable "$missingVar" is not defined by operation "SomeQuery".\n\nGraphQL request:16:32\n15 |           frontmatter {\n16 |             date(formatString: $missingVar)\n   |                                ^\n17 |             title\n\nGraphQL request:2:3\n1 |\n2 |   query {\n  |   ^\n3 |     site {`,
+    code: "85901",
+    type: "GRAPHQL",
+    filePath: "templates/blog-post.js",
     location: {
       start: {
         line: 13,

--- a/src/components/BuildLogs/FormattedMessage.tsx
+++ b/src/components/BuildLogs/FormattedMessage.tsx
@@ -4,18 +4,28 @@ import Markdown from "markdown-to-jsx"
 // Check for "1 |" presence to create a code block
 // Stores every last index owning a " |" string
 // to close the code block at the good position
+//
+// Example code block:
+// 15 |           frontmatter {
+// 16 |             date(formatString: $invaludVar)
+//    |                                ^
+//
 const formatCodeBlocks = (stringPartsByLines: string[]) => {
   let lastIndexFound = -1
   let codeBlockOpen = false
 
   const nextLines = stringPartsByLines.map((str, index) => {
-    if (str.match(/(\s|\t)*\d+\s\|/)) {
+    if (str.match(/(\s|\t)*\d+\s\|/) || str.match(/(\s|\t)*\|(\s|\t)*\^/)) {
       if (codeBlockOpen) {
         lastIndexFound = index
       } else {
         codeBlockOpen = true
         return "```" + str
       }
+    } else if (codeBlockOpen) {
+      // Close the current code block if the line doesn't match anymore
+      codeBlockOpen = false
+      return "```" + str
     }
 
     return str

--- a/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
+++ b/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
@@ -139,4 +139,41 @@ describe("utils", () => {
       </div>
     `)
   })
+
+  it(`should format multiple code blocks`, () => {
+    const message = `There was an error in your GraphQL query:\n\nVariable "$missingVar" is not defined by operation "SomeQuery".\n\nGraphQL request:16:32\n15 |           frontmatter {\n16 |             date(formatString: $missingVar)\n   |                                ^\n17 |             title\n\nGraphQL request:2:3\n1 |\n2 |   query {\n  |   ^\n3 |     site {`
+
+    expect(render(<FormattedMessage rawMessage={message} />).container)
+      .toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <p>
+            There was an error in your GraphQL query:
+          </p>
+          <p>
+            Variable "$missingVar" is not defined by operation "SomeQuery".
+          </p>
+          <p>
+            GraphQL request:16:32
+      
+            <code>
+              15 |           frontmatter {
+      16 |             date(formatString: $missingVar)
+         |                                ^
+      17 |             title
+            </code>
+            
+      GraphQL request:2:3
+      
+            <code>
+              1 |
+      2 |   query {
+        |   ^
+      3 |     site {
+            </code>
+          </p>
+        </div>
+      </div>
+    `)
+  })
 })


### PR DESCRIPTION
The generated markdown was invalid when there were multiple code blocks.

Before
<img width="460" alt="Screenshot 2020-10-06 at 13 57 39" src="https://user-images.githubusercontent.com/387068/95198691-e966e900-07db-11eb-9116-8d1a727cd785.png">

After
<img width="456" alt="Screenshot 2020-10-06 at 14 00 21" src="https://user-images.githubusercontent.com/387068/95198913-482c6280-07dc-11eb-952d-82e9e85df366.png">
