### PR TITLE
fix(BuildLogs): Format gaphql errors with stacktraces

### DIFF
--- a/src/components/BuildLogs/BuildLogsList.stories.tsx
+++ b/src/components/BuildLogs/BuildLogsList.stories.tsx
@@ -275,6 +275,50 @@ const ALL_INCLUSIVE = [
   },
 
   {
+    id: "e42b5321-9239-44fb-859e-5ca3dc1e3f9b",
+    message: `Missing onError handler for invocation 'building-schema', error was 'Syntax Error: Unexpected Name "agilityNEW"
+
+GraphQL request:1:1
+1 | agilityNEW-RightOrLeftCaseStudyTestimonial-Dev
+  | ^'. Stacktrace was 'GraphQLError: Syntax Error: Unexpected Name "agilityNEW"
+    at syntaxError (/usr/src/app/www/node_modules/graphql/error/syntaxError.js:15:10)
+    at Parser.unexpected (/usr/src/app/www/node_modules/graphql/language/parser.js:1463:41)
+    at Parser.parseDefinition (/usr/src/app/www/node_modules/graphql/language/parser.js:157:16)
+    at Parser.many (/usr/src/app/www/node_modules/graphql/language/parser.js:1518:26)
+    at Parser.parseDocument (/usr/src/app/www/node_modules/graphql/language/parser.js:111:25)
+    at parse (/usr/src/app/www/node_modules/graphql/language/parser.js:36:17)
+    at TypeMapper.createType (/usr/src/app/www/node_modules/graphql-compose/lib/TypeMapper.js:113:43)
+    at Function.createTemp (/usr/src/app/www/node_modules/graphql-compose/lib/ObjectTypeComposer.js:80:28)
+    at Function.create (/usr/src/app/www/node_modules/graphql-compose/lib/ObjectTypeComposer.js:56:21)
+    at forEach (/usr/src/app/www/node_modules/gatsby/src/schema/infer/index.js:44:41)
+    at Array.forEach (<anonymous>)
+    at addInferredTypes (/usr/src/app/www/node_modules/gatsby/src/schema/infer/index.js:27:13)
+    at updateSchemaComposer (/usr/src/app/www/node_modules/gatsby/src/schema/schema.js:142:9)
+    at buildSchema (/usr/src/app/www/node_modules/gatsby/src/schema/schema.js:62:3)
+    at build (/usr/src/app/www/node_modules/gatsby/src/schema/index.js:105:18)
+    at buildSchema (/usr/src/app/www/node_modules/gatsby/src/services/build-schema.ts:19:3)'`,
+    code: "85901",
+    type: "GRAPHQL",
+    filePath: "templates/blog-post.js",
+    location: {
+      start: {
+        line: 13,
+        column: 5,
+      },
+    },
+    errorUrl:
+      "https://www.github.com/julienp-test-org/gatsby-starter-blog/blob/local-dev/src/pages/index3.js#L13",
+    docsUrl: "https://gatsby.dev/issue-how-to",
+    context: {
+      sourceMessage:
+        'Variable "$slug" is never used in operation "BlogPostBySlug".\n\nGraphQL request:2:24\n1 |\n2 |   query BlogPostBySlug($slug: String!) {\n  |                        ^\n3 |     site {',
+    },
+    level: StructuredLogLevel.Error,
+    __typename: "StructuredLog",
+    activity: null,
+  },
+
+  {
     id: "93e9769c-24a8-401c-865a-ca3ab1696057",
     message: 'Building static HTML failed for path "/index3/"',
     code: "95313",

--- a/src/components/BuildLogs/FormattedMessage.tsx
+++ b/src/components/BuildLogs/FormattedMessage.tsx
@@ -6,16 +6,31 @@ import Markdown from "markdown-to-jsx"
 // to close the code block at the good position
 //
 // Example code block:
+//
 // 15 |           frontmatter {
 // 16 |             date(formatString: $invaludVar)
 //    |                                ^
+//
+// Example with a stacktrace:
+//
+// 1 | agilityNEW-RightOrLeftCaseStudyTestimonial-Dev
+//   | ^'. Stacktrace was 'GraphQLError: Syntax Error: Unexpected Name "agilityNEW"
+//     at syntaxError (/usr/src/app/www/node_modules/graphql/error/syntaxError.js:15:10)
+//     at Parser.unexpected (/usr/src/app/www/node_modules/graphql/language/parser.js:1463:41)
 //
 const formatCodeBlocks = (stringPartsByLines: string[]) => {
   let lastIndexFound = -1
   let codeBlockOpen = false
 
   const nextLines = stringPartsByLines.map((str, index) => {
-    if (str.match(/(\s|\t)*\d+\s\|/) || str.match(/(\s|\t)*\|(\s|\t)*\^/)) {
+    if (
+      str.match(/(\s|\t)*\d+\s\|/) ||
+      str.match(/(\s|\t)*\|(\s|\t)*\^/) ||
+      // There is no leading `|` if there is a stacktrace. To limit false
+      // positives we only check for a stacktrace if we are already inside
+      // a code block.
+      (codeBlockOpen && str.match(/(\s|\t)at \w+/))
+    ) {
       if (codeBlockOpen) {
         lastIndexFound = index
       } else {

--- a/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
+++ b/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
@@ -176,4 +176,63 @@ describe("utils", () => {
       </div>
     `)
   })
+
+  it(`should format messages with a stacktrace`, () => {
+    const message = `Missing onError handler for invocation 'building-schema', error was 'Syntax Error: Unexpected Name "agilityNEW"
+
+GraphQL request:1:1
+1 | agilityNEW-RightOrLeftCaseStudyTestimonial-Dev
+  | ^'. Stacktrace was 'GraphQLError: Syntax Error: Unexpected Name "agilityNEW"
+    at syntaxError (/usr/src/app/www/node_modules/graphql/error/syntaxError.js:15:10)
+    at Parser.unexpected (/usr/src/app/www/node_modules/graphql/language/parser.js:1463:41)
+    at Parser.parseDefinition (/usr/src/app/www/node_modules/graphql/language/parser.js:157:16)
+    at Parser.many (/usr/src/app/www/node_modules/graphql/language/parser.js:1518:26)
+    at Parser.parseDocument (/usr/src/app/www/node_modules/graphql/language/parser.js:111:25)
+    at parse (/usr/src/app/www/node_modules/graphql/language/parser.js:36:17)
+    at TypeMapper.createType (/usr/src/app/www/node_modules/graphql-compose/lib/TypeMapper.js:113:43)
+    at Function.createTemp (/usr/src/app/www/node_modules/graphql-compose/lib/ObjectTypeComposer.js:80:28)
+    at Function.create (/usr/src/app/www/node_modules/graphql-compose/lib/ObjectTypeComposer.js:56:21)
+    at forEach (/usr/src/app/www/node_modules/gatsby/src/schema/infer/index.js:44:41)
+    at Array.forEach (<anonymous>)
+    at addInferredTypes (/usr/src/app/www/node_modules/gatsby/src/schema/infer/index.js:27:13)
+    at updateSchemaComposer (/usr/src/app/www/node_modules/gatsby/src/schema/schema.js:142:9)
+    at buildSchema (/usr/src/app/www/node_modules/gatsby/src/schema/schema.js:62:3)
+    at build (/usr/src/app/www/node_modules/gatsby/src/schema/index.js:105:18)
+    at buildSchema (/usr/src/app/www/node_modules/gatsby/src/services/build-schema.ts:19:3)'`
+
+    expect(render(<FormattedMessage rawMessage={message} />).container)
+      .toMatchInlineSnapshot(`
+    <div>
+      <div>
+        <p>
+          Missing onError handler for invocation 'building-schema', error was 'Syntax Error: Unexpected Name "agilityNEW"
+        </p>
+        <p>
+          GraphQL request:1:1
+
+          <code>
+            1 | agilityNEW-RightOrLeftCaseStudyTestimonial-Dev
+      | ^'. Stacktrace was 'GraphQLError: Syntax Error: Unexpected Name "agilityNEW"
+        at syntaxError (/usr/src/app/www/node_modules/graphql/error/syntaxError.js:15:10)
+        at Parser.unexpected (/usr/src/app/www/node_modules/graphql/language/parser.js:1463:41)
+        at Parser.parseDefinition (/usr/src/app/www/node_modules/graphql/language/parser.js:157:16)
+        at Parser.many (/usr/src/app/www/node_modules/graphql/language/parser.js:1518:26)
+        at Parser.parseDocument (/usr/src/app/www/node_modules/graphql/language/parser.js:111:25)
+        at parse (/usr/src/app/www/node_modules/graphql/language/parser.js:36:17)
+        at TypeMapper.createType (/usr/src/app/www/node_modules/graphql-compose/lib/TypeMapper.js:113:43)
+        at Function.createTemp (/usr/src/app/www/node_modules/graphql-compose/lib/ObjectTypeComposer.js:80:28)
+        at Function.create (/usr/src/app/www/node_modules/graphql-compose/lib/ObjectTypeComposer.js:56:21)
+        at forEach (/usr/src/app/www/node_modules/gatsby/src/schema/infer/index.js:44:41)
+        at Array.forEach (&lt;anonymous&gt;)
+        at addInferredTypes (/usr/src/app/www/node_modules/gatsby/src/schema/infer/index.js:27:13)
+        at updateSchemaComposer (/usr/src/app/www/node_modules/gatsby/src/schema/schema.js:142:9)
+        at buildSchema (/usr/src/app/www/node_modules/gatsby/src/schema/schema.js:62:3)
+        at build (/usr/src/app/www/node_modules/gatsby/src/schema/index.js:105:18)
+        at buildSchema (/usr/src/app/www/node_modules/gatsby/src/services/build-schema.ts:19:3)'
+          </code>
+        </p>
+      </div>
+    </div>
+    `)
+  })
 })


### PR DESCRIPTION
Before the code block ends before the stack trace:
<img width="789" alt="Screenshot 2020-10-23 at 14 19 38" src="https://user-images.githubusercontent.com/387068/97002854-dd4c8c80-153a-11eb-99ca-0900c6fabbe3.png">

After:
<img width="901" alt="Screenshot 2020-10-23 at 14 18 05" src="https://user-images.githubusercontent.com/387068/97002877-e3426d80-153a-11eb-93e5-e87ffa37873c.png">
