### PR TITLE
[fix] Preserve changing '_' to <em> in structured log error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "test": "jest --env=jest-environment-jsdom-sixteen",
+    "test": "jest --env=jest-environment-jsdom-sixteen --verbose",
     "test:a11y": "jest __tests__/AccessiblityStoryshots.test.js --testPathIgnorePatterns=[] --env=jest-environment-jsdom-sixteen",
-    "test:watch": "jest --watch --env=jest-environment-jsdom-sixteen",
+    "test:watch": "jest --watch --env=jest-environment-jsdom-sixteen --verbose",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "tsc": "tsc",

--- a/src/components/BuildLogs/BuildLogsList.stories.tsx
+++ b/src/components/BuildLogs/BuildLogsList.stories.tsx
@@ -422,6 +422,22 @@ GraphQL request:1:1
     total: null,
     __typename: "BuildActivity",
   },
+
+  {
+    activity: null,
+    code: "98124",
+    context: null,
+    docsUrl: "https://gatsby.dev/issue-how-to",
+    errorUrl: null,
+    filePath: "lerna_version_node/src/pages/index.js",
+    id: "a5c5d16a-b5f4-421c-8c05-7bea82c25c98",
+    level: StructuredLogLevel.Error,
+    location: null,
+    message:
+      "undefined failed\n\nCan't resolve '../lerna_node_version.json' in '/usr/src/app/www/lerna_version_node/src/pages'\n\nIf you're trying to use a package make sure that '../lerna_node_version.json' is installed. If you're trying to use a local file make sure that the path is correct.",
+    type: "WEBPACK",
+    __typename: "StructuredLog",
+  },
 ]
 
 export const Basic = () => (

--- a/src/components/BuildLogs/FormattedMessage.tsx
+++ b/src/components/BuildLogs/FormattedMessage.tsx
@@ -22,7 +22,9 @@ const formatCodeBlocks = (stringPartsByLines: string[]) => {
   let lastIndexFound = -1
   let codeBlockOpen = false
 
-  const nextLines = stringPartsByLines.map((str, index) => {
+  const nextLines = stringPartsByLines.map((orgStr, index) => {
+    const str = orgStr.replace(/(?<='.*)_(?=.*')/gi, `\\_`)
+
     if (
       str.match(/(\s|\t)*\d+\s\|/) ||
       str.match(/(\s|\t)*\|(\s|\t)*\^/) ||

--- a/src/components/BuildLogs/FormattedMessage.tsx
+++ b/src/components/BuildLogs/FormattedMessage.tsx
@@ -23,7 +23,8 @@ const formatCodeBlocks = (stringPartsByLines: string[]) => {
   let codeBlockOpen = false
 
   const nextLines = stringPartsByLines.map((orgStr, index) => {
-    const str = orgStr.replace(/(?<='.*)_(?=.*')/gi, `\\_`)
+    //
+    const str = orgStr.replace(/(')(\S*\/\S*)(')/gi, "`$2`")
 
     if (
       str.match(/(\s|\t)*\d+\s\|/) ||

--- a/src/components/BuildLogs/FormattedMessage.tsx
+++ b/src/components/BuildLogs/FormattedMessage.tsx
@@ -23,7 +23,6 @@ const formatCodeBlocks = (stringPartsByLines: string[]) => {
   let codeBlockOpen = false
 
   const nextLines = stringPartsByLines.map((orgStr, index) => {
-    //
     const str = orgStr.replace(/(')(\S*\/\S*)(')/gi, "`$2`")
 
     if (

--- a/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
+++ b/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
@@ -251,10 +251,21 @@ If you're trying to use a package make sure that '../lerna_node_version.json' is
             failed
           </p>
           <p>
-            Can't resolve '../lerna_node_version.json' in '/usr/src/app/www/lerna_version_node/src/pages'
+            Can't resolve 
+            <code>
+              ../lerna_node_version.json
+            </code>
+             in 
+            <code>
+              /usr/src/app/www/lerna_version_node/src/pages
+            </code>
           </p>
           <p>
-            If you're trying to use a package make sure that '../lerna_node_version.json' is installed. If you're trying to use a local file make sure that the path is correct.
+            If you're trying to use a package make sure that 
+            <code>
+              ../lerna_node_version.json
+            </code>
+             is installed. If you're trying to use a local file make sure that the path is correct.
           </p>
         </div>
       </div>

--- a/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
+++ b/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
@@ -235,4 +235,66 @@ GraphQL request:1:1
     </div>
     `)
   })
+
+  it(`should format multiple code blocks`, () => {
+    const message = `There was an error in your GraphQL query:\n\nVariable "$missingVar" is not defined by operation "SomeQuery".\n\nGraphQL request:16:32\n15 |           frontmatter {\n16 |             date(formatString: $missingVar)\n   |                                ^\n17 |             title\n\nGraphQL request:2:3\n1 |\n2 |   query {\n  |   ^\n3 |     site {`
+
+    expect(render(<FormattedMessage rawMessage={message} />).container)
+      .toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <p>
+            There was an error in your GraphQL query:
+          </p>
+          <p>
+            Variable "$missingVar" is not defined by operation "SomeQuery".
+          </p>
+          <p>
+            GraphQL request:16:32
+      
+            <code>
+              15 |           frontmatter {
+      16 |             date(formatString: $missingVar)
+         |                                ^
+      17 |             title
+            </code>
+            
+      GraphQL request:2:3
+      
+            <code>
+              1 |
+      2 |   query {
+        |   ^
+      3 |     site {
+            </code>
+          </p>
+        </div>
+      </div>
+    `)
+  })
+
+  it(`should preserve underscores (do not change them to <em>) in single quoted strings`, () => {
+    const message = `failed
+    
+Can't resolve '../lerna_node_version.json' in '/usr/src/app/www/lerna_version_node/src/pages'
+
+If you're trying to use a package make sure that '../lerna_node_version.json' is installed. If you're trying to use a local file make sure that the path is correct.`
+
+    expect(render(<FormattedMessage rawMessage={message} />).container)
+      .toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <p>
+            failed
+          </p>
+          <p>
+            Can't resolve '../lerna_node_version.json' in '/usr/src/app/www/lerna_version_node/src/pages'
+          </p>
+          <p>
+            If you're trying to use a package make sure that '../lerna_node_version.json' is installed. If you're trying to use a local file make sure that the path is correct.
+          </p>
+        </div>
+      </div>
+      `)
+  })
 })

--- a/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
+++ b/src/components/BuildLogs/__tests__/FormattedMessage.spec.tsx
@@ -236,43 +236,6 @@ GraphQL request:1:1
     `)
   })
 
-  it(`should format multiple code blocks`, () => {
-    const message = `There was an error in your GraphQL query:\n\nVariable "$missingVar" is not defined by operation "SomeQuery".\n\nGraphQL request:16:32\n15 |           frontmatter {\n16 |             date(formatString: $missingVar)\n   |                                ^\n17 |             title\n\nGraphQL request:2:3\n1 |\n2 |   query {\n  |   ^\n3 |     site {`
-
-    expect(render(<FormattedMessage rawMessage={message} />).container)
-      .toMatchInlineSnapshot(`
-      <div>
-        <div>
-          <p>
-            There was an error in your GraphQL query:
-          </p>
-          <p>
-            Variable "$missingVar" is not defined by operation "SomeQuery".
-          </p>
-          <p>
-            GraphQL request:16:32
-      
-            <code>
-              15 |           frontmatter {
-      16 |             date(formatString: $missingVar)
-         |                                ^
-      17 |             title
-            </code>
-            
-      GraphQL request:2:3
-      
-            <code>
-              1 |
-      2 |   query {
-        |   ^
-      3 |     site {
-            </code>
-          </p>
-        </div>
-      </div>
-    `)
-  })
-
   it(`should preserve underscores (do not change them to <em>) in single quoted strings`, () => {
     const message = `failed
     


### PR DESCRIPTION
CB: https://app.clubhouse.io/gatsbyjs/story/23024/structured-logs-formatter-interferes-with-error-message

Because we are using `Markdown` to format structured log messages. When the message contains something like 

```
Can't resolve '../lerna_node_version.json' in '/usr/src/app/www/lerna_version_node/src/pages'
```
the underscores inside the path strings are transformed to `<em>` tags as it's expected for markdown transformation so that results with such a view for a user.

<img width="741" alt="Screenshot 2021-01-19 at 10 48 08" src="https://user-images.githubusercontent.com/32480082/105017242-d94ddf00-5a43-11eb-851c-5f8204150809.png">


The PR prevents this by escaping `_` char if they are a part of a single quoted string. 

