### PR TITLE
feat(Text): support as='div' and margin reset props

### DIFF
--- a/src/components/BaseText/BaseText.tsx
+++ b/src/components/BaseText/BaseText.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { PropsOf } from "../../utils/types"
 
-type AllowedAs = "p" | "span"
+type AllowedAs = "p" | "span" | "div"
 
 export type BaseTextProps = Omit<PropsOf<AllowedAs>, "ref"> & {
   as?: AllowedAs

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -9,12 +9,16 @@ export type TextProps = BaseTextProps & {
   tone?: TextTone
   variant?: TextVariant
   size?: TextSize
+  noMarginTop?: boolean
+  noMarginBottom?: boolean
 }
 
 function Text({
   tone = `NEUTRAL`,
   variant = `PRIMARY`,
   size = `M`,
+  noMarginTop = false,
+  noMarginBottom = false,
   ...rest
 }: TextProps) {
   return (
@@ -23,6 +27,12 @@ function Text({
         baseStyle(tone)(theme),
         sizeStyles[size](theme),
         variantStyles[variant](theme),
+        noMarginTop && {
+          marginTop: 0,
+        },
+        noMarginBottom && {
+          marginBottom: 0,
+        },
       ]}
       {...rest}
     />


### PR DESCRIPTION
* Allows to use `div` in `Text`'s and `BaseText`'s `as` prop.
* `Text` now accepts `noMarginTop` and `noMarginBottom` props, which allow to reset browser defaults for the corresponding CSS properties.