### PR TITLE
fix(form): set StyledTextArea's height to 'auto' so that 'rows' attribute works

### DIFF
--- a/src/components/form/components/styled-primitives/StyledTextArea.tsx
+++ b/src/components/form/components/styled-primitives/StyledTextArea.tsx
@@ -19,6 +19,7 @@ export const StyledTextArea = React.forwardRef<
     baseInputCss(theme),
     {
       display: `block`,
+      height: `auto`,
       minHeight: `4.85em`,
       resize: `vertical`,
       padding: `${theme.space[2]} ${theme.space[3]}`,

--- a/src/components/form/stories/connectedFields.stories.tsx
+++ b/src/components/form/stories/connectedFields.stories.tsx
@@ -167,6 +167,7 @@ export const Example = () => {
             name="description"
             hint={`Be concise, the field can't be longer than ${DESCRIPTION_MAX_LENGTH} characters`}
             layout={layout}
+            rows={7}
           />
 
           <SelectConnectedField


### PR DESCRIPTION
Currently we have to do some terrible things if we want to use `rows` attribute for text areas:
```jsx
<TextAreaFieldBlock
  rows={10}
  css={{ textarea: { height: `auto` } }}
/>
```

This was due to `StyledTextArea` inheriting styled input styles which have an explicitly set height. This PR fixes this oversight by setting `height: auto` for styled text areas. 