### PR TITLE
fix(forms): fix CheckboxConnectedField not properly applying 'checked' state

### DIFF
--- a/src/components/form/components/CheckboxConnectedField.tsx
+++ b/src/components/form/components/CheckboxConnectedField.tsx
@@ -15,7 +15,10 @@ export const CheckboxConnectedField = React.forwardRef<
   HTMLInputElement,
   CheckboxConnectedFieldProps
 >(function CheckboxConnectedField(props, ref) {
-  const [connectedProps] = useConnectedField(props.name)
+  const [connectedProps] = useConnectedField({
+    name: props.name,
+    type: `checkbox`,
+  })
 
   return <CheckboxFieldBlock ref={ref} {...connectedProps} {...props} />
 })

--- a/src/components/form/hooks/useConnectedField.ts
+++ b/src/components/form/hooks/useConnectedField.ts
@@ -1,25 +1,33 @@
 import Case from "case"
-import { useField, FormikHandlers } from "formik"
+import { useField, FormikHandlers, FieldHookConfig } from "formik"
 
 export type ConnectedFieldProps<TValue = string> = {
   id: string
   label: string
   value: TValue
+  checked?: boolean
   error?: string
   onBlur: FormikHandlers["handleBlur"]
   onChange: FormikHandlers["handleBlur"]
 }
 
-export function useConnectedField<TValue = string>(fieldName: string) {
-  const id = `${fieldName}Field`
-  const label = Case.sentence(fieldName)
+export function useConnectedField<TValue = string>(
+  propsOrFieldName: string | FieldHookConfig<TValue>
+) {
+  const name =
+    typeof propsOrFieldName === `string`
+      ? propsOrFieldName
+      : propsOrFieldName.name
+  const id = `${name}Field`
+  const label = Case.sentence(name)
 
-  const [field, meta, helpers] = useField<TValue>(fieldName)
+  const [field, meta, helpers] = useField<TValue>(propsOrFieldName)
 
   const connectedProps: ConnectedFieldProps<TValue> = {
     id,
     label,
     value: field.value,
+    checked: field.checked,
     error: meta.touched ? meta.error : "",
     onBlur: field.onBlur,
     onChange: field.onChange,


### PR DESCRIPTION
`CheckboxConnectedField` currently does not work properly if its initial value is `true` — it does not inject the `checked` prop to the checkbox under the hood, essentially resulting in the latter behaving like an uncontrolled input. 

This PR extends `useConnectedField` hook signature to match the one from Formik's `useField` for better checkbox support., allowing to pass a field configuration object instead of the field name.