### PR TITLE
Sanity check in formatMessage at RawLogs

### DIFF
--- a/src/components/RawLogs/RawLogs.tsx
+++ b/src/components/RawLogs/RawLogs.tsx
@@ -96,6 +96,10 @@ const itemCss: ThemeCss = theme => [
 ]
 
 function formatMessage(message: string): React.ReactNode {
+  if (!message) {
+    return
+  }
+
   const formated = message.replace(
     /(^|\n)(success|info|warning|error) /gi,
     (_: string, match1: string, match2: string) => {


### PR DESCRIPTION
# Purpose

Check existence of `message` before start formatting.  The PR will prevent future Sentry errors like this https://sentry.io/organizations/gatsby-inc-9z/issues/1973075081/?project=1405194&referrer=slack