### PR TITLE
Show line breaks in RawLogs

### DIFF
--- a/src/components/RawLogs/RawLogs.tsx
+++ b/src/components/RawLogs/RawLogs.tsx
@@ -91,7 +91,7 @@ export function RawLogs({
 
           const itemCss: ThemeCss = theme => ({
             margin: 0,
-            display: `flex`,
+
             color:
               sourceStream === "STDERR"
                 ? theme.colors.red[40]
@@ -105,6 +105,15 @@ export function RawLogs({
             p: {
               margin: 0,
               whiteSpace: `pre-wrap`,
+              marginLeft: theme.space[5],
+            },
+
+            [theme.mediaQueries.desktop]: {
+              display: `flex`,
+
+              p: {
+                marginLeft: 0,
+              },
             },
           })
 

--- a/src/components/RawLogs/RawLogs.tsx
+++ b/src/components/RawLogs/RawLogs.tsx
@@ -91,10 +91,21 @@ export function RawLogs({
 
           const itemCss: ThemeCss = theme => ({
             margin: 0,
+            display: `flex`,
             color:
               sourceStream === "STDERR"
                 ? theme.colors.red[40]
                 : theme.colors.white,
+
+            time: {
+              whiteSpace: `nowrap`,
+              marginRight: theme.space[2],
+            },
+
+            p: {
+              margin: 0,
+              whiteSpace: `pre-wrap`,
+            },
           })
 
           return (
@@ -104,10 +115,9 @@ export function RawLogs({
                   <time dateTime={timestampDate.toString()}>
                     {format(timestampDate, timeFormat)}
                   </time>
-                  &nbsp;
                 </React.Fragment>
               )}
-              {message}
+              <p>{message}</p>
             </li>
           )
         })}


### PR DESCRIPTION
Clubhouse: https://app.clubhouse.io/gatsbyjs/story/16929/show-line-breaks-in-the-raw-logs-ui

Current `RawLogs` ignore  line breaks in messages `\n`. This change should improve readability.
 
.


Current shape: `success` messages are combined in single rows if they come from the same timestamp

<img width="963" alt="Screenshot 2020-10-16 at 16 03 37" src="https://user-images.githubusercontent.com/32480082/96268740-b685d780-0fc9-11eb-9f12-91b498b1cd79.png">


With this PR: every `success`, `info` and `error` starts from the new line as it is in `cli`

<img width="969" alt="Screenshot 2020-10-16 at 16 03 52" src="https://user-images.githubusercontent.com/32480082/96268753-bab1f500-0fc9-11eb-902d-53a70354ce59.png">



Bigger preview:

<img width="981" alt="Screenshot 2020-10-16 at 15 57 00" src="https://user-images.githubusercontent.com/32480082/96267819-91449980-0fc8-11eb-80d9-2b44579becba.png">


Mobile styles:

<img width="1143" alt="Screenshot 2020-10-16 at 16 22 09" src="https://user-images.githubusercontent.com/32480082/96270377-d918f000-0fcb-11eb-9d59-56c96d7c8f4d.png">

