### PR TITLE
fix(form): various performance optimizations across form components

### DIFF
--- a/src/components/form-skeletons/hooks/useAriaFormField.tsx
+++ b/src/components/form-skeletons/hooks/useAriaFormField.tsx
@@ -1,3 +1,4 @@
+import * as React from "react"
 import { getHintId, getErrorId, getErrorAriaLiveAttribute } from "../utils"
 import { ErrorValidationMode } from "../types"
 
@@ -36,31 +37,33 @@ export function useAriaFormField(
     validationMode?: ErrorValidationMode
   }
 ): AriaFormFieldData {
-  const hintId = getHintId(fieldId)
-  const errorId = getErrorId(fieldId)
-  const controlDescribedBy =
-    [hasError && errorId, hasHint && hintId]
-      .filter(describedBy => describedBy)
-      .join(` `) || undefined
+  return React.useMemo(() => {
+    const hintId = getHintId(fieldId)
+    const errorId = getErrorId(fieldId)
+    const controlDescribedBy =
+      [hasError && errorId, hasHint && hintId]
+        .filter(describedBy => describedBy)
+        .join(` `) || undefined
 
-  return {
-    controlProps: {
-      id: fieldId,
-      "aria-describedby": controlDescribedBy,
-      "aria-invalid": hasError,
-      required,
-    },
-    labelProps: {
-      htmlFor: fieldId,
-    },
-    hintProps: {
-      id: hintId,
-      hidden: !hasHint,
-    },
-    errorProps: {
-      id: errorId,
-      hidden: !hasError,
-      "aria-live": getErrorAriaLiveAttribute(validationMode),
-    },
-  }
+    return {
+      controlProps: {
+        id: fieldId,
+        "aria-describedby": controlDescribedBy,
+        "aria-invalid": hasError,
+        required,
+      },
+      labelProps: {
+        htmlFor: fieldId,
+      },
+      hintProps: {
+        id: hintId,
+        hidden: !hasHint,
+      },
+      errorProps: {
+        id: errorId,
+        hidden: !hasError,
+        "aria-live": getErrorAriaLiveAttribute(validationMode),
+      },
+    }
+  }, [fieldId, required, hasError, hasHint, validationMode])
 }

