### PR TITLE
Update displayMessage construction at BuildStandardLogEntry

### DIFF
--- a/src/components/BuildLogs/BuildLogsList.stories.tsx
+++ b/src/components/BuildLogs/BuildLogsList.stories.tsx
@@ -438,6 +438,21 @@ GraphQL request:1:1
     type: "WEBPACK",
     __typename: "StructuredLog",
   },
+  {
+    activity: null,
+    code: "98124",
+    context: { stageLabel: "Generating JavaScript bundles" },
+    docsUrl: "https://gatsby.dev/issue-how-to",
+    errorUrl: null,
+    filePath: "src/components/layout.tsx",
+    id: "1a3da811-6218-4afa-a31c-1cfed789c65b",
+    level: StructuredLogLevel.Error,
+    location: null,
+    message:
+      "Generating JavaScript bundles failed\n\nCan't resolve './BetSlipTwoStep' in '/usr/src/app/www/src/components'\n\nIf you're trying to use a package make sure that './BetSlipTwoStep' is installed. If you're trying to use a local file make sure that the path is correct.",
+    type: "WEBPACK",
+    __typename: "StructuredLog",
+  },
 ]
 
 export const Basic = () => (

--- a/src/components/BuildLogs/BuildStandardLogEntry.tsx
+++ b/src/components/BuildLogs/BuildStandardLogEntry.tsx
@@ -44,7 +44,10 @@ export function BuildStandardLogEntry({
 }: BuildStandardLogEntryProps) {
   const displayMessage =
     context && context.stageLabel
-      ? `${context.stageLabel} failed at ${filePath}`
+      ? `${context.stageLabel} failed at ${filePath} ${message?.replace(
+          `${context.stageLabel} failed`,
+          ``
+        )}`
       : message
 
   return (

--- a/src/components/BuildLogs/types.ts
+++ b/src/components/BuildLogs/types.ts
@@ -35,7 +35,7 @@ export type BuildLogItem = {
   level?: StructuredLogLevel | null
   activity?: BuildActivity | null
   filePath?: string | null
-  context?: { [k: string]: string } | null
+  context?: { [k: string]: string | undefined } | null
   docsUrl?: string | null
   errorUrl?: string | null
   location?: { start?: Location | null; end?: Location | null } | null


### PR DESCRIPTION
# Purpose

- CH: [Structured Logs/Raw logs Problems](https://app.clubhouse.io/gatsbyjs/story/31683/structured-logs-raw-logs-problems)
- update `displayMessage` construction at `BuildStandardLogEntry.tsx` to show `message` body also when `context.stageLabel` is defined. 

before: 

<img width="1285" alt="Screenshot 2021-05-28 at 12 57 47" src="https://user-images.githubusercontent.com/32480082/119973956-6554b200-bfb4-11eb-9468-844dc47d39c0.png">

after:

<img width="1269" alt="Screenshot 2021-05-28 at 12 47 24" src="https://user-images.githubusercontent.com/32480082/119973965-6980cf80-bfb4-11eb-9498-27071cf8eac9.png">
