### PR TITLE
Add SUCCESS tone and withBorder prop to NumberBadge

### DIFF
--- a/src/components/NumberBadge/NumberBadge.stories.tsx
+++ b/src/components/NumberBadge/NumberBadge.stories.tsx
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+import * as React from "react"
 import { jsx } from "@emotion/core"
 import { Meta, Story } from "@storybook/react"
 import { withVariationsContainer } from "../../utils/storybook"
@@ -15,19 +16,36 @@ const Template: Story<NumberBadgeProps> = args => <NumberBadge {...args} />
 export const Basic = Template.bind({})
 
 Basic.args = {
-  children: 8,
+  children: 80,
 }
 
-const TONES: NumberBadgeTone[] = [`NEUTRAL`, `WARNING`, `DANGER`]
+const TONES: NumberBadgeTone[] = [`NEUTRAL`, `WARNING`, `DANGER`, `SUCCESS`]
 
 export const Tones = () =>
   TONES.map(tone => (
     <StoryPropVariant propName="tone" propValue={tone}>
-      <NumberBadge key={tone} tone={tone}>
-        8
+      <NumberBadge key={tone} tone={tone} withBorder={true}>
+        80
       </NumberBadge>
     </StoryPropVariant>
   ))
+
+Tones.story = {
+  decorators: [withVariationsContainer],
+}
+
+export const withBorder = () => (
+  <React.Fragment>
+    <StoryPropVariant propName="withBorder" propValue={false}>
+      <NumberBadge tone={`SUCCESS`}>80</NumberBadge>
+    </StoryPropVariant>
+    <StoryPropVariant propName="withBorder" propValue={true}>
+      <NumberBadge tone={`SUCCESS`} withBorder={true}>
+        80
+      </NumberBadge>
+    </StoryPropVariant>
+  </React.Fragment>
+)
 
 Tones.story = {
   decorators: [withVariationsContainer],

--- a/src/components/NumberBadge/NumberBadge.stories.tsx
+++ b/src/components/NumberBadge/NumberBadge.stories.tsx
@@ -34,7 +34,7 @@ Tones.story = {
   decorators: [withVariationsContainer],
 }
 
-export const withBorder = () => (
+export const WithBorder = () => (
   <React.Fragment>
     <StoryPropVariant propName="withBorder" propValue={false}>
       <NumberBadge tone={`SUCCESS`}>80</NumberBadge>
@@ -47,6 +47,6 @@ export const withBorder = () => (
   </React.Fragment>
 )
 
-Tones.story = {
+WithBorder.story = {
   decorators: [withVariationsContainer],
 }

--- a/src/components/NumberBadge/NumberBadge.tsx
+++ b/src/components/NumberBadge/NumberBadge.tsx
@@ -15,10 +15,19 @@ const baseCss: ThemeCss = theme => ({
   paddingRight: `calc(3 * ${theme.space[1]})`,
   paddingTop: theme.space[1],
   paddingBottom: theme.space[1],
-  borderRadius: `10px`,
+  borderRadius: theme.radii[5],
 })
 
-const toneCss: Record<NumberBadgeTone, ThemeCss> = {
+const borderStyle: ThemeCss = _ => ({
+  borderWidth: `1px`,
+  borderStyle: `solid`,
+})
+
+const colorsCss: Record<NumberBadgeTone, ThemeCss> = {
+  SUCCESS: theme => ({
+    backgroundColor: theme.tones.SUCCESS.lighter,
+    color: theme.tones.SUCCESS.superDark,
+  }),
   DANGER: theme => ({
     backgroundColor: theme.tones.DANGER.lighter,
     color: theme.tones.DANGER.superDark,
@@ -33,16 +42,40 @@ const toneCss: Record<NumberBadgeTone, ThemeCss> = {
   }),
 }
 
-export type NumberBadgeTone = `DANGER` | `WARNING` | `NEUTRAL`
+const borderCss: Record<NumberBadgeTone, ThemeCss> = {
+  SUCCESS: theme => ({
+    borderColor: theme.tones.SUCCESS.darker,
+  }),
+  DANGER: theme => ({
+    borderColor: theme.tones.DANGER.darker,
+  }),
+  WARNING: theme => ({
+    borderColor: theme.tones.WARNING.darker,
+  }),
+  NEUTRAL: theme => ({
+    borderColor: theme.tones.NEUTRAL.darker,
+  }),
+}
+
+export type NumberBadgeTone = `SUCCESS` | `DANGER` | `WARNING` | `NEUTRAL`
 
 export type NumberBadgeProps = React.ComponentPropsWithoutRef<"span"> & {
   tone?: NumberBadgeTone
+  withBorder?: boolean
 }
 
-export function NumberBadge({ tone = `NEUTRAL`, ...rest }: NumberBadgeProps) {
+export function NumberBadge({
+  tone = `NEUTRAL`,
+  withBorder = false,
+  ...rest
+}: NumberBadgeProps) {
   return (
     <span
-      css={(theme: Theme) => [baseCss(theme), toneCss[tone](theme)]}
+      css={(theme: Theme) => [
+        baseCss(theme),
+        colorsCss[tone](theme),
+        withBorder && [borderStyle(theme), borderCss[tone](theme)],
+      ]}
       {...rest}
     />
   )


### PR DESCRIPTION
To use `NuberBadge` as component presenting the new updated Lighthouse scores we need to extend its functinality

- add `SUCCESS` tone

<img width="1162" alt="Screenshot 2020-12-16 at 09 44 07" src="https://user-images.githubusercontent.com/32480082/102325310-4a9cfc80-3f83-11eb-8474-269299e20cee.png">

- add `withBorder` prop

<img width="1174" alt="Screenshot 2020-12-16 at 09 44 16" src="https://user-images.githubusercontent.com/32480082/102325305-483aa280-3f83-11eb-8cfb-02f998ad1fbc.png">
