### PR TITLE
chore: bring back color palette modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@types/react": "16.8.1",
     "@types/react-dom": "16.8.1",
     "@types/theme-ui": "^0.2.6",
+    "@types/wcag-contrast": "^3.0.0",
     "@types/yup": "^0.26.26",
     "@typescript-eslint/eslint-plugin": "^2.15.0",
     "@typescript-eslint/parser": "^2.15.0",
@@ -126,6 +127,7 @@
     "babel-plugin-typescript-to-proptypes": "^1.1.0",
     "babel-preset-gatsby": "^0.1.11",
     "chalk": "^2.4.2",
+    "color-blend": "^3.0.0",
     "commander": "^3.0.1",
     "deepmerge": "^4.0.0",
     "dotenv": "^5.0.1",
@@ -180,6 +182,7 @@
     "typescript": "3.9.7",
     "unfetch": "^3.1.1",
     "watch": "^1.0.2",
+    "wcag-contrast": "^3.0.0",
     "yup": "^0.27.0"
   },
   "resolutions": {

--- a/src/theme/utils/ColorPaletteModal.tsx
+++ b/src/theme/utils/ColorPaletteModal.tsx
@@ -1,0 +1,645 @@
+/** @jsx jsx */
+import { Global, jsx } from "@emotion/core"
+import * as React from "react"
+import { Colors, Shade } from "gatsby-design-tokens"
+import { rgb as wcag } from "wcag-contrast"
+import { normal } from "color-blend"
+import { Heading } from "../../components/Heading"
+import { Text } from "../../components/Text"
+import { getTheme, Theme, ThemeCss } from ".."
+import { hexToRGB } from "../../utils/helpers"
+import Dialog from "@reach/dialog"
+import { MdClose } from "react-icons/md"
+import "@reach/dialog/styles.css"
+
+const baseTheme = getTheme()
+const { colors: themeColors } = getTheme()
+
+const paddingMixin: ThemeCss = theme => ({
+  padding: theme.space[7],
+  [theme.mediaQueries.desktop]: {
+    padding: theme.space[9],
+  },
+})
+
+// adapted from https://github.com/jxnblk/colorable 🙏
+const minimums = {
+  aa: 4.5,
+  aaLarge: 3,
+  aaa: 7,
+  aaaLarge: 4.5,
+}
+
+const rgbArray = (color: string) => {
+  const pars = color.indexOf(`,`)
+  const repars = color.indexOf(`,`, pars + 1)
+
+  return [
+    parseInt(color.substr(5, pars)),
+    parseInt(color.substr(pars + 1, repars)),
+    parseInt(
+      color.substr(color.indexOf(`,`, pars + 1) + 1, color.indexOf(`,`, repars))
+    ),
+    parseFloat(
+      color.substr(color.indexOf(`,`, repars + 1) + 1, color.indexOf(`)`))
+    ),
+  ] as const
+}
+
+function getA11yLabel(colorA11yInfo: ColorA11yInfo, compact?: boolean) {
+  let label = compact ? `×` : `Fail`
+
+  if (colorA11yInfo.aaa || colorA11yInfo.aa || colorA11yInfo.aaLarge) {
+    if (colorA11yInfo.aaa) {
+      label = compact ? `3` : `AAA`
+    } else if (colorA11yInfo.aa) {
+      label = compact ? `2` : `AA`
+    } else if (colorA11yInfo.aaLarge) {
+      label = compact ? `2+` : `AA Large`
+    }
+  }
+
+  return label
+}
+
+function getTextColor(contrast: ColorableContrast) {
+  return contrast.blackOnColor < contrast.whiteOnColor ? `white` : `black`
+}
+
+function colorToHex(
+  color: string
+): readonly [number, number, number, number | undefined] {
+  if (color.startsWith(`rgba(`)) {
+    return rgbArray(color)
+  }
+
+  const rgb = hexToRGB(color)
+
+  return rgb ? [rgb.r, rgb.g, rgb.b, 1] : [0, 0, 0, 1]
+}
+
+type ColorA11yInfo = {
+  contrast: number
+  aa: boolean
+  aaLarge: boolean
+  aaa: boolean
+  aaaLarge: boolean
+}
+
+function getA11YInfo(hex: string, bg: string): ColorA11yInfo {
+  const text = colorToHex(hex)
+  const background = colorToHex(bg)
+
+  // not 100% sure how well this works — values are slightly different
+  // than what https://contrast-ratio.com/ produces when the text
+  // color is an rgba value; contrast ratios for solid colors seem fine
+  const overlaid = normal(
+    {
+      r: background[0],
+      g: background[1],
+      b: background[2],
+      a: background[3] || 1,
+    },
+    { r: text[0], g: text[1], b: text[2], a: text[3] || 1 }
+  )
+
+  const contrast = wcag(
+    [overlaid.r, overlaid.g, overlaid.b],
+    [background[0], background[1], background[2]]
+  )
+  if (isNaN(contrast)) {
+    console.log(hex, bg)
+  }
+
+  return {
+    contrast: contrast,
+    aa: contrast >= minimums.aa,
+    aaLarge: contrast >= minimums.aaLarge,
+    aaa: contrast >= minimums.aaa,
+    aaaLarge: contrast >= minimums.aaaLarge,
+  }
+}
+
+function Column({ children, ...rest }: React.ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      css={(theme: Theme) => [
+        paddingMixin(theme),
+        {
+          display: `flex`,
+          alignItems: `center`,
+          flexWrap: `wrap`,
+          width: `100%`,
+          margin: 0,
+          [theme.mediaQueries.desktop]: {
+            width: `50%`,
+          },
+        },
+      ]}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+}
+
+function CloseButton(props: React.ComponentPropsWithoutRef<"button">) {
+  return (
+    <button
+      {...props}
+      css={(theme: Theme) => ({
+        display: `flex`,
+        alignItems: `center`,
+        textAlign: `center`,
+        background: `transparent`,
+        borderRadius: theme.radii[6],
+        fontSize: theme.fontSizes[7],
+        width: 48,
+        height: 48,
+        justifyContent: `center`,
+        marginLeft: `auto`,
+        border: 0,
+        cursor: `pointer`,
+        outline: 0,
+        WebkitAppearance: `none`,
+        padding: theme.space[4],
+        transition: `all ${theme.transitions.speed.fast} ${theme.transitions.curve.default}`,
+      })}
+    >
+      <MdClose />
+    </button>
+  )
+}
+
+function AADescription() {
+  return (
+    <Text as="p" css={{ marginBottom: 0 }}>
+      This text is conforming to AA requirements of the WCAG. This is a score of
+      at least <strong>4.5</strong>, the required contrast score for text sizes
+      below 18pt/~24px @1x.
+    </Text>
+  )
+}
+
+function AALargeDescription() {
+  return (
+    <Text
+      as="p"
+      css={(theme: Theme) => ({
+        marginBottom: 0,
+        fontSize: theme.fontSizes[5],
+      })}
+    >
+      This text is conforming to <strong>AA Large</strong> — the smallest
+      acceptable amount of contrast for type sizes of 14pt bold/18pt (which
+      roughly translates to ~18.5px bold/24px @1x) and larger. This is a score
+      of at least
+      {` `}
+      <strong>3.0</strong>.
+    </Text>
+  )
+}
+
+function AAADescription() {
+  return (
+    <Text as="p" css={{ marginBottom: 0 }}>
+      This text is conforming to AAA requirements of WCAG. The contrast score of
+      at least <strong>7.0</strong> qualifies it for long form text.
+    </Text>
+  )
+}
+
+// Renders either white or black text samples
+function TextSamples({
+  contrast,
+  bg,
+  colorName,
+}: {
+  contrast: ColorableContrast
+  bg: string
+  colorName: string
+}) {
+  const inverted = contrast.blackOnColor < contrast.whiteOnColor
+  const colors = inverted
+    ? baseTheme.colors.whiteFade
+    : baseTheme.colors.blackFade
+
+  return (
+    <React.Fragment>
+      {Object.keys(colors).map((color, i) => {
+        const shade = Number(color) as Shade
+        const a11yInfo = getA11YInfo(colors[shade], bg)
+        const a11yLabel = getA11yLabel(a11yInfo)
+
+        if (a11yLabel !== `Fail`) {
+          return (
+            <div key={`text-sample-${colorName}-${shade}-${i}`}>
+              <div
+                css={{
+                  display: `flex`,
+                  alignItems: `center`,
+                  color: colors[shade],
+                }}
+              >
+                <Text
+                  css={(theme: Theme) => ({
+                    marginRight: theme.space[5],
+                    color: colors[shade],
+                    fontFamily: theme.fonts.monospace,
+                    ":before, :after": { display: `none` },
+                    background: `none`,
+                  })}
+                >
+                  {inverted ? `white` : `black`}Fade[{shade}]
+                </Text>
+                {` `}
+                <div
+                  css={{
+                    display: `flex`,
+                    alignItems: `center`,
+                  }}
+                >
+                  <Text
+                    css={(theme: Theme) => ({
+                      marginRight: theme.space[5],
+                      color: colors[shade],
+                      textAlign: `right`,
+                      width: `40px`,
+                    })}
+                  >
+                    {(Math.round(a11yInfo.contrast * 100) / 100).toFixed(2)}
+                  </Text>
+                  {a11yLabel}
+                </div>
+              </div>
+            </div>
+          )
+        } else {
+          return false
+        }
+      })}
+    </React.Fragment>
+  )
+}
+
+const modalContent = (color: SupportedColors) => {
+  const colors: JSX.Element[] = []
+
+  Object.keys(palette[color].colors)
+    .sort((a, b) => Number(b) - Number(a))
+    .forEach((colorNumber, index) => {
+      const colorData = palette[color].colors[Number(colorNumber) as Shade]
+      const textColor = getTextColor(colorData.contrast)
+
+      colors.push(
+        <div
+          css={theme => ({
+            width: `100%`,
+            [theme.mediaQueries.desktop]: {
+              display: `flex`,
+              alignItems: `stretch`,
+            },
+          })}
+          key={`palette-${index}`}
+        >
+          <Column css={{ background: colorData.hex, color: textColor }}>
+            <Text
+              as="span"
+              css={(theme: Theme) => ({
+                color: textColor,
+                fontFamily: theme.fonts.monospace,
+                fontWeight: theme.fontWeights.bold,
+                marginBottom: theme.space[5],
+              })}
+            >
+              colors.{color}[{colorNumber}] {colorData.name && colorData.name}
+            </Text>
+            <Text
+              css={(theme: Theme) => ({
+                color: textColor,
+                marginRight: theme.space[5],
+                marginLeft: `auto`,
+              })}
+            >
+              {colorData.hex}
+            </Text>
+            <Text as="span" css={{ color: textColor }}>
+              {colorData.rgb.red}, {colorData.rgb.green}, {colorData.rgb.blue}
+            </Text>
+            <div
+              css={{
+                width: `100%`,
+                flexShrink: 0,
+              }}
+            >
+              <TextSamples
+                contrast={colorData.contrast}
+                bg={colorData.hex}
+                colorName={`colors.${color}[${colorNumber}]`}
+              />
+            </div>
+          </Column>
+          <Column
+            css={(theme: Theme) => ({
+              background: theme.colors.white,
+              alignContent: `baseline`,
+            })}
+          >
+            <Text
+              as="p"
+              css={(theme: Theme) => ({
+                color: theme.colors.grey[80],
+                fontFamily: theme.fonts.monospace,
+                fontWeight: theme.fontWeights.bold,
+                marginRight: theme.space[4],
+                marginBottom: theme.space[5],
+              })}
+            >
+              colors.{color}[{colorNumber}] {colorData.name && colorData.name}
+            </Text>
+            <Text
+              as="span"
+              css={(theme: Theme) => ({
+                color: theme.colors.grey[80],
+                fontWeight: theme.fontWeights.body,
+                marginLeft: `auto`,
+              })}
+            >
+              {colorData.contrast.colorOnWhite.toFixed(2)} /{` `}
+              {getA11yLabel(colorData.a11y)}
+            </Text>
+            <div
+              css={{
+                width: `100%`,
+                flexShrink: 0,
+                "& p": { color: colorData.hex },
+              }}
+            >
+              {getA11yLabel(colorData.a11y) === `AA` && <AADescription />}
+              {getA11yLabel(colorData.a11y) === `AAA` && <AAADescription />}
+              {getA11yLabel(colorData.a11y) === `AA Large` && (
+                <AALargeDescription />
+              )}
+            </div>
+          </Column>
+        </div>
+      )
+    })
+
+  return colors
+}
+
+type ColorableContrast = {
+  colorOnWhite: number
+  whiteOnColor: number
+  blackOnColor: number
+}
+
+const colorable = function(
+  hex: string
+): {
+  hex: string
+  rgb: { red: number; green: number; blue: number }
+  contrast: ColorableContrast
+  a11y: any
+} {
+  const rgb = hexToRGB(hex)
+  const red = rgb ? rgb.r : 0
+  const green = rgb ? rgb.g : 0
+  const blue = rgb ? rgb.b : 0
+  const rgbArray: [number, number, number] = [red, green, blue]
+
+  return {
+    hex,
+    rgb: {
+      red,
+      green,
+      blue,
+    },
+    contrast: {
+      colorOnWhite: wcag(rgbArray, [255, 255, 255]),
+      whiteOnColor: wcag([255, 255, 255], rgbArray),
+      blackOnColor: wcag([0, 0, 0], rgbArray),
+    },
+    a11y: getA11YInfo(hex, themeColors.white),
+  }
+}
+
+// Palette meta information
+const meta: Record<
+  SupportedColors,
+  { base: Shade; meta?: { [k: string]: any } }
+> = {
+  purple: {
+    base: 60,
+    meta: {
+      60: {
+        name: `Gatsby`,
+        pms: {
+          value: `2077 C`,
+          href: `https://www.pantone.com/color-finder/2077-C`,
+        },
+        cmyk: {
+          value: `76 85 0 0`,
+        },
+      },
+      50: { name: `Lilac` },
+      20: { name: `Lavender` },
+    },
+  },
+  orange: {
+    base: 50,
+    meta: {
+      50: { name: `Accent` },
+    },
+  },
+  magenta: { base: 50 },
+  red: {
+    base: 50,
+    meta: {
+      70: { name: `Warning` },
+    },
+  },
+  green: {
+    base: 50,
+  },
+  yellow: {
+    base: 40,
+  },
+  blue: {
+    base: 50,
+  },
+  // black: {
+  //   meta: {
+  //     name: `Black`,
+  //     cmyk: {
+  //       value: `0 0 0 100`,
+  //     },
+  //   },
+  // },
+  // white: {
+  //   meta: {
+  //     name: `White`,
+  //     cmyk: {
+  //       value: `0 0 0 0`,
+  //     },
+  //   },
+  // },
+  grey: {
+    base: 40,
+  },
+  teal: {
+    base: 50,
+  },
+}
+
+type Palette = Record<
+  SupportedColors,
+  {
+    name: string
+    base: Shade
+    colors: Record<Shade, any>
+  }
+>
+
+// Merge info from `meta` and `colors`
+// and add contrast and accessibility information
+function createPalette(): Palette {
+  const palette: Partial<Palette> = {}
+
+  for (const key of Object.keys(themeColors)) {
+    if (!(key in meta)) {
+      continue
+    }
+    const color = key as SupportedColors
+    const colorData = meta[color]
+    const shadesInfo: Partial<Record<Shade, unknown>> = {}
+
+    Object.keys(themeColors[color])
+      .sort((a, b) => Number(a) - Number(b))
+      .forEach(key => {
+        const shade = Number(key) as Shade
+        shadesInfo[shade] = {
+          ...colorable(themeColors[color][shade]),
+          ...(colorData.base && colorData.base === shade && { base: true }),
+          ...(colorData.meta &&
+            colorData.meta[shade] && {
+              name: colorData.meta[shade].name,
+              pms: colorData.meta[shade].pms,
+              cmyk: colorData.meta[shade].cmyk,
+            }),
+        }
+      })
+
+    palette[color] = {
+      name: color, // Color group name
+      base: colorData.base,
+      colors: shadesInfo as Record<Shade, unknown>,
+    }
+  }
+
+  return palette as Palette
+}
+
+const palette = createPalette()
+
+export type SupportedColors = Extract<
+  keyof Colors,
+  | "purple"
+  | "orange"
+  | "yellow"
+  | "red"
+  | "magenta"
+  | "blue"
+  | "teal"
+  | "green"
+  | "grey"
+>
+
+export function ColorPaletteModal<T extends SupportedColors>({
+  isOpen,
+  color,
+  onClose,
+}: {
+  isOpen: boolean
+  color: T
+  onClose: () => void
+}) {
+  const base = palette[color].colors[palette[color].base]
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onDismiss={onClose}
+      aria-label={color}
+      css={(theme: Theme) => ({
+        position: `fixed`,
+        top: 0,
+        width: `100%`,
+        height: `100%`,
+        zIndex: theme.zIndices.modals,
+        background: theme.colors.white,
+        fontFamily: theme.fonts.body,
+        overflowY: `auto`,
+        "&[data-reach-dialog-content]": {
+          width: `100%`,
+          margin: 0,
+          padding: 0,
+        },
+      })}
+    >
+      <Global
+        styles={(theme: Theme) => ({
+          "[data-reach-dialog-overlay]": {
+            zIndex: theme.zIndices.modals,
+          },
+        })}
+      />
+      <div
+        css={(theme: Theme) => [
+          paddingMixin(theme),
+          {
+            display: `flex`,
+            alignItems: `baseline`,
+          },
+        ]}
+      >
+        <Heading
+          css={(theme: Theme) => ({
+            fontSize: theme.fontSizes[7],
+            marginRight: theme.space[5],
+            marginTop: 0,
+            color: theme.colors.black,
+            textTransform: `capitalize`,
+          })}
+        >
+          {palette[color].name}
+        </Heading>
+        <CloseButton
+          onClick={onClose}
+          aria-label={`Close “${palette[color].name}” modal`}
+        />
+      </div>
+      <div
+        css={(theme: Theme) => [
+          paddingMixin(theme),
+          {
+            background: base.hex,
+          },
+        ]}
+      >
+        <Heading
+          as="h2"
+          css={(theme: Theme) => ({
+            margin: 0,
+            lineHeight: theme.lineHeights.solid,
+            color: getTextColor(base.contrast),
+          })}
+        >
+          Base {palette[color].base} {base.name && <span> — {base.name}</span>}
+        </Heading>
+      </div>
+      {modalContent(color).map(color => color)}
+    </Dialog>
+  )
+}

