### PR TITLE
feat(ConcealedValue): UI rinse

### DIFF
--- a/src/components/ConcealedValue/ConcealedValue.styles.tsx
+++ b/src/components/ConcealedValue/ConcealedValue.styles.tsx
@@ -2,29 +2,37 @@ import { ThemeCss } from "../../theme"
 
 export const concealedValueContainerCss: ThemeCss = theme => ({
   display: `flex`,
-  alignItems: `center`,
   justifyContent: `space-between`,
-  padding: theme.space[2],
+  backgroundColor: theme.colors.grey[10],
+  border: `1px solid ${theme.colors.grey[30]}`,
+  borderRadius: theme.radii[2],
   width: `100%`,
 })
 
-export const concealedValueContentCss: ThemeCss = theme => ({
+export const concealedValueContentCss = {
   overflow: `hidden`,
   flexGrow: 1,
-  marginRight: theme.space[4],
+}
+
+export const concealedValueActionsCss: ThemeCss = theme => ({
+  display: `flex`,
+  padding: theme.space[2],
 })
 
-export const concealedValueActionsCss = {}
-
 export const concealedValueInputCss: ThemeCss = theme => ({
+  background: `transparent`,
   border: `none`,
   overflow: `hidden`,
-  fontFamily: theme.fonts.heading,
-  fontSize: theme.fontSizes[1],
+  fontFamily: theme.fonts.body,
+  fontSize: theme.fontSizes[2],
   color: theme.tones[`NEUTRAL`].text,
+  paddingLeft: theme.space[3],
+  paddingRight: theme.space[3],
+  height: `100%`,
   width: `100%`,
 })
 
 export const concealedValueButtonCss: ThemeCss = theme => ({
+  background: theme.colors.white,
   marginLeft: theme.space[2],
 })

--- a/src/components/ConcealedValue/ConcealedValue.tsx
+++ b/src/components/ConcealedValue/ConcealedValue.tsx
@@ -1,7 +1,10 @@
 /** @jsx jsx */
 import { useState } from "react"
 import { jsx } from "@emotion/core"
+import { MdVisibility, MdVisibilityOff } from "react-icons/md"
+
 import { Button } from "../Button"
+import { IconButton } from "../IconButton"
 import copyToClipboard from "../../utils/helpers/copyToClipboard"
 import {
   concealedValueContainerCss,
@@ -46,7 +49,7 @@ export function ConcealedValue({
           <input
             css={concealedValueInputCss}
             type="text"
-            value="&bull; &bull; &bull; &bull; &bull; &bull;"
+            value="&bull; &bull; &bull; &bull; &bull;"
             aria-label={`Hidden value of ${ariaLabel}`}
             readOnly
           />
@@ -71,15 +74,16 @@ export function ConcealedValue({
         >
           {isCopied ? `Copied` : `Copy`}
         </Button>
-        <Button
+        <IconButton
           size="S"
           tone="NEUTRAL"
           variant="SECONDARY"
           css={concealedValueButtonCss}
           onClick={revealHandler}
+          icon={isConcealed ? <MdVisibility /> : <MdVisibilityOff />}
         >
           {isConcealed ? `Reveal` : `Conceal`}
-        </Button>
+        </IconButton>
       </div>
     </div>
   )


### PR DESCRIPTION
we still want a lighter variant (similar to the old UI) for tables, so more coming ^^

* no more `Futura` for the `input`, back to the default `16px` (probably still prevents zooming on iOS? 👴)
* visually contain the component: add border and background mimicking a (disabled) `input` (not fully though — `height` doesn't match ;))
* use an <IconButton> for `Reveal`/`Conceal` to save space
* one `bull` less :)