### PR TITLE
Unify paddings for all Notification variants

### DIFF
--- a/src/components/Notification/Notification.helpers.ts
+++ b/src/components/Notification/Notification.helpers.ts
@@ -35,9 +35,6 @@ const variants: Record<NotificationVariant, GetVariantStylesFn> = {
       borderRadius: theme.radii[2],
       boxShadow: `0 0 0 1px ${theme.tones[tone].light} inset`,
       padding: `${theme.space[5]} ${theme.space[7]}`,
-      [theme.mediaQueries.desktop]: {
-        padding: `${theme.space[7]} ${theme.space[9]}`,
-      },
     })
   },
   SOLID: tone => {
@@ -49,9 +46,6 @@ const variants: Record<NotificationVariant, GetVariantStylesFn> = {
           ? theme.tones[tone].textInverted
           : theme.colors.white,
         padding: `${theme.space[5]} ${theme.space[7]}`,
-        [theme.mediaQueries.desktop]: {
-          padding: `${theme.space[7]} ${theme.space[9]}`,
-        },
       },
     ]
   },


### PR DESCRIPTION
There is no need for `SECONDARY` and `SOLID` `Notification` to have such wide paddings. 


<img width="1373" alt="Screenshot 2021-02-02 at 16 28 59" src="https://user-images.githubusercontent.com/32480082/106622688-25387200-6574-11eb-8de5-f5bbb613ff23.png">

Let's unify the padding with the `PRIMARY` variant. 

<img width="1370" alt="Screenshot 2021-02-02 at 16 28 31" src="https://user-images.githubusercontent.com/32480082/106622779-3e412300-6574-11eb-9bfb-0615e9cecd4e.png">

This will let reproduce design for the Hosting Features banners. 

Now the banner looks like below. 

<img width="1532" alt="Screenshot 2021-02-02 at 16 29 25" src="https://user-images.githubusercontent.com/32480082/106622892-5b75f180-6574-11eb-9944-3f25ffc6ebd3.png">

with the changes will look like here

<img width="1513" alt="Screenshot 2021-02-02 at 16 29 54" src="https://user-images.githubusercontent.com/32480082/106622993-747ea280-6574-11eb-8803-1468f0576085.png">

Take a look at the Design Doc point 2. 

https://www.figma.com/file/95HMgM1GfqL86C0Ff33hnr/Hosting?node-id=2622%3A733