--- a/src/components/form-skeletons/hooks/useAriaFormGroupField.tsx
+++ b/src/components/form-skeletons/hooks/useAriaFormGroupField.tsx
@@ -72,8 +72,8 @@ export function useAriaFormGroupField(
   const hintId = getHintId(fieldId)
   const errorId = getErrorId(fieldId)
 
-  return {
-    getLegendProps: (label: React.ReactNode) => ({
+  const getLegendProps: AriaFormGroupFieldData["getLegendProps"] = React.useCallback(
+    label => ({
       children: (
         <React.Fragment>
           {label}
@@ -84,13 +84,28 @@ export function useAriaFormGroupField(
         </React.Fragment>
       ),
     }),
-    getOptionControlProps: (optionValue: string) => ({
+    [hint, error]
+  )
+
+  const getOptionControlProps: AriaFormGroupFieldData["getOptionControlProps"] = React.useCallback(
+    optionValue => ({
       id: getGroupOptionId(fieldId, optionValue),
       required,
     }),
-    getOptionLabelProps: (optionValue: string) => ({
+    [fieldId, required]
+  )
+
+  const getOptionLabelProps: AriaFormGroupFieldData["getOptionLabelProps"] = React.useCallback(
+    optionValue => ({
       htmlFor: getGroupOptionId(fieldId, optionValue),
     }),
+    [fieldId]
+  )
+
+  return {
+    getLegendProps,
+    getOptionControlProps,
+    getOptionLabelProps,
     hintProps: {
       id: hintId,
       hidden: !hasHint,

--- a/src/components/form/components/CheckboxGroupConnectedField.tsx
+++ b/src/components/form/components/CheckboxGroupConnectedField.tsx
@@ -20,25 +20,32 @@ export const CheckboxGroupConnectedField: React.FC<CheckboxGroupConnectedFieldPr
   )
   const value = connectedProps.value || []
 
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = React.useCallback(
+    e => {
+      const target = e.currentTarget
+      let newValue
+
+      if (target.checked) {
+        newValue = [...value, target.value]
+      } else {
+        newValue = value.filter(optionValue => optionValue !== target.value)
+      }
+
+      helpers.setValue(newValue)
+    },
+    [value, helpers.setValue]
+  )
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = React.useCallback(() => {
+    helpers.setTouched(true)
+  }, [helpers.setTouched])
+
   return (
     <CheckboxGroupFieldBlock
       {...connectedProps}
       {...props}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-        const target = e.currentTarget
-        let newValue
-
-        if (target.checked) {
-          newValue = [...value, target.value]
-        } else {
-          newValue = value.filter(optionValue => optionValue !== target.value)
-        }
-
-        helpers.setValue(newValue)
-      }}
-      onBlur={() => {
-        helpers.setTouched(true)
-      }}
+      onChange={handleChange}
+      onBlur={handleBlur}
     />
   )
 }

--- a/src/components/form/components/InputFieldBlock.tsx
+++ b/src/components/form/components/InputFieldBlock.tsx
@@ -1,8 +1,8 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
 import * as React from "react"
-
-import { FormFieldBlock, WithFormFieldBlock } from "./FormFieldBlock"
+import { useAriaFormField } from "../../form-skeletons"
+import { FormFieldBlockBoilerplate, WithFormFieldBlock } from "./FormFieldBlock"
 import { StyledInput, StyledInputProps } from "./styled-primitives/StyledInput"
 
 export type InputFieldBlockProps = WithFormFieldBlock<StyledInputProps>
@@ -24,26 +24,30 @@ export const InputFieldBlock = React.forwardRef<
     ...rest
   } = props
 
+  const fieldData = useAriaFormField(id, {
+    required: required,
+    hasError: !!error,
+    hasHint: !!hint,
+    validationMode,
+  })
+
   return (
-    <FormFieldBlock
+    <FormFieldBlockBoilerplate
+      fieldData={fieldData}
       id={id}
       label={label}
       error={error}
       hint={hint}
-      required={required}
       labelSize={labelSize}
-      validationMode={validationMode}
       layout={layout}
       className={className}
     >
-      {controlProps => (
-        <StyledInput
-          ref={ref}
-          {...controlProps}
-          css={{ width: `100%` }}
-          {...rest}
-        />
-      )}
-    </FormFieldBlock>
+      <StyledInput
+        ref={ref}
+        {...fieldData.controlProps}
+        css={{ width: `100%` }}
+        {...rest}
+      />
+    </FormFieldBlockBoilerplate>
   )
 })

--- a/src/components/form/components/TextAreaFieldBlock.tsx
+++ b/src/components/form/components/TextAreaFieldBlock.tsx
@@ -1,8 +1,8 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core"
 import * as React from "react"
-
-import { FormFieldBlock, WithFormFieldBlock } from "./FormFieldBlock"
+import { useAriaFormField } from "../../form-skeletons"
+import { FormFieldBlockBoilerplate, WithFormFieldBlock } from "./FormFieldBlock"
 import {
   StyledTextArea,
   StyledTextAreaProps,
@@ -27,19 +27,25 @@ export const TextAreaFieldBlock = React.forwardRef<
     ...rest
   } = props
 
+  const fieldData = useAriaFormField(id, {
+    required: required,
+    hasError: !!error,
+    hasHint: !!hint,
+    validationMode,
+  })
+
   return (
-    <FormFieldBlock
+    <FormFieldBlockBoilerplate
+      fieldData={fieldData}
       id={id}
       label={label}
       error={error}
       hint={hint}
-      required={required}
       labelSize={labelSize}
-      validationMode={validationMode}
       layout={layout}
       className={className}
     >
-      {controlProps => <StyledTextArea ref={ref} {...controlProps} {...rest} />}
-    </FormFieldBlock>
+      <StyledTextArea ref={ref} {...fieldData.controlProps} {...rest} />
+    </FormFieldBlockBoilerplate>
   )
 })

--- a/src/components/form/hooks/useConnectedField.ts
+++ b/src/components/form/hooks/useConnectedField.ts
@@ -1,5 +1,11 @@
+import * as React from "react"
 import Case from "case"
-import { useField, FormikHandlers } from "formik"
+import {
+  useField,
+  FormikHandlers,
+  useFormikContext,
+  FieldHelperProps,
+} from "formik"
 
 export type ConnectedFieldProps<TValue = string> = {
   id: string
@@ -14,7 +20,7 @@ export function useConnectedField<TValue = string>(fieldName: string) {
   const id = `${fieldName}Field`
   const label = Case.sentence(fieldName)
 
-  const [field, meta, helpers] = useField<TValue>(fieldName)
+  const [field, meta, helpers] = useFieldFast<TValue>(fieldName)
 
   const connectedProps: ConnectedFieldProps<TValue> = {
     id,
@@ -26,4 +32,29 @@ export function useConnectedField<TValue = string>(fieldName: string) {
   }
 
   return [connectedProps, field, meta, helpers] as const
+}
+
+/**
+ * Taken from this comment in Formik's issues:
+ * https://github.com/formium/formik/issues/2268#issuecomment-682685788
+ */
+function useFieldFast<TValue = string>(fieldName: string) {
+  const [field, meta] = useField<TValue>(fieldName)
+
+  // `setField*` helpers from `useFormikContext` seem to be more "stable" than the ones returned by `useField`
+  const { setFieldTouched, setFieldValue, setFieldError } = useFormikContext()
+
+  // so we are going to shim field level helpers using them and `useMemo`:
+  const helpers = React.useMemo<FieldHelperProps<TValue>>(
+    () => ({
+      setValue: (...args) => setFieldValue(field.name, ...args),
+      setTouched: (...args) => setFieldTouched(field.name, ...args),
+      // Seems like Formik's type defs for `setError` are incorrectly expecting the argument to have type TValue instead of a string
+      // @ts-expect-error
+      setError: (...args) => setFieldError(field.name, ...args),
+    }),
+    [setFieldTouched, setFieldValue, setFieldError, field.name]
+  )
+
+  return [field, meta, helpers] as const
 }

--- a/src/utils/debug/index.tsx
+++ b/src/utils/debug/index.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+
+export function useDebugChangedProps(
+  label: string,
+  props: { [k: string]: unknown }
+) {
+  const prev = React.useRef(props)
+  React.useEffect(() => {
+    const changedProps = Object.entries(props).reduce((ps, [k, v]) => {
+      if (prev.current[k] !== v) {
+        console.log("Changed: " + k)
+        // @ts-expect-error
+        ps[k] = [prev.current[k], v]
+      }
+      return ps
+    }, {})
+    if (Object.keys(changedProps).length > 0) {
+      console.log(`Changed props in ${label}:`, changedProps)
+    }
+    prev.current = props
+  })
+}


### PR DESCRIPTION
This PR contains several performance improvements for form components, some of them are based on these issues in Formik repo: https://github.com/formium/formik/issues/2268 and https://github.com/formium/formik/issues/1026.

Summary of improvements:
* `useAriaFormField` and `useAriaFormGroupField` now wrap their inner logic in `useCallback` and `useMemo` hooks — the values in objects such as `labelProps`, `hintProps` etc do not change very often, yet every call to the `useAriaForm` results in a new object being created (new `labelProps`, `hintProps` etc), leading to false prop changes. Memoizing these helps to reduce the amount of unnecessary re-renders.
* `CheckboxGroupConnectedField` wraps its inner `onBlur` and `onChange` handlers in `useCallback` for the same reason as the previous item. If we have an `InputConnectedField` in the same form as `CheckboxGroupConnectedField`, each time the user types something in the former, the latter gets re-rendered because `onBlur` and `onChange` are re-created. `useCallback` prevents that.
* `InputFieldBlock` and `TextAreaFieldBlock` now use `useAriaFormField` directly instead of relying on `FormFieldBlock` and its render children — these two fields are the most prone to performance issues on value update, since the user types inside them and each keystroke results in a value change. Skipping render function allows to speed re-renders a little bit.
* `useConnectedField` is now using a custom "fast" wrapper for Formik's `useField` based on comments from one of the issues mentioned in the beginning of this PR. 