### PR TITLE
fix(form): desctructure Formik's field props instead of copying them

### DIFF
--- a/src/components/form/hooks/useConnectedField.ts
+++ b/src/components/form/hooks/useConnectedField.ts
@@ -24,13 +24,10 @@ export function useConnectedField<TValue = string>(
   const [field, meta, helpers] = useField<TValue>(propsOrFieldName)
 
   const connectedProps: ConnectedFieldProps<TValue> = {
+    ...field,
     id,
     label,
-    value: field.value,
-    checked: field.checked,
     error: meta.touched ? meta.error : "",
-    onBlur: field.onBlur,
-    onChange: field.onChange,
   }
 
   return [connectedProps, field, meta, helpers] as const


### PR DESCRIPTION
The changes to `useConnectedField` from #411 resulted in an obscure bug with `RadioButtonConnectedField` — now the selected radio option did not have its "checked" state applied properly. It was caused by this line:
```typescript
const connectedProps: ConnectedFieldProps<TValue> = {
  checked: field.checked,
}
```
When we defined `checked` prop like this, it will _always_ be present in the object, even if it's `undefined`. This, in turn, affects props override logic. In `RadioButtonFieldBlock` (wrapped by `RadioButtonConnectedField`) we have this element:
```jsx
<StyledRadioButton
  value={value}
  // Support uncontrolled field
  checked={
    fieldValue === undefined ? undefined : fieldValue === value
  }
  {...getOptionControlProps(value)}
  {...rest}
  {...restOption}
/>
```
The`...rest` in that element comes from `useConnectedField`, which _always_ has a `checked` property, and that property takes precedence over our explicit `checked` prop.

This PR fixes this problem by using destructured field props in `connectedProps`:
 ```typescript
const connectedProps: ConnectedFieldProps<TValue> = {
  ...field
}
```
This way we can be sure that if some prop is not present in `field`, it won't be present in `connectedProps`.