### PR TITLE
ProgressBar extension - second value 

### DIFF
--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -115,7 +115,7 @@ export const WithSecondValue = () => {
         value={30}
         secondValue={50}
         max={100}
-        aria-describedby="remaining-days-1"
+        aria-describedby="main score, secondary score"
         height={10}
       />
     </React.Fragment>

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -107,3 +107,21 @@ export const CustomHeight = () => {
 CustomHeight.story = {
   decorators: [withVariationsContainer],
 }
+
+export const WithSecondValue = () => {
+  return (
+    <React.Fragment>
+      <ProgressBar
+        value={30}
+        secondValue={50}
+        max={100}
+        aria-describedby="remaining-days-1"
+        height={10}
+      />
+    </React.Fragment>
+  )
+}
+
+WithSecondValue.story = {
+  decorators: [withVariationsContainer],
+}

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -22,6 +22,19 @@ const defaultGetProgressColor: GetProgressColor = (
   return theme.colors.green[50]
 }
 
+const sharedPseudoCss = (
+  theme: Theme,
+  progression: number,
+  getProgressColor: GetProgressColor
+): CSSObject => ({
+  content: "''",
+  width: `${progression}%`,
+  height: "6px",
+  position: "absolute",
+  backgroundColor: getProgressColor(theme, progression),
+  borderRadius: theme.radii[5],
+})
+
 const progressCss = (
   theme: Theme,
   progression: number,
@@ -32,17 +45,17 @@ const progressCss = (
   height: "6px",
   borderRadius: theme.radii[5],
   position: "relative",
-
-  "&:before": {
-    content: "''",
-    width: `${progression}%`,
-    height: "6px",
-    position: "absolute",
-    backgroundColor: getProgressColor(theme, progression),
-    borderRadius: theme.radii[5],
-  },
-
   background: theme.colors.grey[20],
+
+  "&:after": sharedPseudoCss(theme, progression, getProgressColor),
+})
+
+const secondProgressCss = (
+  theme: Theme,
+  progression: number,
+  getProgressColor: GetProgressColor
+): CSSObject => ({
+  "&:before": sharedPseudoCss(theme, progression, getProgressColor),
 })
 
 export interface ProgressBarProps {
@@ -50,7 +63,9 @@ export interface ProgressBarProps {
   min?: number
   value: number
   "aria-describedby": string
+  secondValue?: number
   getProgressColor?: GetProgressColor
+  getSecondProgressColor?: GetProgressColor
   height?: number
 }
 
@@ -58,12 +73,23 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
   max,
   min = 0,
   value,
+  secondValue,
   getProgressColor = defaultGetProgressColor,
+  getSecondProgressColor = defaultGetProgressColor,
   height = 6,
   ...props
 }) => {
   const normalizedValue = value > max ? max : value < min ? min : value
   const progression = (normalizedValue / max) * 100
+
+  let normalizedSecondValue: null | number = null
+  let secondProgression: null | number = null
+
+  if (secondValue) {
+    normalizedSecondValue =
+      secondValue > max ? max : secondValue < min ? min : secondValue
+    secondProgression = (normalizedSecondValue / max) * 100
+  }
 
   return (
     <div
@@ -74,16 +100,20 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
       aria-valuemax={max}
       css={theme => [
         progressCss(theme, progression, getProgressColor),
+        secondProgression &&
+          secondProgressCss(theme, secondProgression, getSecondProgressColor),
         height && {
           height: `${height}px`,
-          "&:before": {
+          "&:before, &:after": {
             height: `${height}px`,
           },
         },
       ]}
     >
       <span css={visuallyHiddenCss}>
-        {normalizedValue}/{max}
+        {`${normalizedValue}/${max}${
+          secondProgression ? `, ${normalizedSecondValue}/${max}` : ``
+        }`}
       </span>
     </div>
   )


### PR DESCRIPTION
## Purpose 

Add second optional value to render in `ProgressBar`, need to present `site` scoped hosting usage & limits at Cloud.

<img width="991" alt="Screenshot 2021-02-17 at 00 10 42" src="https://user-images.githubusercontent.com/32480082/108133839-82284200-70b5-11eb-82e2-7e75fded5bc9.png">
