### PR TITLE
feat(DropdownMenu): add support for 'tone' and 'Icon' props

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -232,7 +232,7 @@ MenuLinks.parameters = {
   chromatic: { delay: 150 },
 }
 
-export const ItemVariants = () => {
+export const ItemTones = () => {
   useOpenMenuOnMount()
 
   return (
@@ -245,32 +245,32 @@ export const ItemVariants = () => {
             target="_blank"
             rel="noreferrer noopener"
             as={"a"}
-            onSelect={() => action("Select")(`Variant: DEFAULT`)}
+            onSelect={() => action("Select")(`Tone: DEFAULT`)}
           >
-            Variant: DEFAULT
+            Tone: DEFAULT
           </DropdownMenuLink>
           <DropdownMenuLink
             href={`https://www.google.com/search?q=Ashalmawia`}
             target="_blank"
             rel="noreferrer noopener"
             as={"a"}
-            variant="CRITICAL"
-            onSelect={() => action("Select")(`Variant: CRITICAL`)}
+            tone="CRITICAL"
+            onSelect={() => action("Select")(`Tone: CRITICAL`)}
           >
-            Variant: CRITICAL
+            Tone: CRITICAL
           </DropdownMenuLink>
           <DropdownMenuItem
             Icon={MdRefresh}
-            onSelect={() => action("Select")(`Variant: DEFAULT (with icon)`)}
+            onSelect={() => action("Select")(`Tone: DEFAULT (with icon)`)}
           >
-            Variant: DEFAULT (with icon)
+            Tone: DEFAULT (with icon)
           </DropdownMenuItem>
           <DropdownMenuItem
             Icon={MdDelete}
-            variant="CRITICAL"
-            onSelect={() => action("Select")(`Variant: CRITICAL (with icon)`)}
+            tone="CRITICAL"
+            onSelect={() => action("Select")(`Tone: CRITICAL (with icon)`)}
           >
-            Variant: CRITICAL (with icon)
+            Tone: CRITICAL (with icon)
           </DropdownMenuItem>
         </DropdownMenuItems>
       </DropdownMenu>
@@ -278,7 +278,7 @@ export const ItemVariants = () => {
   )
 }
 
-ItemVariants.parameters = {
+ItemTones.parameters = {
   chromatic: { delay: 150 },
 }
 

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -25,6 +25,7 @@ import { DropdownMenuSize } from "./DropdownMenu"
 import { Notification } from "../Notification"
 import { Link } from "gatsby"
 import { positionRight } from "@reach/popover"
+import { MdDelete, MdRefresh } from "react-icons/md"
 
 export default {
   title: `DropdownMenu`,
@@ -228,6 +229,56 @@ export const MenuLinks = () => {
 }
 
 MenuLinks.parameters = {
+  chromatic: { delay: 150 },
+}
+
+export const ItemVariants = () => {
+  useOpenMenuOnMount()
+
+  return (
+    <div css={{ minHeight: "100vh" }}>
+      <DropdownMenu>
+        <DropdownMenuButton>{text("label", "Actions")}</DropdownMenuButton>
+        <DropdownMenuItems>
+          <DropdownMenuLink
+            href={`https://www.google.com/search?q=Ashalmawia`}
+            target="_blank"
+            rel="noreferrer noopener"
+            as={"a"}
+            onSelect={() => action("Select")(`Variant: DEFAULT`)}
+          >
+            Variant: DEFAULT
+          </DropdownMenuLink>
+          <DropdownMenuLink
+            href={`https://www.google.com/search?q=Ashalmawia`}
+            target="_blank"
+            rel="noreferrer noopener"
+            as={"a"}
+            variant="CRITICAL"
+            onSelect={() => action("Select")(`Variant: CRITICAL`)}
+          >
+            Variant: CRITICAL
+          </DropdownMenuLink>
+          <DropdownMenuItem
+            Icon={MdRefresh}
+            onSelect={() => action("Select")(`Variant: DEFAULT (with icon)`)}
+          >
+            Variant: DEFAULT (with icon)
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            Icon={MdDelete}
+            variant="CRITICAL"
+            onSelect={() => action("Select")(`Variant: CRITICAL (with icon)`)}
+          >
+            Variant: CRITICAL (with icon)
+          </DropdownMenuItem>
+        </DropdownMenuItems>
+      </DropdownMenu>
+    </div>
+  )
+}
+
+ItemVariants.parameters = {
   chromatic: { delay: 150 },
 }
 

--- a/src/components/DropdownMenu/DropdownMenu.styles.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.styles.tsx
@@ -1,5 +1,5 @@
 import { ThemeCss } from "../../theme"
-import { DropdownMenuSize } from "./DropdownMenu"
+import { DropdownMenuItemVariant, DropdownMenuSize } from "./DropdownMenu"
 
 export const dropdownCss: ThemeCss = theme => ({
   background: theme.colors.primaryBackground,
@@ -55,6 +55,48 @@ export const menuItemCss: ThemeCss = theme => ({
   display: `block`,
   textDecoration: `none`,
 })
+
+export const menuItemVariantCss: Record<DropdownMenuItemVariant, ThemeCss> = {
+  DEFAULT: theme => ({
+    color: theme.colors.grey[90],
+    "[data-selected] > &": {
+      color: theme.colors.purple[50],
+    },
+  }),
+  CRITICAL: theme => ({
+    color: theme.colors.red[90],
+    "[data-selected] &": {
+      color: theme.colors.red[90],
+    },
+  }),
+}
+
+export const menuItemIconCss: ThemeCss = theme => ({
+  marginRight: theme.space[3],
+  verticalAlign: `middle`,
+  transition: `0.5s`,
+  "[data-selected] &": {
+    transform: "scale(1.2)",
+  },
+})
+
+export const menuItemIconVariantCss: Record<
+  DropdownMenuItemVariant,
+  ThemeCss
+> = {
+  DEFAULT: theme => ({
+    color: theme.colors.grey[40],
+    "[data-selected] &": {
+      color: theme.colors.purple[50],
+    },
+  }),
+  CRITICAL: theme => ({
+    color: theme.colors.red[20],
+    "[data-selected] &": {
+      color: theme.colors.red[90],
+    },
+  }),
+}
 
 export const dropdownButtonCss: ThemeCss = theme => ({
   cursor: "pointer",

--- a/src/components/DropdownMenu/DropdownMenu.styles.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.styles.tsx
@@ -1,5 +1,5 @@
 import { ThemeCss } from "../../theme"
-import { DropdownMenuItemVariant, DropdownMenuSize } from "./DropdownMenu"
+import { DropdownMenuItemTone, DropdownMenuSize } from "./DropdownMenu"
 
 export const dropdownCss: ThemeCss = theme => ({
   background: theme.colors.primaryBackground,
@@ -56,7 +56,7 @@ export const menuItemCss: ThemeCss = theme => ({
   textDecoration: `none`,
 })
 
-export const menuItemVariantCss: Record<DropdownMenuItemVariant, ThemeCss> = {
+export const menuItemToneCss: Record<DropdownMenuItemTone, ThemeCss> = {
   DEFAULT: theme => ({
     color: theme.colors.grey[90],
     "[data-selected] > &": {
@@ -80,10 +80,7 @@ export const menuItemIconCss: ThemeCss = theme => ({
   },
 })
 
-export const menuItemIconVariantCss: Record<
-  DropdownMenuItemVariant,
-  ThemeCss
-> = {
+export const menuItemIconToneCss: Record<DropdownMenuItemTone, ThemeCss> = {
   DEFAULT: theme => ({
     color: theme.colors.grey[40],
     "[data-selected] &": {

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -24,11 +24,13 @@ import { MdKeyboardArrowDown } from "react-icons/md"
 import {
   dropdownCss,
   dropdownButtonCss,
-  menuItemCss,
   dropdownButtonIconCss,
   dropdownSizeCss,
   dropdownDividerCss,
   dropdownHeaderCss,
+  menuItemCss,
+  menuItemIconCss,
+  menuItemVariantCss,
 } from "./DropdownMenu.styles"
 import { DisableReachStyleCheck } from "../../utils/helpers/DisableReachStyleCheck"
 import { ThemeCss } from "../../theme"
@@ -103,19 +105,53 @@ export const DropdownMenuItemsLowLevel: React.FC<DropdownMenuItemsLowLevelProps>
   return <AnimatedMenuItems style={styleProps} {...rest} css={finalCss} />
 }
 
-export type DropdownMenuItemProps = MenuItemProps
+export type DropdownMenuItemVariant = "DEFAULT" | "CRITICAL"
+
+export type StyledMenuItemProps = {
+  Icon?: React.ComponentType
+  variant?: DropdownMenuItemVariant
+}
+
+export type DropdownMenuItemProps = MenuItemProps & StyledMenuItemProps
 
 export const DropdownMenuItem: React.FC<DropdownMenuItemProps> = props => (
-  <MenuItem {...props} css={menuItemCss} />
+  <MenuItem {...props} {...getStyledMenuItemProps(props)} />
 )
 
-export type DropdownMenuLinkProps = MenuLinkProps
+export type DropdownMenuLinkProps = MenuLinkProps & StyledMenuItemProps
 
 export const DropdownMenuLink = forwardRefWithAs<DropdownMenuLinkProps, "a">(
   function DropdownMenuLink(props, ref) {
-    return <MenuLink ref={ref} {...props} css={menuItemCss} />
+    return <MenuLink ref={ref} {...props} {...getStyledMenuItemProps(props)} />
   }
 )
+
+function getStyledMenuItemProps({
+  children,
+  variant = `DEFAULT`,
+  Icon,
+}: DropdownMenuItemProps | DropdownMenuLinkProps) {
+  const itemCss: ThemeCss = theme => [
+    menuItemCss(theme),
+    menuItemVariantCss[variant](theme),
+  ]
+  const iconCss: ThemeCss = theme => [
+    menuItemIconCss(theme),
+    menuItemVariantCss[variant](theme),
+  ]
+
+  return {
+    css: itemCss,
+    children: Icon ? (
+      <React.Fragment>
+        <Icon css={iconCss} />
+        {children}
+      </React.Fragment>
+    ) : (
+      children
+    ),
+  }
+}
 
 export type DropdownMenuPopoverProps = MenuPopoverProps
 

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -29,8 +29,9 @@ import {
   dropdownDividerCss,
   dropdownHeaderCss,
   menuItemCss,
+  menuItemToneCss,
   menuItemIconCss,
-  menuItemVariantCss,
+  menuItemIconToneCss,
 } from "./DropdownMenu.styles"
 import { DisableReachStyleCheck } from "../../utils/helpers/DisableReachStyleCheck"
 import { ThemeCss } from "../../theme"
@@ -105,11 +106,11 @@ export const DropdownMenuItemsLowLevel: React.FC<DropdownMenuItemsLowLevelProps>
   return <AnimatedMenuItems style={styleProps} {...rest} css={finalCss} />
 }
 
-export type DropdownMenuItemVariant = "DEFAULT" | "CRITICAL"
+export type DropdownMenuItemTone = "DEFAULT" | "CRITICAL"
 
 export type StyledMenuItemProps = {
   Icon?: React.ComponentType
-  variant?: DropdownMenuItemVariant
+  tone?: DropdownMenuItemTone
 }
 
 export type DropdownMenuItemProps = MenuItemProps & StyledMenuItemProps
@@ -128,16 +129,16 @@ export const DropdownMenuLink = forwardRefWithAs<DropdownMenuLinkProps, "a">(
 
 function getStyledMenuItemProps({
   children,
-  variant = `DEFAULT`,
+  tone = `DEFAULT`,
   Icon,
 }: DropdownMenuItemProps | DropdownMenuLinkProps) {
   const itemCss: ThemeCss = theme => [
     menuItemCss(theme),
-    menuItemVariantCss[variant](theme),
+    menuItemToneCss[tone](theme),
   ]
   const iconCss: ThemeCss = theme => [
     menuItemIconCss(theme),
-    menuItemVariantCss[variant](theme),
+    menuItemIconToneCss[tone](theme),
   ]
 
   return {


### PR DESCRIPTION
`DropdownMenuLink` and `DropdownMenuItem` now support two new props: `tone` and `Icon`. If this is approved and shipped, we can use those props to replace our `DropdownMenuActionLabel` component in Cloud.