### PR TITLE
chore: fix a11y CI check

### DIFF
--- a/src/components/form/stories/CheckboxFieldBlock.stories.tsx
+++ b/src/components/form/stories/CheckboxFieldBlock.stories.tsx
@@ -11,7 +11,10 @@ import {
   withErrorArgs,
   withHintArgs,
 } from "./stories.utils"
-import { withVariationsContainer } from "../../../utils/storybook"
+import {
+  disableAnimationsDecorator,
+  withVariationsContainer,
+} from "../../../utils/storybook"
 import {
   CheckboxFieldBlock,
   CheckboxFieldBlockProps,
@@ -35,6 +38,7 @@ export default {
   argTypes: {
     ...commonFieldArgTypes,
   },
+  decorators: [disableAnimationsDecorator],
 } as Meta
 
 const Template: Story<CheckboxFieldBlockProps> = args => (

--- a/src/components/form/stories/CheckboxGroupFieldBlock.stories.tsx
+++ b/src/components/form/stories/CheckboxGroupFieldBlock.stories.tsx
@@ -14,6 +14,7 @@ import {
 import {
   withVariationsContainer,
   getGroupFieldStoryOptions,
+  disableAnimationsDecorator,
 } from "../../../utils/storybook"
 import {
   CheckboxGroupFieldBlock,
@@ -38,6 +39,7 @@ export default {
     ...commonFieldArgTypes,
     ...commonGroupFieldArgTypes,
   },
+  decorators: [disableAnimationsDecorator],
 } as Meta
 
 const options = getGroupFieldStoryOptions("short")

--- a/src/components/form/stories/InputFieldBlock.stories.tsx
+++ b/src/components/form/stories/InputFieldBlock.stories.tsx
@@ -11,7 +11,10 @@ import {
   withErrorArgs,
   withHintArgs,
 } from "./stories.utils"
-import { withVariationsContainer } from "../../../utils/storybook"
+import {
+  disableAnimationsDecorator,
+  withVariationsContainer,
+} from "../../../utils/storybook"
 import {
   InputFieldBlock,
   InputFieldBlockProps,
@@ -47,6 +50,7 @@ export default {
       },
     },
   },
+  decorators: [disableAnimationsDecorator],
 } as Meta
 
 const Template: Story<InputFieldBlockProps> = args => (
@@ -80,6 +84,10 @@ WithError.args = withErrorArgs
 export const WithErrorAndHint = Template.bind({})
 
 WithErrorAndHint.args = withErrorAndHintArgs
+
+WithErrorAndHint.parameters = {
+  chromatic: { pauseAnimationAtEnd: true },
+}
 
 export const LabelSizes = () =>
   LABEL_SIZES.map(labelSize => (

--- a/src/components/form/stories/RadioButtonFieldBlock.stories.tsx
+++ b/src/components/form/stories/RadioButtonFieldBlock.stories.tsx
@@ -14,6 +14,7 @@ import {
 import {
   withVariationsContainer,
   getGroupFieldStoryOptions,
+  disableAnimationsDecorator,
 } from "../../../utils/storybook"
 import {
   RadioButtonFieldBlock,
@@ -56,6 +57,7 @@ export default {
       },
     },
   },
+  decorators: [disableAnimationsDecorator],
 } as Meta
 
 const options = getGroupFieldStoryOptions(`short`)

--- a/src/components/form/stories/SelectFieldBlock.stories.tsx
+++ b/src/components/form/stories/SelectFieldBlock.stories.tsx
@@ -14,6 +14,7 @@ import {
 import {
   withVariationsContainer,
   getGroupFieldStoryOptions,
+  disableAnimationsDecorator,
 } from "../../../utils/storybook"
 import {
   SelectFieldBlock,
@@ -41,6 +42,7 @@ export default {
   argTypes: {
     ...commonFieldArgTypes,
   },
+  decorators: [disableAnimationsDecorator],
 } as Meta
 
 const Template: Story<SelectFieldBlockProps> = args => (

--- a/src/components/form/stories/TextAreaFieldBlock.stories.tsx
+++ b/src/components/form/stories/TextAreaFieldBlock.stories.tsx
@@ -11,7 +11,10 @@ import {
   withErrorArgs,
   withHintArgs,
 } from "./stories.utils"
-import { withVariationsContainer } from "../../../utils/storybook"
+import {
+  disableAnimationsDecorator,
+  withVariationsContainer,
+} from "../../../utils/storybook"
 import {
   TextAreaFieldBlock,
   TextAreaFieldBlockProps,
@@ -47,6 +50,7 @@ export default {
       },
     },
   },
+  decorators: [disableAnimationsDecorator],
 } as Meta
 
 const Template: Story<TextAreaFieldBlockProps> = args => (

--- a/src/utils/storybook/envUtils.ts
+++ b/src/utils/storybook/envUtils.ts
@@ -1,3 +1,3 @@
 export function isA11yTest() {
-  return process.env.STORYBOOK_A11Y_CHECK === "1"
+  return Boolean(process.env.STORYBOOK_A11Y_CHECK)
 }


### PR DESCRIPTION
For some reasons updating to stable Storybook 6 resulted in a11y CI checks failing for "error" states in form block components. Adding `disableAnimationsDecorator` seems to fix it.