### PR TITLE
fix(DropdownMenu): fix icon's vertical alignment and make it more opaque

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -25,7 +25,8 @@ import { DropdownMenuSize } from "./DropdownMenu"
 import { Notification } from "../Notification"
 import { Link } from "gatsby"
 import { positionRight } from "@reach/popover"
-import { MdDelete, MdRefresh } from "react-icons/md"
+import { MdDelete } from "react-icons/md"
+import { GatsbyCloudIcon } from "../icons"
 
 export default {
   title: `DropdownMenu`,
@@ -260,7 +261,7 @@ export const ItemTones = () => {
             Tone: CRITICAL
           </DropdownMenuLink>
           <DropdownMenuItem
-            Icon={MdRefresh}
+            Icon={GatsbyCloudIcon}
             onSelect={() => action("Select")(`Tone: DEFAULT (with icon)`)}
           >
             Tone: DEFAULT (with icon)

--- a/src/components/DropdownMenu/DropdownMenu.styles.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.styles.tsx
@@ -72,8 +72,12 @@ export const menuItemToneCss: Record<DropdownMenuItemTone, ThemeCss> = {
 }
 
 export const menuItemIconCss: ThemeCss = theme => ({
+  // Based on suggestion from https://blog.prototypr.io/align-svg-icons-to-text-and-say-goodbye-to-font-icons-d44b3d7b26b4
+  top: `.125em`,
+  position: `relative`,
   marginRight: theme.space[3],
-  verticalAlign: `middle`,
+  width: theme.fontSizes[2],
+  height: theme.fontSizes[2],
   transition: `0.5s`,
   "[data-selected] &": {
     transform: "scale(1.2)",
@@ -82,13 +86,13 @@ export const menuItemIconCss: ThemeCss = theme => ({
 
 export const menuItemIconToneCss: Record<DropdownMenuItemTone, ThemeCss> = {
   DEFAULT: theme => ({
-    color: theme.colors.grey[40],
+    color: theme.colors.grey[50],
     "[data-selected] &": {
       color: theme.colors.purple[50],
     },
   }),
   CRITICAL: theme => ({
-    color: theme.colors.red[20],
+    color: theme.colors.red[30],
     "[data-selected] &": {
       color: theme.colors.red[90],
     },

--- a/src/components/DropdownMenu/DropdownMenu.styles.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.styles.tsx
@@ -73,7 +73,7 @@ export const menuItemToneCss: Record<DropdownMenuItemTone, ThemeCss> = {
 
 export const menuItemIconCss: ThemeCss = theme => ({
   // Based on suggestion from https://blog.prototypr.io/align-svg-icons-to-text-and-say-goodbye-to-font-icons-d44b3d7b26b4
-  top: `.125em`,
+  top: `.125rem`,
   position: `relative`,
   marginRight: theme.space[3],
   width: theme.fontSizes[2],

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -109,7 +109,7 @@ export const DropdownMenuItemsLowLevel: React.FC<DropdownMenuItemsLowLevelProps>
 export type DropdownMenuItemTone = "DEFAULT" | "CRITICAL"
 
 export type StyledMenuItemProps = {
-  Icon?: React.ComponentType
+  Icon?: React.ComponentType<React.ComponentPropsWithoutRef<"svg">>
   tone?: DropdownMenuItemTone
 }
 
@@ -145,7 +145,7 @@ function getStyledMenuItemProps({
     css: itemCss,
     children: Icon ? (
       <React.Fragment>
-        <Icon css={iconCss} />
+        <Icon css={iconCss} style={{ verticalAlign: `baseline` }} />
         {children}
       </React.Fragment>
     ) : (


### PR DESCRIPTION
In #429 I have added support for `Icon` to dropdown items, but the vertical alignment was off. I have updated it based on [this article](https://blog.prototypr.io/align-svg-icons-to-text-and-say-goodbye-to-font-icons-d44b3d7b26b4) and also fixed sizing issues with icons from Gatsby Interface.
I have also made the icons more vibrant by bumping their default shades of grey and red a bit.

![localhost_6006_iframe html_id=dropdownmenu--item-tones viewMode=story](https://user-images.githubusercontent.com/4366711/101965770-a73a9900-3bca-11eb-8aa6-d093d402ce2b.png)
  