--- a/src/theme/utils/ColorsTable.tsx
+++ b/src/theme/utils/ColorsTable.tsx
@@ -2,25 +2,15 @@
 import { jsx } from "@emotion/core"
 import * as React from "react"
 import { Shade } from "gatsby-design-tokens"
-import { Colors } from "../colors"
 import { copyToClipboard } from "../../utils/helpers"
 import { VisuallyHidden } from "../../components/VisuallyHidden"
-import { getTheme } from ".."
+import { getTheme, Theme } from ".."
+import { ColorPaletteModal, SupportedColors } from "./ColorPaletteModal"
 
 const baseTheme = getTheme()
 
-type ColorKey = Extract<
-  keyof Colors,
-  | "purple"
-  | "orange"
-  | "magenta"
-  | "blue"
-  | "teal"
-  | "yellow"
-  | "red"
-  | "green"
-  | "grey"
->
+type ColorKey = SupportedColors
+
 const primaryColors: ColorKey[] = ["purple", "orange"]
 const secondaryColors: ColorKey[] = [
   "magenta",
@@ -134,6 +124,9 @@ const invertTextColor: Record<ColorKey, Partial<Record<Shade, boolean>>> = {
 }
 
 export function ColorsTable() {
+  const [selectedColor, setSelectedColor] = React.useState<ColorKey | null>(
+    null
+  )
   const renderGroup = (group: ColorKey[], groupLabel: string) => {
     return group.map((color, idx, list) => {
       return (
@@ -154,11 +147,29 @@ export function ColorsTable() {
           )}
           <td
             css={theme => ({
-              textTransform: `capitalize`,
               paddingRight: theme.space[10],
             })}
           >
-            {color}
+            <button
+              onClick={() => setSelectedColor(color)}
+              css={(theme: Theme) => ({
+                margin: 0,
+                padding: 0,
+                background: `none`,
+                border: `none`,
+                textTransform: `capitalize`,
+                cursor: `pointer`,
+                color: theme.colors.purple[50],
+                fontSize: theme.fontSizes[3],
+                fontFamily: theme.fonts.body,
+                borderBottom: `1px solid currentColor`,
+                "&:hover": {
+                  color: theme.colors.purple[70],
+                },
+              })}
+            >
+              {color}
+            </button>
           </td>
           {shades.map(shade => {
             const contrastScore = contrastScores[color][shade]
@@ -194,31 +205,40 @@ export function ColorsTable() {
     })
   }
   return (
-    <table
-      css={theme => ({
-        verticalAlign: `baseline`,
-        lineHeight: `40px`,
-        borderSpacing: 8,
-        fontFamily: theme.fonts.body,
-      })}
-    >
-      <thead>
-        <tr>
-          <th>
-            <VisuallyHidden>Color group</VisuallyHidden>
-          </th>
-          <th>
-            <VisuallyHidden>Color</VisuallyHidden>
-          </th>
-          {shades.map(shade => (
-            <th key={shade}>{shade}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>{renderGroup(primaryColors, "Primary")}</tbody>
-      <tbody>{renderGroup(secondaryColors, "Secondary")}</tbody>
-      <tbody>{renderGroup(neutralColors, "Neutral")}</tbody>
-    </table>
+    <React.Fragment>
+      <table
+        css={theme => ({
+          verticalAlign: `baseline`,
+          lineHeight: `40px`,
+          borderSpacing: 8,
+          fontFamily: theme.fonts.body,
+        })}
+      >
+        <thead>
+          <tr>
+            <th>
+              <VisuallyHidden>Color group</VisuallyHidden>
+            </th>
+            <th>
+              <VisuallyHidden>Color</VisuallyHidden>
+            </th>
+            {shades.map(shade => (
+              <th key={shade}>{shade}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{renderGroup(primaryColors, "Primary")}</tbody>
+        <tbody>{renderGroup(secondaryColors, "Secondary")}</tbody>
+        <tbody>{renderGroup(neutralColors, "Neutral")}</tbody>
+      </table>
+      {selectedColor && (
+        <ColorPaletteModal
+          isOpen={Boolean(selectedColor)}
+          color={selectedColor}
+          onClose={() => setSelectedColor(null)}
+        />
+      )}
+    </React.Fragment>
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4318,6 +4318,11 @@
   resolved "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
   integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
+"@types/wcag-contrast@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@types/wcag-contrast/-/wcag-contrast-3.0.0.tgz#640a4c36a6b62d54f1dd64a74322595df465148d"
+  integrity sha512-RDinJW4P1bg+dWA6C0/looxA0zyi24gIDHrewzFW/xyU2v97D38KRzXdxMbiVpqovrjTa/xsX8abj3/hpASklg==
+
 "@types/webpack-env@^1.15.2":
   version "1.15.3"
   resolved "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.3.tgz#fb602cd4c2f0b7c0fb857e922075fdf677d25d84"
@@ -7016,6 +7021,11 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
+color-blend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/color-blend/-/color-blend-3.0.0.tgz#077073ee59ebce15e084f00590c5bf7577899cb5"
+  integrity sha512-m21ytRyjsIkVOGG1jrrpijhx7icji0MljlxUoa0ER7lgGW11as0GPLrXQQuMULH1BWJ7OsR11Dy2S6A5lehg5A==
+
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -9149,7 +9159,7 @@ eslint@^6.3.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.25:
+esm@^3.0.84, esm@^3.2.25:
   version "3.2.25"
   resolved "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
@@ -17929,6 +17939,13 @@ relateurl@^0.2.7:
   resolved "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+relative-luminance@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/relative-luminance/-/relative-luminance-2.0.1.tgz#2babddf3a5a59673227d6f02e0f68e13989e3d13"
+  integrity sha512-wFuITNthJilFPwkK7gNJcULxXBcfFZvZORsvdvxeOdO44wCeZnuQkf3nFFzOR/dpJNxYsdRZJLsepWbyKhnMww==
+  dependencies:
+    esm "^3.0.84"
+
 relay-runtime@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/relay-runtime/-/relay-runtime-2.0.0.tgz#0e42df90365cc69f104f7e4b20fdcf975f5a9c0b"
@@ -20985,6 +21002,13 @@ watchpack@^1.7.4:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
+
+wcag-contrast@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/wcag-contrast/-/wcag-contrast-3.0.0.tgz#51c2df43f15162993006454b3362844205889efb"
+  integrity sha512-RWbpg/S7FOXDCwqC2oFhN/vh8dHzj0OS6dpyOSDHyQFSmqmR+lAUStV/ziTT1GzDqL9wol+nZQB4vCi5yEak+w==
+  dependencies:
+    relative-luminance "^2.0.0"
 
 web-namespaces@^1.0.0, web-namespaces@^1.1.2:
   version "1.1.4"


### PR DESCRIPTION
As the title says — this PR brings back the palette modal for each of our main colors. This modal can be opened by clicking on the color name in Colors story.

It will definitely need some polishing, but it should do its job for now 🙂 
![localhost_6006_iframe html_id=theme-colors--page viewMode=story (4)](https://user-images.githubusercontent.com/4366711/98434733-1a5e6600-2087-11eb-916f-a72733512269.png)
