### PR TITLE
SidebarNav fix for inner page links

### DIFF
--- a/src/components/SidebarNav/SidebarNav.stories.tsx
+++ b/src/components/SidebarNav/SidebarNav.stories.tsx
@@ -44,7 +44,7 @@ const Template: Story<SidebarNavProps> = args => {
       Icon: GeneralIcon,
       onClick: () => setNav(`general`),
       active: activeNav === `general`,
-      to: getPath(`#general`),
+      to: getPath(`/general`),
       subItems: [
         {
           label: `Site Details`,
@@ -83,14 +83,14 @@ const Template: Story<SidebarNavProps> = args => {
       Icon: BuildsIcon,
       onClick: () => setNav(`builds`),
       active: activeNav === `builds`,
-      to: getPath(`#builds`),
+      to: getPath(`/builds`),
     },
     {
       label: `Reports`,
       Icon: ReportsIcon,
       onClick: () => setNav(`reports`),
       active: activeNav === `reports`,
-      to: getPath(`#reports`),
+      to: getPath(`/reports`),
     },
     {
       label: `Integrations`,
@@ -124,7 +124,7 @@ const Template: Story<SidebarNavProps> = args => {
       Icon: SkullIcon,
       onClick: () => setNav(`danger`),
       active: activeNav === `danger`,
-      to: getPath(`#danger`),
+      to: getPath(`/danger`),
     },
   ]
 

--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -187,6 +187,15 @@ function SidebarBaseItem({
   href,
   ...rest
 }: SidebarBaseItemProps) {
+  const isOverwritten = to && href
+  const isText = (!to && !href) || isOverwritten
+
+  if (isOverwritten) {
+    console.warn(
+      `You can't set both 'to' and 'href' props on SidebarBaseItem at the same time! Check the '${label}' link.`
+    )
+  }
+
   return (
     <li
       css={theme => [
@@ -217,7 +226,7 @@ function SidebarBaseItem({
         </a>
       )}
 
-      {!to && !href && label}
+      {isText && label}
       {children}
     </li>
   )

--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -7,6 +7,7 @@ import { Theme, ThemeCss } from "../../theme"
 export type SidebarNavItem = {
   label: React.ReactNode
   to?: string
+  href?: string
   active?: boolean
   onClick?: React.MouseEventHandler<HTMLAnchorElement>
 }
@@ -183,6 +184,7 @@ function SidebarBaseItem({
   active,
   onClick,
   current,
+  href,
   ...rest
 }: SidebarBaseItemProps) {
   return (
@@ -193,7 +195,7 @@ function SidebarBaseItem({
       ]}
       {...rest}
     >
-      {to ? (
+      {to && !href && (
         <Link
           to={to}
           onClick={onClick}
@@ -202,9 +204,20 @@ function SidebarBaseItem({
         >
           {label}
         </Link>
-      ) : (
-        label
       )}
+
+      {!to && href && (
+        <a
+          href={href}
+          onClick={onClick}
+          css={itemLinkCss}
+          aria-current={current}
+        >
+          {label}
+        </a>
+      )}
+
+      {!to && !href && label}
       {children}
     </li>
   )

--- a/src/components/SidebarNav/SidebarNav.tsx
+++ b/src/components/SidebarNav/SidebarNav.tsx
@@ -3,6 +3,7 @@ import { jsx } from "@emotion/core"
 import * as React from "react"
 import { Link } from "gatsby"
 import { Theme, ThemeCss } from "../../theme"
+import { warn } from "../../utils/maintenance/warn"
 
 export type SidebarNavItem = {
   label: React.ReactNode
@@ -191,8 +192,9 @@ function SidebarBaseItem({
   const isText = (!to && !href) || isOverwritten
 
   if (isOverwritten) {
-    console.warn(
-      `You can't set both 'to' and 'href' props on SidebarBaseItem at the same time! Check the '${label}' link.`
+    warn(
+      `You can't set both 'to' and 'href' props on SidebarBaseItem at the same time! Check the '${label}' link.`,
+      `warning`
     )
   }
 


### PR DESCRIPTION
# Purpose 

To fix issues with inner page linking (https://app.clubhouse.io/gatsbyjs/story/16993/the-scroll-to-section-isn-t-working-in-the-site-settings-side-bar) we have to use `a` tag instead of Gatsby `Link`  more context here https://gatsbyjs.slack.com/archives/CGJ457QTT/p1603890513003300 

Related PR https://github.com/gatsby-inc/mansion/pull/9916